### PR TITLE
Using the Label, Input, Checkbox, and HelperErrorText components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,9 +2817,9 @@
       "integrity": "sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ=="
     },
     "@nypl/design-system-react-components": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.6.2.tgz",
-      "integrity": "sha512-sXfbZVDq5OM4SiHWdxGWlMVxRMM3h2uRQi+v4dIDplhgO6uU09sMNZHoyUY56FQZun8ALE+ZBBtbqZfvVzx5Iw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.7.0.tgz",
+      "integrity": "sha512-hiepQq2KL5ggW3DtuubPXdhlBj1PeG5vF9PVPDuG5I/QMTHWdcNTU2+uOepvfQUs0AcuimPWCnzSkKpkiZhmtA==",
       "requires": {
         "he": "^1.2.0",
         "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@nypl/design-system-react-components": "^0.6.2",
+    "@nypl/design-system-react-components": "^0.7.0",
     "@nypl/design-toolkit": "0.1.37",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.7",

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,4 +1,10 @@
-import React from 'react';
+import React from "react";
+import {
+  Label,
+  Input,
+  InputTypes,
+  HelperErrorText,
+} from "@nypl/design-system-react-components";
 
 interface FormFieldProps {
   id: string;
@@ -10,88 +16,57 @@ interface FormFieldProps {
   className?: string;
   isRequired?: boolean;
   handleOnChange?: any;
-  checked?: boolean;
   instructionText?: string;
   maxLength?: number;
   onBlur?: any;
   childRef?: any;
-};
+}
 
 class FormField extends React.Component<FormFieldProps> {
   static defaultProps = {
-    className: '',
-    value: '',
+    className: "",
+    value: "",
     isRequired: false,
     errorState: {},
-  }
-
-  renderInstructionText(text) {
-    if (!text) {
-      return null;
-    }
-
-    return (
-      <span
-        className="nypl-field-status"
-        id={`${this.props.id}-status`}
-        aria-live="assertive"
-        aria-atomic="true"
-      >
-        {text}
-      </span>
-    );
-  }
-
-  renderErrorBox() {
-    return (
-      <span
-        className="nypl-field-status"
-        id={`${this.props.id}-status`}
-        aria-live="assertive"
-        aria-atomic="true"
-      >
-        {this.props.errorState[this.props.fieldName]}
-      </span>
-    );
-  }
+  };
 
   render() {
-    const requiredMarkup = this.props.isRequired ?
-      <span className="nypl-required-field"> Required</span> : null;
-    let errorClass = '';
-    let underInputSuggestion = this.renderInstructionText(this.props.instructionText);
-    if (this.props.errorState && this.props.errorState[this.props.fieldName]) {
-      errorClass = 'nypl-field-error';
-      underInputSuggestion = this.renderErrorBox();
+    const errorText = this.props.errorState[this.props.fieldName];
+    let helperText = this.props.instructionText || null;
+    let isError = false;
+    if (this.props.errorState && errorText) {
+      isError = true;
+      helperText = errorText;
     }
+    const ariaLabelledby = helperText ? `${this.props.id}-helperText` : "";
+
     return (
-      <div className={`${this.props.className} ${errorClass}`}>
-        <label htmlFor={this.props.id} id={`${this.props.id}-label`}>
-          {
-            this.props.type === 'checkbox' ?
-              <span className="visuallyHidden">{this.props.label}</span> :
-              <span>{this.props.label}</span>
-          }
-          {requiredMarkup}
-        </label>
-        <input
+      <div className={this.props.className}>
+        <Label
+          htmlFor={`input-${this.props.id}`}
+          id={`${this.props.id}-label`}
+          optReqFlag={this.props.isRequired ? "Required" : ""}
+        >
+          <span>{this.props.label}</span>
+        </Label>
+        <Input
           value={this.props.value}
-          type={this.props.type}
+          type={InputTypes.text}
           id={this.props.id}
-          aria-required={this.props.type === 'checkbox' ? null : this.props.isRequired}
-          aria-labelledby={
-            (this.props.instructionText || (this.props.errorState && this.props.errorState[this.props.fieldName]))
-              ? `${this.props.id}-label ${this.props.id}-status`
-              : `${this.props.id}-label`
-          }
-          onChange={this.props.handleOnChange}
-          checked={this.props.checked}
-          maxLength={this.props.maxLength || null}
-          onBlur={this.props.onBlur}
+          aria-required={this.props.isRequired}
+          aria-labelledby={`${this.props.id}-label ${ariaLabelledby}`}
+          helperTextId={`${this.props.id}-helperText`}
+          attributes={{
+            onChange: this.props.handleOnChange,
+            maxLength: this.props.maxLength || null,
+            onBlur: this.props.onBlur,
+            tabIndex: 0,
+          }}
           ref={this.props.childRef}
-          tabIndex={0}
         />
-        {underInputSuggestion}
+        <HelperErrorText id={`${this.props.id}-helperText`} isError={isError}>
+          {helperText}
+        </HelperErrorText>
       </div>
     );
   }

--- a/src/components/LibraryCardForm/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm/LibraryCardForm.tsx
@@ -10,6 +10,7 @@ import FormField from "../FormField/FormField";
 import ApiErrors from "../ApiErrors/ApiErrors";
 import config from "../../../appConfig";
 import FormFooterText from "../FormFooterText";
+import { Checkbox } from "@nypl/design-system-react-components";
 
 interface LibraryCardFormState {
   agencyType: string;
@@ -374,6 +375,16 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
   }
 
   renderFormFields() {
+    const checkBoxLabelOptions = {
+      id: "receiveEmails",
+      labelContent: (
+        <>
+          Yes, I would like to receive information about NYPL&apos;s programs
+          and services
+        </>
+      ),
+    };
+
     return (
       <form className="nypl-library-card-form" onSubmit={this.handleSubmit}>
         <h2>Please enter the following information</h2>
@@ -431,23 +442,12 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
           onBlur={this.handleOnBlur("email")}
           childRef={this.email}
         />
-        <FormField
-          id="patronECommunications"
-          className={
-            this.state.patronFields.ecommunicationsPref
-              ? "nypl-terms-checkbox checked"
-              : "nypl-terms-checkbox"
-          }
-          type="checkbox"
-          label="Receive emails"
-          fieldName="ecommunicationsPref"
-          instructionText={
-            "Yes, I would like to receive information about NYPL's programs " +
-            "and services."
-          }
-          handleOnChange={this.handleInputChange("ecommunicationsPref")}
-          value={this.state.patronFields.ecommunicationsPref}
-          checked={this.state.patronFields.ecommunicationsPref}
+        <Checkbox
+          checkboxId="patronECommunications"
+          isSelected={this.state.patronFields.ecommunicationsPref}
+          name="ecommunicationsPref"
+          onChange={this.handleInputChange("ecommunicationsPref")}
+          labelOptions={checkBoxLabelOptions}
         />
         <h3>Address</h3>
 

--- a/src/utils/FormValidationUtils.tsx
+++ b/src/utils/FormValidationUtils.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable */
 import React from "react";
 
-function isDate(input, minYear = 1902, maxYear = new Date().getFullYear()): boolean {
+function isDate(
+  input,
+  minYear = 1902,
+  maxYear = new Date().getFullYear()
+): boolean {
   // regular expression to match required date format
   const regex = /^(\d{2})\/(\d{2})\/(\d{4})$/;
 
@@ -33,9 +37,7 @@ function isDate(input, minYear = 1902, maxYear = new Date().getFullYear()): bool
  * return {object} {anchorText, restText}
  */
 function createAnchorText(wholeText: string) {
-  const anchorText = wholeText
-      ? wholeText.split(" field")[0]
-      : "";
+  const anchorText = wholeText ? wholeText.split(" field")[0] : "";
   const restText = !anchorText ? "" : ` field ${wholeText.split(" field")[1]}`;
 
   return { anchorText, restText };
@@ -49,9 +51,7 @@ function createAnchorText(wholeText: string) {
  * return {string}
  */
 function createAnchorID(key: string): string | null {
-  let hashElement = key 
-      ? `${key.charAt(0).toUpperCase()}${key.substr(1)}`
-      : "";
+  let hashElement = key ? `${key.charAt(0).toUpperCase()}${key.substr(1)}` : "";
 
   if (hashElement === "DateOfBirth") {
     hashElement = "Dob";
@@ -65,7 +65,9 @@ function createAnchorID(key: string): string | null {
     return null;
   }
 
-  return `#patron${hashElement}`;
+  // @nypl/design-system-react-components prepends an `input` before the
+  // id of the input element we want an anchor for.
+  return `#input-patron${hashElement}`;
 }
 
 /**


### PR DESCRIPTION
…from the Design System.

Resolves [DQ-334](https://jira.nypl.org/browse/DQ-334). [Design System #275](https://github.com/NYPL/nypl-design-system/pull/275) is the related PR and those updates need to be published first before this can be merged.

The DS components help reduce some of the existing code but I needed to update some props in the DS components to get everything to work as it use to. It is functionally the same as before - labels and inputs work the same as before and when there are errors, the error links focus on the appropriate input element through its `ref`.

This also doesn't change the styling of the app which I think could use some help. Here are before and afters:

### Error input state
Before:
<img width="727" alt="Screen Shot 2020-07-14 at 9 41 00 AM" src="https://user-images.githubusercontent.com/1280564/87432632-44f75100-c5b6-11ea-9cd5-1d89d6e52487.png">

After:
<img width="643" alt="Screen Shot 2020-07-14 at 9 41 05 AM" src="https://user-images.githubusercontent.com/1280564/87432676-517ba980-c5b6-11ea-8a5c-463b7f39de58.png">

### Checkbox
This may actually not need an updated design but wanted to point out what is now gone.

Before:
<img width="617" alt="Screen Shot 2020-07-14 at 9 41 16 AM" src="https://user-images.githubusercontent.com/1280564/87432700-57718a80-c5b6-11ea-8ff7-0077d8372a81.png">

After:
<img width="635" alt="Screen Shot 2020-07-14 at 9 41 20 AM" src="https://user-images.githubusercontent.com/1280564/87432755-68220080-c5b6-11ea-97f6-a1c69531ae52.png">

