### PR TITLE
Using the new Card Creator API endpoints and request object

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 NODE_ENV='production' shuts off hot-reloading, affects npm install, just delete this for dev mode
-PATRON_CREATION_URL=The URL used to create patrons (e.g: https://api.nypltech.org/api/v0.1/patrons)
-PATRON_VALIDATION_URL=The URL used to validate people's usernames and addresses (e.g: https://api.nypltech.org/api/v0.1/validations)
+PATRON_CREATION_URL=The URL used to create patrons (e.g: https://qa-platform.nypl.org/api/v0.3/patrons)
+PATRON_VALIDATION_URL=The URL used to validate people's usernames and addresses (e.g: https://qa-platform.nypl.org/api/v0.3/validations)
 OAUTH_PROVIDER_URL=URL to OAuth provider who guards the API Gateway (e.g: https://isso.nypl.org/oauth/token)
 OAUTH_CLIENT_ID=The ID this app uses to auth to the OAuth provider above
 OAUTH_CLIENT_SECRET=The secret this app uses to auth to the OAuth provider above

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "trailingComma": "es5",
+  "semi": true,
+  "singleQuote": false,
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "printWidth": 80
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updated to use Nextjs for the server and updated app and api routes accordingly.
 - Added Typescript for development.
 - Replaced Mocha with Jest, but still using Enzyme to test React components.
+- Updated the API endpoints and the error/response objects from the API endpoint that the front-end will use.
 
 ### v0.5.0
 

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,22 @@
+## Description
+
+<!--- Describe your changes -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] I have updated the documentation accordingly.
+- [ ] All new and existing tests passed.

--- a/pages/library-card/new/index.tsx
+++ b/pages/library-card/new/index.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import Head from "next/head";
 import ApplicationContainer from "../../../src/shared/components/Application/ApplicationContainer";
-import { config, gaUtils } from 'dgx-react-ga';
+import { config, gaUtils } from "dgx-react-ga";
+import appConfig from "../../../appConfig";
 
 /**
  * Determines if we are running on server or in the client.
@@ -36,13 +37,14 @@ if (process.env.USE_AXE_ENV === 'true' && !isServerRendered()) {
 function HomePage() {
   // TODO: Work on CSRF token auth.
   const csrfToken = "";
+  const { favIconPath, appTitle } = appConfig;
   return (
     <>
       <Head>
         <meta charSet="utf-8" />
         <meta http-equiv="x-ua-compatible" content="ie=edge" />
-        <title>Library Card Application Form | NYPL</title>
-        <link rel="icon" type="image/png" href="//www.nypl.org/images/favicon.ico" />
+        <title>{appTitle} | NYPL</title>
+        <link rel="icon" type="image/png" href={favIconPath} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content="With a library card you get free access to resources and services across all New York Public Library locations." />
         <meta name="keywords" content="NYPL, The New York Public Library, Manhattan, Bronx, Staten Island" />

--- a/src/shared/components/ApiErrors/ApiErrors.jsx
+++ b/src/shared/components/ApiErrors/ApiErrors.jsx
@@ -8,7 +8,7 @@ class ApiErrors extends React.Component {
     const errorClass = 'nypl-error-content';
     let resultMarkup = null;
 
-    if (apiResults.response) {
+    if (apiResults.response.message) {
       resultMarkup = <ErrorBox errorObject={apiResults.response} className="nypl-form-error" />;
     }
 

--- a/src/shared/components/ErrorBox/ErrorBox.jsx
+++ b/src/shared/components/ErrorBox/ErrorBox.jsx
@@ -4,7 +4,7 @@ import { renderServerValidationError } from './../../../utils/FormValidationUtil
 
 const ErrorBox = ({ errorObject, className }) => {
   const renderErrorByType = (errorObj) => {
-    const { type, details } = errorObject;
+    const { type, details, message } = errorObject;
     const defaultError = 'There was an error processing your submission. Please try again later.';
     let error;
 
@@ -17,8 +17,9 @@ const ErrorBox = ({ errorObject, className }) => {
           error =
             <li>This <a href="#patronUsername">username</a> is already taken. Please try again.</li>;
           break;
+        case 'invalid-request':
         case 'server-validation-error':
-          error = <div>{renderServerValidationError(details)}</div>;
+          error = <div>{renderServerValidationError(message)}</div>;
           break;
         case 'server':
           error =

--- a/src/shared/containers/LibraryCardForm/LibraryCardForm.jsx
+++ b/src/shared/containers/LibraryCardForm/LibraryCardForm.jsx
@@ -33,7 +33,7 @@ class LibraryCardForm extends React.Component {
         zip: '',
         username: '',
         pin: '',
-        ecommunications_pref: true,
+        ecommunicationsPref: true,
         location: '',
       },
     };
@@ -202,7 +202,7 @@ class LibraryCardForm extends React.Component {
       case 'line2':
         currentErrors = fieldErrors;
         break;
-      case 'ecommunications_pref':
+      case 'ecommunicationsPref':
         currentErrors = fieldErrors;
         break;
       default:
@@ -280,7 +280,7 @@ class LibraryCardForm extends React.Component {
         zip,
         username,
         pin,
-        ecommunications_pref,
+        ecommunicationsPref,
       } = this.state.patronFields;
       const agencyType = this.getPatronAgencyType(this.state.patronFields.location);
 
@@ -297,7 +297,7 @@ class LibraryCardForm extends React.Component {
         zip,
         username,
         pin,
-        ecommunications_pref,
+        ecommunicationsPref,
         agencyType,
       }, {
         headers: { 'csrf-token': this.state.csrfToken },
@@ -308,7 +308,9 @@ class LibraryCardForm extends React.Component {
           formEntrySuccessful: false,
           apiResults: response.data,
         });
-        window.location.href = window.confirmationURL;
+        // TODO: Waiting on whether we will make a redirect in the app
+        // or in Drupal.
+        // window.location.href = window.confirmationURL;
       })
       .catch((error) => {
         this.setState({ formProcessing: false, focusOnResult: true });
@@ -399,16 +401,16 @@ class LibraryCardForm extends React.Component {
         />
         <FormField
           id="patronECommunications"
-          className={this.state.patronFields.ecommunications_pref ? 'nypl-terms-checkbox checked' :
+          className={this.state.patronFields.ecommunicationsPref ? 'nypl-terms-checkbox checked' :
             'nypl-terms-checkbox'}
           type="checkbox"
           label="Receive emails"
-          fieldName="ecommunications_pref"
+          fieldName="ecommunicationsPref"
           instructionText={'Yes, I would like to receive information about NYPL\'s programs ' +
           'and services.'}
-          handleOnChange={this.handleInputChange('ecommunications_pref')}
-          value={this.state.patronFields.ecommunications_pref}
-          checked={this.state.patronFields.ecommunications_pref}
+          handleOnChange={this.handleInputChange('ecommunicationsPref')}
+          value={this.state.patronFields.ecommunicationsPref}
+          checked={this.state.patronFields.ecommunicationsPref}
         />
         <h3>Address</h3>
 

--- a/src/utils/FormValidationUtils.js
+++ b/src/utils/FormValidationUtils.js
@@ -1,22 +1,23 @@
-import React from 'react';
+/* eslint-disable */
+import React from "react";
 
 function isDate(input, minYear = 1902, maxYear = new Date().getFullYear()) {
   // regular expression to match required date format
   const regex = /^(\d{2})\/(\d{2})\/(\d{4})$/;
 
-  if (input === '') {
+  if (input === "") {
     return false;
   }
 
   if (input.match(regex)) {
-    const temp = input.split('/');
+    const temp = input.split("/");
     const dateFromInput = new Date(`${temp[2]}/${temp[0]}/${temp[1]}`);
 
     return (
-      dateFromInput.getDate() === Number(temp[1])
-      && (dateFromInput.getMonth() + 1) === Number(temp[0])
-      && Number(temp[2]) > minYear
-      && Number(temp[2]) < maxYear
+      dateFromInput.getDate() === Number(temp[1]) &&
+      dateFromInput.getMonth() + 1 === Number(temp[0]) &&
+      Number(temp[2]) > minYear &&
+      Number(temp[2]) < maxYear
     );
   }
 
@@ -31,9 +32,11 @@ function isDate(input, minYear = 1902, maxYear = new Date().getFullYear()) {
  * return {object} {anchorText, restText}
  */
 function createAnchorText(wholeText) {
-  const anchorText = (wholeText && typeof wholeText === 'string') ?
-    wholeText.split(' field')[0] : '';
-  const restText = (!anchorText) ? '' : ` field ${wholeText.split(' field')[1]}`;
+  const anchorText =
+    wholeText && typeof wholeText === "string"
+      ? wholeText.split(" field")[0]
+      : "";
+  const restText = !anchorText ? "" : ` field ${wholeText.split(" field")[1]}`;
 
   return { anchorText, restText };
 }
@@ -46,18 +49,22 @@ function createAnchorText(wholeText) {
  * return {string}
  */
 function createAnchorID(key) {
-  let hashElement = (key && typeof key === 'string') ?
-    `${key.charAt(0).toUpperCase()}${key.substr(1)}` : '';
+  let hashElement =
+    key && typeof key === "string"
+      ? `${key.charAt(0).toUpperCase()}${key.substr(1)}`
+      : "";
 
-  if (hashElement === 'DateOfBirth') {
-    hashElement = 'Dob';
+  if (hashElement === "DateOfBirth") {
+    hashElement = "Dob";
   }
 
-  if (hashElement === 'Line1') {
-    hashElement = 'Street1';
+  if (hashElement === "Line1") {
+    hashElement = "Street1";
   }
 
-  if (!hashElement) { return null; }
+  if (!hashElement) {
+    return null;
+  }
 
   return `#patron${hashElement}`;
 }
@@ -77,27 +84,61 @@ function renderServerValidationError(object) {
     if (object.hasOwnProperty(key)) {
       let errorMessage = null;
 
-      if (object[key].indexOf('empty') !== -1) {
-        const anchorText = createAnchorText(object[key]).anchorText || '';
-        const restText = createAnchorText(object[key]).restText || '';
+      if (object[key].indexOf("empty") !== -1) {
+        const anchorText = createAnchorText(object[key]).anchorText || "";
+        const restText = createAnchorText(object[key]).restText || "";
 
-        errorMessage = (!anchorText && !anchorText) ? <li>One of the fields is incorrect.</li> :
-          <li key={index}><a href={createAnchorID(key)}>{anchorText}</a>{restText}</li>;
+        errorMessage =
+          !anchorText && !anchorText ? (
+            <li>One of the fields is incorrect.</li>
+          ) : (
+            <li key={index}>
+              <a href={createAnchorID(key)}>{anchorText}</a>
+              {restText}
+            </li>
+          );
       } else {
-        if (key === 'zip') {
-          errorMessage = <li key={index}>Please enter a 5-digit <a href={createAnchorID(key)}>postal code</a>.</li>;
+        if (key === "zip") {
+          errorMessage = (
+            <li key={index}>
+              Please enter a 5-digit{" "}
+              <a href={createAnchorID(key)}>postal code</a>.
+            </li>
+          );
         }
 
-        if (key === 'email') {
-          errorMessage = <li key={index}>Please enter a valid <a href={createAnchorID(key)}>email address</a>.</li>;
+        if (key === "email") {
+          errorMessage = (
+            <li key={index}>
+              Please enter a valid{" "}
+              <a href={createAnchorID(key)}>email address</a>.
+            </li>
+          );
         }
 
-        if (key === 'username') {
-          errorMessage = <li key={index}>Please enter a <a href={createAnchorID(key)}>username</a> between 5-25 alphanumeric characters.</li>;
+        if (key === "username") {
+          errorMessage = (
+            <li key={index}>
+              Please enter a <a href={createAnchorID(key)}>username</a> between
+              5-25 alphanumeric characters.
+            </li>
+          );
         }
 
-        if (key === 'pin') {
-          errorMessage = <li key={index}>Please enter a 4-digit <a href={createAnchorID(key)}>PIN</a>.</li>;
+        if (key === "pin") {
+          errorMessage = (
+            <li key={index}>
+              Please enter a 4-digit <a href={createAnchorID(key)}>PIN</a>.
+            </li>
+          );
+        }
+
+        if (key === "address") {
+          errorMessage = (
+            <li key={index}>
+              <a href={createAnchorID("Street1")}>{object[key]}</a>
+            </li>
+          );
         }
       }
 
@@ -108,7 +149,4 @@ function renderServerValidationError(object) {
   return errorMessages;
 }
 
-export {
-  isDate,
-  renderServerValidationError,
-};
+export { isDate, renderServerValidationError };


### PR DESCRIPTION
This resolves [https://jira.nypl.org/browse/DQ-297](DQ-297). 

The new `/v0.3/patrons` endpoint from the card creator expects the request object to be in a different shape than what was sent before. This PR updates that request object. It also updates the correct and the error responses so they get sent properly to the front-end.

One of the biggest changes is removing the initial address and username validation requests. Before it used to:
* make two requests to validate address and username
* get results and if both are valid, make a request to create a patron

Now, it will just make one request and that endpoint will take care of everything. If the address or username are invalid, it will return that error. If they are both valid it will continue to make the patron. Both the address and username validation functions are still in the code because if we do go with a real-time address or username validation checker, then we'll need to use those.

I tested this out with the new card creator endpoints but loaded the API locally through localhost. The errors still show up and work as before. A correct submission does not do a redirect simply because we haven't decided what to do with a correct response, so I left that as a TODO.
