### PR TITLE
RENO-696 Add Image/Content to Fb/Twitter Meta Tags

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -7,17 +7,17 @@
     <link rel="icon" type="image/png" href="<%- favicon %>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:title" content=" | The New York Public Library">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="With a library card you get free access to resources and services across all New York Public Library locations.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="">
+    <meta property="og:image" content="https://www.nypl.org/sites/default/files/library_card-1200x800.jpg">
     <meta property="og:site_name" content=" | The New York Public Library">
     <meta property="og:url" content="http://www.nypl.org/">
     <meta name="twitter:title" content=" | The New York Public Library">
-    <meta name="twitter:description" content="">
+    <meta name="twitter:description" content="With a library card you get free access to resources and services across all New York Public Library locations.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@nypl">
     <meta name="twitter:creator" content="@nypl">
-    <meta name="twitter:image" content="">
+    <meta name="twitter:image" content="https://www.nypl.org/sites/default/files/library_card-1200x800.jpg">
     <meta name="csrf-token" content="<%- csrfToken %>">
     <% if (isProduction) { %>
       <!-- Minified Styles -->


### PR DESCRIPTION
Jira: https://jira.nypl.org/browse/RENO-696

** This PR does the following:
Provides an image and description for the Facebook and Twitter card meta tags. Image is of the new library card design.

### Review
- [ ] Update local repository. In /src/views/index.ejs, ensure the og:image, og:description, twitter:image and twitter:description meta tags are populated with the image link location and description snippet.