### PR TITLE
React hook form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16559,6 +16559,11 @@
         }
       }
     },
+    "react-hook-form": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.0.6.tgz",
+      "integrity": "sha512-qxWhV++1V7SKKlr2hHFsessGwATCdexgVsByxOHltDyO9F0VWB1WN4ZvxnKuHTVGwjj6CLZo0mL+Hgy0QH1sAw=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "qs": "6.9.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-hook-form": "^6.0.6",
     "sass": "^1.26.9",
     "save-dev": "0.0.1-security",
     "underscore": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@nypl/design-system-react-components": "^0.6.2",
+    "@nypl/design-system-react-components": "^0.6.3",
     "@nypl/design-toolkit": "0.1.37",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.7",

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from "react";
 import {
   Label,
@@ -12,59 +13,65 @@ interface FormFieldProps {
   type: string;
   fieldName: string;
   errorState?: any;
-  value: any;
   className?: string;
   isRequired?: boolean;
-  handleOnChange?: any;
+  // handleOnChange?: any;
   instructionText?: string;
-  maxLength?: number;
-  onBlur?: any;
+  // maxLength?: number;
+  // onBlur?: any;
   childRef?: any;
 }
 
 class FormField extends React.Component<FormFieldProps> {
   static defaultProps = {
     className: "",
-    value: "",
     isRequired: false,
     errorState: {},
   };
 
   render() {
-    const errorText = this.props.errorState[this.props.fieldName];
-    let helperText = this.props.instructionText || null;
-    let isError = false;
-    if (this.props.errorState && errorText) {
-      isError = true;
-      helperText = errorText;
-    }
-    const ariaLabelledby = helperText ? `${this.props.id}-helperText` : "";
+    const {
+      id,
+      label,
+      type,
+      fieldName,
+      errorState,
+      className,
+      isRequired,
+      instructionText,
+      childRef,
+    } = this.props;
+    const errorText = errorState[fieldName];
+    let helperText = instructionText || null;
 
+    if (errorText?.message) {
+      helperText = errorText.message;
+    }
+    const ariaLabelledby = helperText ? `${id}-helperText` : "";
     return (
-      <div className={this.props.className}>
+      <div className={className}>
         <Label
-          htmlFor={`input-${this.props.id}`}
-          id={`${this.props.id}-label`}
-          optReqFlag={this.props.isRequired ? "Required" : ""}
+          htmlFor={`input-${id}`}
+          id={`${id}-label`}
+          optReqFlag={isRequired ? "Required" : ""}
         >
-          <span>{this.props.label}</span>
+          <span>{label}</span>
         </Label>
         <Input
-          value={this.props.value}
           type={InputTypes.text}
-          id={this.props.id}
-          aria-required={this.props.isRequired}
-          aria-labelledby={`${this.props.id}-label ${ariaLabelledby}`}
-          helperTextId={`${this.props.id}-helperText`}
+          id={id}
+          aria-required={isRequired}
+          aria-labelledby={`${id}-label ${ariaLabelledby}`}
+          helperTextId={`${id}-helperText`}
           attributes={{
-            onChange: this.props.handleOnChange,
-            maxLength: this.props.maxLength || null,
-            onBlur: this.props.onBlur,
+            ["aria-invalid"]: errorText ? "true" : "false",
+            // maxLength: maxLength || null,
+            name: fieldName,
             tabIndex: 0,
           }}
-          ref={this.props.childRef}
+          ref={childRef}
         />
-        <HelperErrorText id={`${this.props.id}-helperText`} isError={isError}>
+        <HelperErrorText id={`${id}-helperText`} isError={!!errorText}>
           {helperText}
         </HelperErrorText>
       </div>

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -15,13 +15,17 @@ interface FormFieldProps {
   errorState?: any;
   className?: string;
   isRequired?: boolean;
-  // handleOnChange?: any;
   instructionText?: string;
-  // maxLength?: number;
-  // onBlur?: any;
+  maxLength?: number;
   childRef?: any;
 }
 
+/**
+ * FormField
+ * Renders a complete form field that includes a label, input, and helper text
+ * which also renders errors. Internal components are rendered by the
+ * NYPL Design System.
+ */
 class FormField extends React.Component<FormFieldProps> {
   static defaultProps = {
     className: "",
@@ -40,6 +44,7 @@ class FormField extends React.Component<FormFieldProps> {
       isRequired,
       instructionText,
       childRef,
+      maxLength,
     } = this.props;
     const errorText = errorState[fieldName];
     let helperText = instructionText || null;
@@ -65,7 +70,7 @@ class FormField extends React.Component<FormFieldProps> {
           helperTextId={`${id}-helperText`}
           attributes={{
             ["aria-invalid"]: errorText ? "true" : "false",
-            // maxLength: maxLength || null,
+            maxLength: maxLength || null,
             name: fieldName,
             tabIndex: 0,
           }}

--- a/src/components/LibraryCardForm/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm/LibraryCardForm.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+/* eslint-disable */
+import React, { useState } from "react";
 import axios from "axios";
 import isEmpty from "lodash/isEmpty";
 import omit from "lodash/omit";
@@ -11,6 +12,7 @@ import ApiErrors from "../ApiErrors/ApiErrors";
 import config from "../../../appConfig";
 import FormFooterText from "../FormFooterText";
 import { Checkbox } from "@nypl/design-system-react-components";
+import { useForm } from "react-hook-form";
 
 interface LibraryCardFormState {
   agencyType: string;
@@ -23,76 +25,89 @@ interface LibraryCardFormState {
   patronFields: any;
 }
 
-class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
-  dynamicSection = React.createRef<HTMLDivElement>();
-  stateName = React.createRef<HTMLInputElement>();
-  firstName = React.createRef<HTMLInputElement>();
-  lastName = React.createRef<HTMLInputElement>();
-  dateOfBirth = React.createRef<HTMLInputElement>();
-  email = React.createRef<HTMLInputElement>();
-  line1 = React.createRef<HTMLInputElement>();
-  zip = React.createRef<HTMLInputElement>();
-  city = React.createRef<HTMLInputElement>();
-  username = React.createRef<HTMLInputElement>();
-  pin = React.createRef<HTMLInputElement>();
+interface FormInput {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  email: string;
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  zip: string;
+  username: string;
+  pin: string;
+  ecommunicationsPref: boolean;
+  location?: string;
+}
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      agencyType: "",
-      csrfToken: "",
-      formEntrySuccessful: false,
-      focusOnResult: false,
-      formProcessing: false,
-      apiResults: {},
-      fieldErrors: {},
-      patronFields: {
-        firstName: "",
-        lastName: "",
-        dateOfBirth: "",
-        email: "",
-        line1: "",
-        line2: "",
-        city: "",
-        state: "",
-        zip: "",
-        username: "",
-        pin: "",
-        ecommunicationsPref: true,
-        location: "",
-      },
-    };
+const LibraryCardForm = () => {
+  const dynamicSection = React.createRef<HTMLDivElement>();
+  const stateName = React.createRef<HTMLInputElement>();
+  const firstName = React.createRef<HTMLInputElement>();
+  const lastName = React.createRef<HTMLInputElement>();
+  const dateOfBirth = React.createRef<HTMLInputElement>();
+  const email = React.createRef<HTMLInputElement>();
+  const line1 = React.createRef<HTMLInputElement>();
+  const zip = React.createRef<HTMLInputElement>();
+  const city = React.createRef<HTMLInputElement>();
+  const username = React.createRef<HTMLInputElement>();
+  const pin = React.createRef<HTMLInputElement>();
 
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.handleOnBlur = this.handleOnBlur.bind(this);
-  }
+  //   this.state = {
+  //     agencyType: "",
+  //     csrfToken: "",
+  //     formEntrySuccessful: false,
+  //     focusOnResult: false,
+  //     formProcessing: false,
+  //     apiResults: {},
+  //     fieldErrors: {},
+  //     patronFields: {
+  //       firstName: "",
+  //       lastName: "",
+  //       dateOfBirth: "",
+  //       email: "",
+  //       line1: "",
+  //       line2: "",
+  //       city: "",
+  //       state: "",
+  //       zip: "",
+  //       username: "",
+  //       pin: "",
+  //       ecommunicationsPref: true,
+  //       location: "",
+  //     },
+  //   };
 
-  componentDidMount() {
-    const csrfToken = this.getMetaTagContent("name=csrf-token");
-    if (csrfToken) {
-      const patronFields = Object.assign(this.state.patronFields, {
-        location: this.getUrlParameter("form_type") || "nyc",
-      });
+  //   this.handleInputChange = this.handleInputChange.bind(this);
+  //   this.handleOnBlur = this.handleOnBlur.bind(this);
+  // }
 
-      this.setState({ csrfToken, patronFields });
-    }
-  }
+  // componentDidMount() {
+  //   const csrfToken = this.getMetaTagContent("name=csrf-token");
+  //   if (csrfToken) {
+  //     const patronFields = Object.assign(this.state.patronFields, {
+  //       location: this.getUrlParameter("form_type") || "nyc",
+  //     });
 
-  componentDidUpdate() {
-    if (this.state.focusOnResult) {
-      this.focusOnApiResponse();
-      if (document && document.title !== "") {
-        document.title = "Form Submission Error | NYPL";
-      }
-    }
-  }
+  //     this.setState({ csrfToken, patronFields });
+  //   }
+  // }
 
-  getMetaTagContent(tag) {
+  // componentDidUpdate() {
+  //   if (this.state.focusOnResult) {
+  //     this.focusOnApiResponse();
+  //     if (document && document.title !== "") {
+  //       document.title = "Form Submission Error | NYPL";
+  //     }
+  //   }
+  // }
+
+  const getMetaTagContent = (tag) => {
     return document.head.querySelector(`[${tag}]`).textContent;
-  }
+  };
 
-  getUrlParameter(name) {
+  const getUrlParameter = (name) => {
     if (typeof location === "undefined") return "";
 
     const paramName = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
@@ -101,280 +116,288 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
     return results === null
       ? ""
       : decodeURIComponent(results[1].replace(/\+/g, " "));
-  }
+  };
 
-  getPatronAgencyType(agencyTypeParam) {
+  const getPatronAgencyType = (agencyTypeParam) => {
     const { agencyType } = config;
     return !isEmpty(agencyTypeParam) && agencyTypeParam.toLowerCase() === "nys"
       ? agencyType.nys
       : agencyType.default;
-  }
+  };
 
-  getFullName() {
+  const getFullName = () => {
     const { firstName, lastName } = this.state.patronFields;
 
     return !isEmpty(firstName) && !isEmpty(lastName)
       ? `${firstName.trim()} ${lastName.trim()}`
       : null;
-  }
+  };
 
-  focusOnApiResponse() {
+  const focusOnApiResponse = () => {
     setTimeout(() => {
-      if (this.dynamicSection) {
-        this.dynamicSection.current.focus();
-        this.setState({ focusOnResult: false });
+      if (dynamicSection) {
+        dynamicSection.current.focus();
+        // this.setState({ focusOnResult: false });
       }
     }, 1000);
-  }
+  };
 
-  validateField(fieldName, value) {
-    const { fieldErrors } = this.state;
-    let currentErrors = {};
+  // const validateField = (fieldName, value) => {
+  //   const { fieldErrors } = this.state;
+  //   let currentErrors = {};
 
-    switch (fieldName) {
-      case "dateOfBirth":
-        if (!isDate(value)) {
-          fieldErrors[fieldName] =
-            "Please enter a valid date, MM/DD/YYYY, including slashes.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "email":
-        if (value.trim().length > 0 && !isEmail(value)) {
-          fieldErrors[fieldName] = "Please enter a valid email address.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "username":
-        if (!isLength(value, { min: 5, max: 25 })) {
-          fieldErrors[fieldName] =
-            "Username must be between 5-25 alphanumeric characters.";
-          currentErrors = fieldErrors;
-        } else if (!isAlphanumeric(value)) {
-          fieldErrors[fieldName] = "Only alphanumeric characters are allowed.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "pin":
-        if (value.length !== 4 || isNaN(value)) {
-          fieldErrors[fieldName] = "Please enter a 4-digit PIN.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "firstName":
-        if (isEmpty(value)) {
-          fieldErrors[fieldName] = "Please enter a valid first name.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "lastName":
-        if (isEmpty(value)) {
-          fieldErrors[fieldName] = "Please enter a valid last name.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "location":
-        if (isEmpty(value)) {
-          fieldErrors[fieldName] = "Please select an address option.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "line1":
-        if (isEmpty(value)) {
-          fieldErrors[fieldName] = "Please enter a valid street address.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "city":
-        if (isEmpty(value)) {
-          fieldErrors[fieldName] = "Please enter a valid city.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "state":
-        if (isEmpty(value) || !isLength(value, { min: 2, max: 2 })) {
-          fieldErrors[fieldName] =
-            "Please enter a 2-character state abbreviation.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "zip":
-        if (
-          isEmpty(value) ||
-          isNaN(value) ||
-          !isLength(value, { min: 5, max: 5 })
-        ) {
-          fieldErrors[fieldName] = "Please enter a 5-digit postal code.";
-          currentErrors = fieldErrors;
-        } else {
-          currentErrors = omit(fieldErrors, fieldName);
-        }
-        break;
-      case "line2":
-        currentErrors = fieldErrors;
-        break;
-      case "ecommunicationsPref":
-        currentErrors = fieldErrors;
-        break;
-      default:
-        break;
-    }
+  //   switch (fieldName) {
+  //     case "dateOfBirth":
+  //       if (!isDate(value)) {
+  //         fieldErrors[fieldName] =
+  //           "Please enter a valid date, MM/DD/YYYY, including slashes.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "email":
+  //       if (value.trim().length > 0 && !isEmail(value)) {
+  //         fieldErrors[fieldName] = "Please enter a valid email address.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "username":
+  //       if (!isLength(value, { min: 5, max: 25 })) {
+  //         fieldErrors[fieldName] =
+  //           "Username must be between 5-25 alphanumeric characters.";
+  //         currentErrors = fieldErrors;
+  //       } else if (!isAlphanumeric(value)) {
+  //         fieldErrors[fieldName] = "Only alphanumeric characters are allowed.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "pin":
+  //       if (value.length !== 4 || isNaN(value)) {
+  //         fieldErrors[fieldName] = "Please enter a 4-digit PIN.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "firstName":
+  //       if (isEmpty(value)) {
+  //         fieldErrors[fieldName] = "Please enter a valid first name.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "lastName":
+  //       if (isEmpty(value)) {
+  //         fieldErrors[fieldName] = "Please enter a valid last name.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "location":
+  //       if (isEmpty(value)) {
+  //         fieldErrors[fieldName] = "Please select an address option.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "line1":
+  //       if (isEmpty(value)) {
+  //         fieldErrors[fieldName] = "Please enter a valid street address.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "city":
+  //       if (isEmpty(value)) {
+  //         fieldErrors[fieldName] = "Please enter a valid city.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "state":
+  //       if (isEmpty(value) || !isLength(value, { min: 2, max: 2 })) {
+  //         fieldErrors[fieldName] =
+  //           "Please enter a 2-character state abbreviation.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "zip":
+  //       if (
+  //         isEmpty(value) ||
+  //         isNaN(value) ||
+  //         !isLength(value, { min: 5, max: 5 })
+  //       ) {
+  //         fieldErrors[fieldName] = "Please enter a 5-digit postal code.";
+  //         currentErrors = fieldErrors;
+  //       } else {
+  //         currentErrors = omit(fieldErrors, fieldName);
+  //       }
+  //       break;
+  //     case "line2":
+  //       currentErrors = fieldErrors;
+  //       break;
+  //     case "ecommunicationsPref":
+  //       currentErrors = fieldErrors;
+  //       break;
+  //     default:
+  //       break;
+  //   }
 
-    this.setState({ fieldErrors: currentErrors });
-  }
+  //   this.setState({ fieldErrors: currentErrors });
+  // }
 
-  focusOnErrorElement() {
+  const focusOnErrorElement = () => {
     // Handle focusing on first element in the object that contains an error
     Object.keys(this.state.fieldErrors).some((key) => {
       if (this.state.fieldErrors[key]) {
         // the keyword state is reserved in React, therefore the reference to the State field
         // is renamed to stateName
         if (key === "state") {
-          this.stateName.current.focus();
+          stateName.current.focus();
           return true;
         }
 
-        this[key] && this[key].current.focus();
+        // this[key] && this[key].current.focus();
         return true;
       }
       return true;
     });
-  }
+  };
 
-  handleInputChange(property) {
-    return (event) => {
-      const target = event.target;
-      const value = target.type === "checkbox" ? target.checked : target.value;
-      const newState = assign({}, this.state.patronFields, {
-        [property]: value,
-      });
-      this.setState({ patronFields: newState });
-    };
-  }
+  const handleInputChange = ({ target }) => {
+    const value = target.type === "checkbox" ? target.checked : target.value;
+    console.log("handle change", value);
+    // return (event) => {
+    //   const target = event.target;
+    //   console.log("target", target.value);
+    //   // const value = target.type === "checkbox" ? target.checked : target.value;
+    //   // const newState = assign({}, this.state.patronFields, {
+    //   //   [property]: value,
+    //   // });
+    //   // this.setState({ patronFields: newState });
+    // };
+  };
 
-  handleOnBlur(property) {
+  const handleOnBlur = (property) => {
     return (event) => {
+      console.log("blur handle", event.target);
       const target = event.target;
       const value = target.value;
 
-      this.validateField(property, value);
+      // validateField(property, value);
     };
-  }
+  };
 
-  handleSubmit(event) {
+  const handleSubmitHere = (formData: FormInput) => {
+    console.log("submit", formData);
     // Clearing server side errors for re-submission.
-    this.setState({ apiResults: {} });
-    event.preventDefault();
+    // this.setState({ apiResults: {} });
+    // event.preventDefault();
 
     // Iterate through patron fields and ensure all fields are valid
-    forIn(this.state.patronFields, (value, key) => {
-      this.validateField(key, value);
-    });
+    // forIn(this.state.patronFields, (value, key) => {
+    //   validateField(key, value);
+    // });
 
     // Has client-side errors, stop processing
-    if (!isEmpty(this.state.fieldErrors)) {
-      // A required form field contains an error, focus on the first error field
-      this.focusOnErrorElement();
-    } else {
+    // if (!isEmpty(this.state.fieldErrors)) {
+    //   // A required form field contains an error, focus on the first error field
+    //   focusOnErrorElement();
+    // } else {
+    console.log("fake submit to API");
+    if (false) {
       // No client-side errors, form is now processing
-      this.setState({ formProcessing: true });
+      // this.setState({ formProcessing: true });
 
-      const {
-        firstName,
-        lastName,
-        email,
-        dateOfBirth,
-        line1,
-        line2,
-        city,
-        state,
-        zip,
-        username,
-        pin,
-        ecommunicationsPref,
-      } = this.state.patronFields;
-      const agencyType = this.getPatronAgencyType(
-        this.state.patronFields.location
-      );
+      // const {
+      //   firstName,
+      //   lastName,
+      //   email,
+      //   dateOfBirth,
+      //   line1,
+      //   line2,
+      //   city,
+      //   state,
+      //   zip,
+      //   username,
+      //   pin,
+      //   ecommunicationsPref,
+      // } = this.state.patronFields;
+      // const agencyType = getPatronAgencyType(
+      //   this.state.patronFields.location
+      // );
 
       // The new and simplier endpoint:
       axios
         .post(
           "/api/create-patron",
           {
-            firstName,
-            lastName,
-            email,
-            dateOfBirth,
-            line1,
-            line2,
-            city,
-            state,
-            zip,
-            username,
-            pin,
-            ecommunicationsPref,
-            agencyType,
-          },
-          {
-            headers: { "csrf-token": this.state.csrfToken },
+            firstName: "test",
+            // lastName,
+            // email,
+            // dateOfBirth,
+            // line1,
+            // line2,
+            // city,
+            // state,
+            // zip,
+            // username,
+            // pin,
+            // ecommunicationsPref,
+            // agencyType,
           }
+          // {
+          // headers: { "csrf-token": this.state.csrfToken },
+          // }
         )
         .then((response) => {
-          this.setState({
-            formProcessing: false,
-            formEntrySuccessful: false,
-            apiResults: response.data,
-          });
+          // this.setState({
+          //   formProcessing: false,
+          //   formEntrySuccessful: false,
+          //   apiResults: response.data,
+          // });
           // TODO: Waiting on whether we will make a redirect in the app
           // or in Drupal.
           // window.location.href = window.confirmationURL;
         })
         .catch((error) => {
-          this.setState({ formProcessing: false, focusOnResult: true });
-          if (error.response && error.response.data) {
-            // The request was made, but the server responded with a status code
-            // that falls out of the range of 2xx
-            this.setState({ apiResults: error.response.data });
-          }
+          console.log("error", error.response);
+          // this.setState({ formProcessing: false, focusOnResult: true });
+          // if (error.response && error.response.data) {
+          //   // The request was made, but the server responded with a status code
+          //   // that falls out of the range of 2xx
+          //   this.setState({ apiResults: error.response.data });
+          // }
         });
     }
-  }
+  };
 
-  renderLoader() {
+  const renderLoader = () => {
     const { formProcessing } = this.state;
     return formProcessing ? <div className="loading" /> : null;
-  }
+  };
 
-  renderApiErrors(errorObj) {
+  const renderApiErrors = (errorObj) => {
     if (!isEmpty(errorObj) && errorObj.status >= 400) {
-      return <ApiErrors ref={this.dynamicSection} apiResults={errorObj} />;
+      return <ApiErrors ref={dynamicSection} apiResults={errorObj} />;
     }
 
     return null;
-  }
+  };
 
-  renderFormFields() {
+  const renderFormFields = () => {
     const checkBoxLabelOptions = {
       id: "receiveEmails",
       labelContent: (
@@ -385,8 +408,13 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
       ),
     };
 
+    const { register, handleSubmit, errors } = useForm<FormInput>();
+
     return (
-      <form className="nypl-library-card-form" onSubmit={this.handleSubmit}>
+      <form
+        className="nypl-library-card-form"
+        onSubmit={handleSubmit(handleSubmitHere)}
+      >
         <h2>Please enter the following information</h2>
         <h3>Personal Information</h3>
         <div className="nypl-name-field">
@@ -396,13 +424,12 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
             label="First Name"
             fieldName="firstName"
             isRequired
-            value={this.state.patronFields.firstName}
-            handleOnChange={this.handleInputChange("firstName")}
-            errorState={this.state.fieldErrors}
-            onBlur={this.handleOnBlur("firstName")}
-            childRef={this.firstName}
+            childRef={register({
+              required: "Please enter a valid first name.",
+            })}
+            errorState={errors}
           />
-          <FormField
+          {/* <FormField
             id="patronLastName"
             type="text"
             label="Last Name"
@@ -413,9 +440,9 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
             errorState={this.state.fieldErrors}
             onBlur={this.handleOnBlur("lastName")}
             childRef={this.lastName}
-          />
+          /> */}
         </div>
-        <FormField
+        {/* <FormField
           id="patronDob"
           className="nypl-date-field"
           type="text"
@@ -600,6 +627,7 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
           onBlur={this.handleOnBlur("pin")}
           childRef={this.pin}
         />
+        */}
 
         <p>
           By submitting an application, you understand and agree to our{" "}
@@ -621,29 +649,27 @@ class LibraryCardForm extends React.Component<{}, LibraryCardFormState> {
         <div>
           <input
             className="nypl-request-button"
-            disabled={this.state.formProcessing}
+            // disabled={this.state.formProcessing}
             type="submit"
             value="Continue"
           />
-          {this.renderLoader()}
+          {/* {this.renderLoader()} */}
         </div>
       </form>
     );
-  }
+  };
 
-  render() {
-    return (
-      <div className="nypl-row">
-        <div className="nypl-column-half nypl-column-offset-one">
-          <div>
-            {this.renderApiErrors(this.state.apiResults)}
-            {this.renderFormFields()}
-          </div>
-          <FormFooterText />
+  return (
+    <div className="nypl-row">
+      <div className="nypl-column-half nypl-column-offset-one">
+        <div>
+          {/* {renderApiErrors(this.state.apiResults)} */}
+          {renderFormFields()}
         </div>
+        <FormFooterText />
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 export default LibraryCardForm;

--- a/src/components/LibraryCardForm/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm/LibraryCardForm.tsx
@@ -1,30 +1,17 @@
 /* eslint-disable */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
 import isEmpty from "lodash/isEmpty";
-import omit from "lodash/omit";
-import assign from "lodash/assign";
-import forIn from "lodash/forIn";
-import { isEmail, isLength, isAlphanumeric } from "validator";
+import { isEmail, isAlphanumeric } from "validator";
+import { Checkbox } from "@nypl/design-system-react-components";
+import { useForm } from "react-hook-form";
 import { isDate } from "../../utils/FormValidationUtils";
 import FormField from "../FormField/FormField";
 import ApiErrors from "../ApiErrors/ApiErrors";
 import config from "../../../appConfig";
 import FormFooterText from "../FormFooterText";
-import { Checkbox } from "@nypl/design-system-react-components";
-import { useForm } from "react-hook-form";
 
-interface LibraryCardFormState {
-  agencyType: string;
-  csrfToken: string;
-  focusOnResult: boolean;
-  formProcessing: boolean;
-  formEntrySuccessful: boolean;
-  apiResults: any;
-  fieldErrors: any;
-  patronFields: any;
-}
-
+// The interface for the react-hook-form state data object.
 interface FormInput {
   firstName: string;
   lastName: string;
@@ -41,81 +28,43 @@ interface FormInput {
   location?: string;
 }
 
+const errorMessages = {
+  firstName: "Please enter a valid first name.",
+  lastName: "Please enter a valid last name.",
+  birthdate: "Please enter a valid date, MM/DD/YYYY, including slashes.",
+  email: "Please enter a valid email address.",
+  username: "Username must be between 5-25 alphanumeric characters.",
+  pin: "Please enter a 4-digit PIN.",
+  location: "Please select an address option.",
+  line1: "Please enter a valid street address.",
+  city: "Please enter a valid city.",
+  state: "Please enter a 2-character state abbreviation.",
+  zip: "Please enter a 5-digit postal code.",
+};
+
 const LibraryCardForm = () => {
-  const dynamicSection = React.createRef<HTMLDivElement>();
-  const stateName = React.createRef<HTMLInputElement>();
-  const firstName = React.createRef<HTMLInputElement>();
-  const lastName = React.createRef<HTMLInputElement>();
-  const dateOfBirth = React.createRef<HTMLInputElement>();
-  const email = React.createRef<HTMLInputElement>();
-  const line1 = React.createRef<HTMLInputElement>();
-  const zip = React.createRef<HTMLInputElement>();
-  const city = React.createRef<HTMLInputElement>();
-  const username = React.createRef<HTMLInputElement>();
-  const pin = React.createRef<HTMLInputElement>();
+  const errorSection = React.createRef<HTMLDivElement>();
+  const [errorObj, setErrorObj] = useState(null);
+  const [apiResults, setApiResults] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [csrfToken, setCsrfToken] = useState(null);
 
-  //   this.state = {
-  //     agencyType: "",
-  //     csrfToken: "",
-  //     formEntrySuccessful: false,
-  //     focusOnResult: false,
-  //     formProcessing: false,
-  //     apiResults: {},
-  //     fieldErrors: {},
-  //     patronFields: {
-  //       firstName: "",
-  //       lastName: "",
-  //       dateOfBirth: "",
-  //       email: "",
-  //       line1: "",
-  //       line2: "",
-  //       city: "",
-  //       state: "",
-  //       zip: "",
-  //       username: "",
-  //       pin: "",
-  //       ecommunicationsPref: true,
-  //       location: "",
-  //     },
-  //   };
+  // Will run whenever the `errorObj` has changes, specifically for
+  // bad requests.
+  useEffect(() => {
+    if (errorObj) {
+      errorSection.current.focus();
+      document.title = "Form Submission Error | NYPL";
+    }
+  }, [errorObj]);
 
-  //   this.handleInputChange = this.handleInputChange.bind(this);
-  //   this.handleOnBlur = this.handleOnBlur.bind(this);
-  // }
-
-  // componentDidMount() {
-  //   const csrfToken = this.getMetaTagContent("name=csrf-token");
-  //   if (csrfToken) {
-  //     const patronFields = Object.assign(this.state.patronFields, {
-  //       location: this.getUrlParameter("form_type") || "nyc",
-  //     });
-
-  //     this.setState({ csrfToken, patronFields });
-  //   }
-  // }
-
-  // componentDidUpdate() {
-  //   if (this.state.focusOnResult) {
-  //     this.focusOnApiResponse();
-  //     if (document && document.title !== "") {
-  //       document.title = "Form Submission Error | NYPL";
-  //     }
-  //   }
-  // }
-
+  // TODO: This works but need to implement CSRF in the backend.
+  // useEffect(() => {
+  //   const csrfToken = getMetaTagContent("name=csrf-token");
+  //   csrfToken && setCsrfToken(csrfToken);
+  // });
   const getMetaTagContent = (tag) => {
     return document.head.querySelector(`[${tag}]`).textContent;
-  };
-
-  const getUrlParameter = (name) => {
-    if (typeof location === "undefined") return "";
-
-    const paramName = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-    const regex = new RegExp(`[\\?&]${paramName}=([^&#]*)`);
-    const results = regex.exec(location.search);
-    return results === null
-      ? ""
-      : decodeURIComponent(results[1].replace(/\+/g, " "));
   };
 
   const getPatronAgencyType = (agencyTypeParam) => {
@@ -125,278 +74,70 @@ const LibraryCardForm = () => {
       : agencyType.default;
   };
 
-  const getFullName = () => {
-    const { firstName, lastName } = this.state.patronFields;
+  /**
+   * submitForm
+   * Makes an internal API call to create a new patron.
+   * @param formData - data object returned from react-hook-form
+   */
+  const submitForm = (formData: FormInput) => {
+    // This is resetting any errors from previous submissions, if any.
+    setErrorObj(null);
+    // Render the loading component.
+    setIsLoading(true);
 
-    return !isEmpty(firstName) && !isEmpty(lastName)
-      ? `${firstName.trim()} ${lastName.trim()}`
-      : null;
-  };
+    const agencyType = getPatronAgencyType(formData.location);
 
-  const focusOnApiResponse = () => {
-    setTimeout(() => {
-      if (dynamicSection) {
-        dynamicSection.current.focus();
-        // this.setState({ focusOnResult: false });
-      }
-    }, 1000);
-  };
-
-  // const validateField = (fieldName, value) => {
-  //   const { fieldErrors } = this.state;
-  //   let currentErrors = {};
-
-  //   switch (fieldName) {
-  //     case "dateOfBirth":
-  //       if (!isDate(value)) {
-  //         fieldErrors[fieldName] =
-  //           "Please enter a valid date, MM/DD/YYYY, including slashes.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "email":
-  //       if (value.trim().length > 0 && !isEmail(value)) {
-  //         fieldErrors[fieldName] = "Please enter a valid email address.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "username":
-  //       if (!isLength(value, { min: 5, max: 25 })) {
-  //         fieldErrors[fieldName] =
-  //           "Username must be between 5-25 alphanumeric characters.";
-  //         currentErrors = fieldErrors;
-  //       } else if (!isAlphanumeric(value)) {
-  //         fieldErrors[fieldName] = "Only alphanumeric characters are allowed.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "pin":
-  //       if (value.length !== 4 || isNaN(value)) {
-  //         fieldErrors[fieldName] = "Please enter a 4-digit PIN.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "firstName":
-  //       if (isEmpty(value)) {
-  //         fieldErrors[fieldName] = "Please enter a valid first name.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "lastName":
-  //       if (isEmpty(value)) {
-  //         fieldErrors[fieldName] = "Please enter a valid last name.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "location":
-  //       if (isEmpty(value)) {
-  //         fieldErrors[fieldName] = "Please select an address option.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "line1":
-  //       if (isEmpty(value)) {
-  //         fieldErrors[fieldName] = "Please enter a valid street address.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "city":
-  //       if (isEmpty(value)) {
-  //         fieldErrors[fieldName] = "Please enter a valid city.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "state":
-  //       if (isEmpty(value) || !isLength(value, { min: 2, max: 2 })) {
-  //         fieldErrors[fieldName] =
-  //           "Please enter a 2-character state abbreviation.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "zip":
-  //       if (
-  //         isEmpty(value) ||
-  //         isNaN(value) ||
-  //         !isLength(value, { min: 5, max: 5 })
-  //       ) {
-  //         fieldErrors[fieldName] = "Please enter a 5-digit postal code.";
-  //         currentErrors = fieldErrors;
-  //       } else {
-  //         currentErrors = omit(fieldErrors, fieldName);
-  //       }
-  //       break;
-  //     case "line2":
-  //       currentErrors = fieldErrors;
-  //       break;
-  //     case "ecommunicationsPref":
-  //       currentErrors = fieldErrors;
-  //       break;
-  //     default:
-  //       break;
-  //   }
-
-  //   this.setState({ fieldErrors: currentErrors });
-  // }
-
-  const focusOnErrorElement = () => {
-    // Handle focusing on first element in the object that contains an error
-    Object.keys(this.state.fieldErrors).some((key) => {
-      if (this.state.fieldErrors[key]) {
-        // the keyword state is reserved in React, therefore the reference to the State field
-        // is renamed to stateName
-        if (key === "state") {
-          stateName.current.focus();
-          return true;
+    axios
+      .post(
+        "/api/create-patron",
+        {
+          ...formData,
+          agencyType,
         }
-
-        // this[key] && this[key].current.focus();
-        return true;
-      }
-      return true;
-    });
-  };
-
-  const handleInputChange = ({ target }) => {
-    const value = target.type === "checkbox" ? target.checked : target.value;
-    console.log("handle change", value);
-    // return (event) => {
-    //   const target = event.target;
-    //   console.log("target", target.value);
-    //   // const value = target.type === "checkbox" ? target.checked : target.value;
-    //   // const newState = assign({}, this.state.patronFields, {
-    //   //   [property]: value,
-    //   // });
-    //   // this.setState({ patronFields: newState });
-    // };
-  };
-
-  const handleOnBlur = (property) => {
-    return (event) => {
-      console.log("blur handle", event.target);
-      const target = event.target;
-      const value = target.value;
-
-      // validateField(property, value);
-    };
-  };
-
-  const handleSubmitHere = (formData: FormInput) => {
-    console.log("submit", formData);
-    // Clearing server side errors for re-submission.
-    // this.setState({ apiResults: {} });
-    // event.preventDefault();
-
-    // Iterate through patron fields and ensure all fields are valid
-    // forIn(this.state.patronFields, (value, key) => {
-    //   validateField(key, value);
-    // });
-
-    // Has client-side errors, stop processing
-    // if (!isEmpty(this.state.fieldErrors)) {
-    //   // A required form field contains an error, focus on the first error field
-    //   focusOnErrorElement();
-    // } else {
-    console.log("fake submit to API");
-    if (false) {
-      // No client-side errors, form is now processing
-      // this.setState({ formProcessing: true });
-
-      // const {
-      //   firstName,
-      //   lastName,
-      //   email,
-      //   dateOfBirth,
-      //   line1,
-      //   line2,
-      //   city,
-      //   state,
-      //   zip,
-      //   username,
-      //   pin,
-      //   ecommunicationsPref,
-      // } = this.state.patronFields;
-      // const agencyType = getPatronAgencyType(
-      //   this.state.patronFields.location
-      // );
-
-      // The new and simplier endpoint:
-      axios
-        .post(
-          "/api/create-patron",
-          {
-            firstName: "test",
-            // lastName,
-            // email,
-            // dateOfBirth,
-            // line1,
-            // line2,
-            // city,
-            // state,
-            // zip,
-            // username,
-            // pin,
-            // ecommunicationsPref,
-            // agencyType,
-          }
-          // {
-          // headers: { "csrf-token": this.state.csrfToken },
-          // }
-        )
-        .then((response) => {
-          // this.setState({
-          //   formProcessing: false,
-          //   formEntrySuccessful: false,
-          //   apiResults: response.data,
-          // });
-          // TODO: Waiting on whether we will make a redirect in the app
-          // or in Drupal.
-          // window.location.href = window.confirmationURL;
-        })
-        .catch((error) => {
-          console.log("error", error.response);
-          // this.setState({ formProcessing: false, focusOnResult: true });
-          // if (error.response && error.response.data) {
-          //   // The request was made, but the server responded with a status code
-          //   // that falls out of the range of 2xx
-          //   this.setState({ apiResults: error.response.data });
-          // }
-        });
-    }
+        // {
+        // headers: { "csrf-token": csrfToken },
+        // }
+      )
+      .then((response) => {
+        // This is setting the state for returned valid response, but
+        // it's not being used. The updated confirmation page is still TBD.
+        setApiResults(response.data);
+        // Don't render the loading component anymore.
+        setIsLoading(false);
+        // TODO: Waiting on whether we will make a redirect in the app
+        // or in Drupal.
+        // window.location.href = window.confirmationURL;
+      })
+      .catch((error) => {
+        // There are server-side errors!
+        // So render the component to display them.
+        setErrorObj(error.response.data);
+        setIsLoading(false);
+      });
   };
 
   const renderLoader = () => {
-    const { formProcessing } = this.state;
-    return formProcessing ? <div className="loading" /> : null;
+    return isLoading ? <div className="loading" /> : null;
   };
 
+  /**
+   * renderApiErrors
+   * This renders the component above the form that displays information on
+   * the error(s) from the submission. Also renders links that link to the
+   * specific input element that is returning an error.
+   * @param errorObj
+   */
   const renderApiErrors = (errorObj) => {
     if (!isEmpty(errorObj) && errorObj.status >= 400) {
-      return <ApiErrors ref={dynamicSection} apiResults={errorObj} />;
+      return <ApiErrors ref={errorSection} apiResults={errorObj} />;
     }
-
     return null;
   };
 
+  /**
+   * renderFormFields
+   * This renders the complete form. Refactoring this later.
+   */
   const renderFormFields = () => {
     const checkBoxLabelOptions = {
       id: "receiveEmails",
@@ -408,12 +149,15 @@ const LibraryCardForm = () => {
       ),
     };
 
-    const { register, handleSubmit, errors } = useForm<FormInput>();
+    // Specific functions and object from react-hook-form.
+    const { register, handleSubmit, errors } = useForm<FormInput>({
+      mode: "onBlur",
+    });
 
     return (
       <form
         className="nypl-library-card-form"
-        onSubmit={handleSubmit(handleSubmitHere)}
+        onSubmit={handleSubmit(submitForm)}
       >
         <h2>Please enter the following information</h2>
         <h3>Personal Information</h3>
@@ -424,25 +168,27 @@ const LibraryCardForm = () => {
             label="First Name"
             fieldName="firstName"
             isRequired
+            // Every input field is registered to react-hook-form. If this
+            // field is empty on blur or on submission, the error message will
+            // display below the input.
             childRef={register({
-              required: "Please enter a valid first name.",
+              required: errorMessages.firstName,
             })}
             errorState={errors}
           />
-          {/* <FormField
+          <FormField
             id="patronLastName"
             type="text"
             label="Last Name"
             fieldName="lastName"
             isRequired
-            value={this.state.patronFields.lastName}
-            handleOnChange={this.handleInputChange("lastName")}
-            errorState={this.state.fieldErrors}
-            onBlur={this.handleOnBlur("lastName")}
-            childRef={this.lastName}
-          /> */}
+            errorState={errors}
+            childRef={register({
+              required: errorMessages.lastName,
+            })}
+          />
         </div>
-        {/* <FormField
+        <FormField
           id="patronDob"
           className="nypl-date-field"
           type="text"
@@ -450,12 +196,13 @@ const LibraryCardForm = () => {
           label="Date of Birth"
           fieldName="dateOfBirth"
           isRequired
-          value={this.state.patronFields.dateOfBirth}
-          handleOnChange={this.handleInputChange("dateOfBirth")}
-          errorState={this.state.fieldErrors}
+          errorState={errors}
           maxLength={10}
-          onBlur={this.handleOnBlur("dateOfBirth")}
-          childRef={this.dateOfBirth}
+          // This `validate` callback allows for specific validation
+          childRef={register({
+            validate: (val) =>
+              (val.length <= 10 && isDate(val)) || errorMessages.birthdate,
+          })}
         />
         <FormField
           id="patronEmail"
@@ -463,19 +210,22 @@ const LibraryCardForm = () => {
           type="text"
           label="E-mail"
           fieldName="email"
-          value={this.state.patronFields.email}
-          handleOnChange={this.handleInputChange("email")}
-          errorState={this.state.fieldErrors}
-          onBlur={this.handleOnBlur("email")}
-          childRef={this.email}
+          errorState={errors}
+          childRef={register({
+            required: false,
+            validate: (val) =>
+              val === "" || isEmail(val) || errorMessages.email,
+          })}
         />
         <Checkbox
           checkboxId="patronECommunications"
-          isSelected={this.state.patronFields.ecommunicationsPref}
           name="ecommunicationsPref"
-          onChange={this.handleInputChange("ecommunicationsPref")}
           labelOptions={checkBoxLabelOptions}
+          // Users must opt-out.
+          isSelected={true}
+          ref={register()}
         />
+
         <h3>Address</h3>
 
         <div className="nypl-radiobutton-field">
@@ -491,8 +241,7 @@ const LibraryCardForm = () => {
                 type="radio"
                 name="location"
                 value="nyc"
-                checked={this.state.patronFields.location === "nyc"}
-                onChange={this.handleInputChange("location")}
+                ref={register()}
               />
               New York City (All five boroughs)
             </label>
@@ -503,8 +252,7 @@ const LibraryCardForm = () => {
                 type="radio"
                 name="location"
                 value="nys"
-                checked={this.state.patronFields.location === "nys"}
-                onChange={this.handleInputChange("location")}
+                ref={register()}
               />
               New York State (Outside NYC)
             </label>
@@ -515,8 +263,11 @@ const LibraryCardForm = () => {
                 type="radio"
                 name="location"
                 value="us"
-                checked={this.state.patronFields.location === "us"}
-                onChange={this.handleInputChange("location")}
+                // For radio buttons or for grouped inputs, the validation
+                // config goes in the last element.
+                ref={register({
+                  required: errorMessages.location,
+                })}
               />
               United States (Visiting NYC)
             </label>
@@ -538,11 +289,10 @@ const LibraryCardForm = () => {
           label="Street Address"
           fieldName="line1"
           isRequired
-          value={this.state.patronFields.line1}
-          handleOnChange={this.handleInputChange("line1")}
-          errorState={this.state.fieldErrors}
-          onBlur={this.handleOnBlur("line1")}
-          childRef={this.line1}
+          errorState={errors}
+          childRef={register({
+            required: errorMessages.line1,
+          })}
         />
         <FormField
           id="patronStreet2"
@@ -550,9 +300,7 @@ const LibraryCardForm = () => {
           type="text"
           label="Apartment / Suite"
           fieldName="line2"
-          value={this.state.patronFields.line2}
-          handleOnChange={this.handleInputChange("line2")}
-          onBlur={this.handleOnBlur("line2")}
+          childRef={register()}
         />
         <FormField
           id="patronCity"
@@ -560,12 +308,11 @@ const LibraryCardForm = () => {
           type="text"
           label="City"
           fieldName="city"
-          value={this.state.patronFields.city}
           isRequired
-          handleOnChange={this.handleInputChange("city")}
-          errorState={this.state.fieldErrors}
-          onBlur={this.handleOnBlur("city")}
-          childRef={this.city}
+          errorState={errors}
+          childRef={register({
+            required: errorMessages.city,
+          })}
         />
         <FormField
           id="patronState"
@@ -574,13 +321,12 @@ const LibraryCardForm = () => {
           instructionText="2-letter abbreviation"
           label="State"
           fieldName="state"
-          value={this.state.patronFields.state}
           isRequired
-          handleOnChange={this.handleInputChange("state")}
-          errorState={this.state.fieldErrors}
+          errorState={errors}
           maxLength={2}
-          onBlur={this.handleOnBlur("state")}
-          childRef={this.stateName}
+          childRef={register({
+            validate: (val) => val.length === 2 || errorMessages.state,
+          })}
         />
         <FormField
           id="patronZip"
@@ -588,13 +334,12 @@ const LibraryCardForm = () => {
           type="text"
           label="Postal Code"
           fieldName="zip"
-          value={this.state.patronFields.zip}
           isRequired
-          handleOnChange={this.handleInputChange("zip")}
-          errorState={this.state.fieldErrors}
+          errorState={errors}
           maxLength={5}
-          onBlur={this.handleOnBlur("zip")}
-          childRef={this.zip}
+          childRef={register({
+            validate: (val) => val.length === 5 || errorMessages.zip,
+          })}
         />
         <h3>Create Your Account</h3>
         <FormField
@@ -604,13 +349,14 @@ const LibraryCardForm = () => {
           label="Username"
           fieldName="username"
           instructionText="5-25 alphanumeric characters"
-          value={this.state.patronFields.username}
           isRequired
-          handleOnChange={this.handleInputChange("username")}
-          errorState={this.state.fieldErrors}
+          errorState={errors}
           maxLength={25}
-          onBlur={this.handleOnBlur("username")}
-          childRef={this.username}
+          childRef={register({
+            validate: (val) =>
+              (val.length >= 5 && val.length <= 25 && isAlphanumeric(val)) ||
+              errorMessages.username,
+          })}
         />
         <FormField
           id="patronPin"
@@ -619,15 +365,13 @@ const LibraryCardForm = () => {
           label="PIN"
           fieldName="pin"
           instructionText="4 digits"
-          value={this.state.patronFields.pin}
           isRequired
-          handleOnChange={this.handleInputChange("pin")}
-          errorState={this.state.fieldErrors}
+          errorState={errors}
           maxLength={4}
-          onBlur={this.handleOnBlur("pin")}
-          childRef={this.pin}
+          childRef={register({
+            validate: (val) => val.length === 4 || errorMessages.pin,
+          })}
         />
-        */}
 
         <p>
           By submitting an application, you understand and agree to our{" "}
@@ -649,11 +393,11 @@ const LibraryCardForm = () => {
         <div>
           <input
             className="nypl-request-button"
-            // disabled={this.state.formProcessing}
+            disabled={isLoading}
             type="submit"
             value="Continue"
           />
-          {/* {this.renderLoader()} */}
+          {renderLoader()}
         </div>
       </form>
     );
@@ -663,7 +407,7 @@ const LibraryCardForm = () => {
     <div className="nypl-row">
       <div className="nypl-column-half nypl-column-offset-one">
         <div>
-          {/* {renderApiErrors(this.state.apiResults)} */}
+          {renderApiErrors(errorObj)}
           {renderFormFields()}
         </div>
         <FormFooterText />

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -281,24 +281,24 @@ export async function createPatron(req, res) {
     // Just for testing purposes locally. Used to verify refs and focus are
     // properly working but also to update the server response interface/type
     // later on.
-    return res.status(400).json({
-      status: 400,
-      response: {
-        type: "server-validation-error",
-        message: "server side validation error",
-        details: {
-          firstName: "First Name field is empty.",
-          lastName: "Last Name field is empty.",
-          dateOfBirth: "Date of Birth field is empty.",
-          line1: "Street Address field is empty.",
-          city: "City field is empty.",
-          state: "State field is empty.",
-          zip: "Postal Code field is empty.",
-          username: "Username field is empty.",
-          pin: "PIN field is empty.",
-        },
-      },
-    });
+    // return res.status(400).json({
+    //   status: 400,
+    //   response: {
+    //     type: "server-validation-error",
+    //     message: "server side validation error",
+    //     details: {
+    //       firstName: "First Name field is empty.",
+    //       lastName: "Last Name field is empty.",
+    //       dateOfBirth: "Date of Birth field is empty.",
+    //       line1: "Street Address field is empty.",
+    //       city: "City field is empty.",
+    //       state: "State field is empty.",
+    //       zip: "Postal Code field is empty.",
+    //       username: "Username field is empty.",
+    //       pin: "PIN field is empty.",
+    //     },
+    //   },
+    // });
 
     return axios
       .post(config.api.patron, patronData, constructApiHeaders(token))

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -110,7 +110,8 @@ const constructPatronObject = (object) => {
     !isEmpty(username) &&
     (!isAlphanumeric(username) || !isLength(username, { min: 5, max: 25 }))
   ) {
-    errorObj = { ...errorObj,
+    errorObj = {
+      ...errorObj,
       username: "Please enter a username between 5-25 alphanumeric characters.",
     };
   }
@@ -160,16 +161,14 @@ const isTokenExpiring = (
   expirationTime,
   timeThreshold = 5,
   type = "minutes"
-): boolean => (
-  expirationTime.diff(moment(), type) < timeThreshold
-);
+): boolean => expirationTime.diff(moment(), type) < timeThreshold;
 
 // App-level cache object for API token related variables to be used in
 // `initializeAppAuth` and `createPatron`.
 const app = {};
 
 export async function initializeAppAuth(req, res) {
-  logger.info('initializeAppAuth');
+  logger.info("initializeAppAuth");
   const tokenObject = app["tokenObject"];
   const tokenExpTime = app["tokenExpTime"];
   const minuteExpThreshold = 10;
@@ -182,7 +181,7 @@ export async function initializeAppAuth(req, res) {
           app["tokenObject"] = response.data;
           app["tokenExpTime"] = moment().add(response.data.expires_in, "s");
         } else {
-          logger.error('No access_token obtained from OAuth Service.');
+          logger.error("No access_token obtained from OAuth Service.");
           const errorObj = {};
           Object.assign(errorObj, {
             oauth: "No access_token obtained from OAuth Service.",
@@ -282,24 +281,24 @@ export async function createPatron(req, res) {
     // Just for testing purposes locally. Used to verify refs and focus are
     // properly working but also to update the server response interface/type
     // later on.
-    // return res.status(400).json({
-    //   "status": 400,
-    //   "response": {
-    //     "type": "server-validation-error",
-    //     "message": "server side validation error",
-    //     "details": {
-    //       "firstName": "First Name field is empty.",
-    //       "lastName": "Last Name field is empty.",
-    //       "dateOfBirth": "Date of Birth field is empty.",
-    //       "line1": "Street Address field is empty.",
-    //       "city": "City field is empty.",
-    //       "state": "State field is empty.",
-    //       "zip": "Postal Code field is empty.",
-    //       "username": "Username field is empty.",
-    //       "pin": "PIN field is empty."
-    //     }
-    //   }
-    // });
+    return res.status(400).json({
+      status: 400,
+      response: {
+        type: "server-validation-error",
+        message: "server side validation error",
+        details: {
+          firstName: "First Name field is empty.",
+          lastName: "Last Name field is empty.",
+          dateOfBirth: "Date of Birth field is empty.",
+          line1: "Street Address field is empty.",
+          city: "City field is empty.",
+          state: "State field is empty.",
+          zip: "Postal Code field is empty.",
+          username: "Username field is empty.",
+          pin: "PIN field is empty.",
+        },
+      },
+    });
 
     return axios
       .post(config.api.patron, patronData, constructApiHeaders(token))
@@ -315,7 +314,7 @@ export async function createPatron(req, res) {
         // If the response from the Patron Creator Service(the wrapper)
         // does not include valid error details, we mark this result as an internal server error
         if (!err.response.data) {
-          logger.error('Error calling Card Creator API: ', err.message);
+          logger.error("Error calling Card Creator API: ", err.message);
           serverError = { type: "server" };
         }
 


### PR DESCRIPTION
This resolves [DQ-335](https://jira.nypl.org/browse/DQ-335). This also has a dependency on an update from the Design System which is [PR 275](https://github.com/NYPL/nypl-design-system/pull/275) - which is why tests are failing.

This introduces [react-hook-form](https://react-hook-form.com/) to simplify rendering, collecting data, rendering errors, and validation. Functionally, there's no difference. I tested this by submitting to the QA Card Creator API endpoint and I can create real patrons and the errors return are also available to the front-end.

Using the package really simplifies a lot and I was able to remove a lot of existing code that did the same thing, just in a more explicit and verbose way. The biggest factor in using it was using refs which is one reason why the Design System components needed the `forwardRef` implementation. `react-hook-form` relies on passing down a `register` function as a ref to handle the `onChange`, `onBlur`, `onSubmit` functions.

Accessibility-wise, input elements get focused when it does not pass validation and a submission is done. This was done manually before but `react-hook-form` handles it automatically. The error component for server side errors still renders and gets focused (using an `useEffect`) and the links to individual input elements still works.

This also uses `useState` and `useEffect` for the minor internal values in the `LibraryCardForm` component (which can be refactored but should be a different story).