### PR TITLE
Autosuggest libraries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7097,6 +7097,11 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "es6-symbol": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -16424,6 +16429,41 @@
         }
       }
     },
+    "react-autosuggest": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-10.0.2.tgz",
+      "integrity": "sha512-ouI0RJDSgM1FBfK0ZmLC3qUqithIwPVTpnC4JQW4DeId3mH2JnZmkNNDKImhcMrxLbSQRpV/DfTLn0uCs4b27w==",
+      "requires": {
+        "es6-promise": "^4.2.8",
+        "prop-types": "^15.7.2",
+        "react-autowhatever": "^10.2.1",
+        "react-themeable": "^1.1.0",
+        "section-iterator": "^2.0.0",
+        "shallow-equal": "^1.2.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        }
+      }
+    },
+    "react-autowhatever": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.2.1.tgz",
+      "integrity": "sha512-5gQyoETyBH6GmuW1N1J81CuoAV+Djeg66DEo03xiZOl3WOwJHBP5LisKUvCGOakjrXU4M3hcIvCIqMBYGUmqOA==",
+      "requires": {
+        "prop-types": "^15.5.8",
+        "react-themeable": "^1.1.0",
+        "section-iterator": "^2.0.0"
+      }
+    },
     "react-axe": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/react-axe/-/react-axe-3.5.3.tgz",
@@ -16576,6 +16616,21 @@
             "object-assign": "^4.1.1",
             "react-is": "^16.8.1"
           }
+        }
+      }
+    },
+    "react-themeable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
+      "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
+      "requires": {
+        "object-assign": "^3.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         }
       }
     },
@@ -17888,6 +17943,11 @@
         "source-map": "^0.4.2"
       }
     },
+    "section-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
+      "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -17972,6 +18032,11 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,9 +2817,9 @@
       "integrity": "sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ=="
     },
     "@nypl/design-system-react-components": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.7.2.tgz",
-      "integrity": "sha512-3nJgUG4BZfBsvQ3Z7CMqhAAuJb76tqGXl3JcVtCoNJyKIrOGtRUnwhzPfGNUIRmfT5GKoh4Dam5ye2qSeMJ17A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.9.0.tgz",
+      "integrity": "sha512-QKYFwYB48rw2hKHtz2QugaETw4dUWz72txU0uW+Oewy5RWHqm4Yg9cpm/2TivodlHUUS81dc/O9KLERVC+Sh8Q==",
       "requires": {
         "he": "^1.2.0",
         "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "next": "^9.4.4",
     "qs": "6.9.3",
     "react": "16.13.1",
+    "react-autosuggest": "^10.0.2",
     "react-dom": "16.13.1",
     "react-hook-form": "^6.0.6",
     "sass": "^1.26.9",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@nypl/design-system-react-components": "^0.7.2",
+    "@nypl/design-system-react-components": "^0.9.0",
     "@nypl/design-toolkit": "0.1.37",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.7",

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -17,6 +17,7 @@ interface FormFieldProps {
   isRequired?: boolean;
   instructionText?: string;
   maxLength?: number;
+  other?: any;
 }
 
 /**
@@ -37,6 +38,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
       isRequired = false,
       instructionText,
       maxLength,
+      other,
     },
     ref
   ) => {
@@ -66,6 +68,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
             maxLength: maxLength || null,
             name: fieldName,
             tabIndex: 0,
+            ...other,
           }}
           ref={ref}
         />

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -38,7 +38,8 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
       isRequired = false,
       instructionText,
       maxLength,
-      other,
+      // any extra input element attributes
+      ...rest
     },
     ref
   ) => {
@@ -68,7 +69,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
             maxLength: maxLength || null,
             name: fieldName,
             tabIndex: 0,
-            ...other,
+            ...rest,
           }}
           ref={ref}
         />

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -19,6 +19,7 @@ import { Address } from "../interfaces";
 import useParamsContext from "../context/ParamsContext";
 import useFormResultsContext from "../context/FormResultsContext";
 import AgeForm from "./AgeForm";
+import { findLibraryCode } from "../utils/FormValidationUtils";
 
 // The interface for the react-hook-form state data object.
 interface FormInput {
@@ -42,7 +43,6 @@ interface FormInput {
   location?: string;
   homeLibraryCode: string;
   acceptTerms: boolean;
-  libraryListSuggest?: string;
 }
 
 const errorMessages = {
@@ -109,13 +109,9 @@ const LibraryCardForm = () => {
     setErrorObj(null);
     // Render the loading component.
     setIsLoading(true);
-    console.log("formdata", formData);
 
-    const lib = ilsLibraryList.find(
-      (list) => list.label === formData.libraryListSuggest
-    );
-    console.log("lib", lib);
-    formData.homeLibraryCode = lib.value;
+    formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
+    // console.log("formdata", formData);
 
     const agencyType = getPatronAgencyType(formData.location);
     axios
@@ -315,7 +311,8 @@ const LibraryCardForm = () => {
 
         <LibraryListForm
           libraryList={ilsLibraryList}
-          // The default branch is the "SimplyE" branch with a code of "eb".
+          // The default branch is the "SimplyE" branch with a code of "eb",
+          // but we do that in the server side on form submission.
           defaultValue=""
         />
 

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -42,6 +42,7 @@ interface FormInput {
   location?: string;
   homeLibraryCode: string;
   acceptTerms: boolean;
+  libraryListSuggest?: string;
 }
 
 const errorMessages = {
@@ -108,6 +109,13 @@ const LibraryCardForm = () => {
     setErrorObj(null);
     // Render the loading component.
     setIsLoading(true);
+    console.log("formdata", formData);
+
+    const lib = ilsLibraryList.find(
+      (list) => list.label === formData.libraryListSuggest
+    );
+    console.log("lib", lib);
+    formData.homeLibraryCode = lib.value;
 
     const agencyType = getPatronAgencyType(formData.location);
     axios
@@ -308,7 +316,7 @@ const LibraryCardForm = () => {
         <LibraryListForm
           libraryList={ilsLibraryList}
           // The default branch is the "SimplyE" branch with a code of "eb".
-          defaultValue="eb"
+          defaultValue=""
         />
 
         <h3>Create Your Account</h3>

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -111,7 +111,6 @@ const LibraryCardForm = () => {
     setIsLoading(true);
 
     formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
-    // console.log("formdata", formData);
 
     const agencyType = getPatronAgencyType(formData.location);
     axios

--- a/src/components/LibraryListForm.tsx
+++ b/src/components/LibraryListForm.tsx
@@ -1,9 +1,4 @@
 import React, { useState } from "react";
-import {
-  Label,
-  Select,
-  HelperErrorText,
-} from "@nypl/design-system-react-components";
 import { useFormContext } from "react-hook-form";
 import Autosuggest from "react-autosuggest";
 import FormField from "./FormField";
@@ -18,29 +13,30 @@ interface LibraryListFormProps {
   defaultValue: string;
 }
 
-// Teach Autosuggest how to calculate suggestions for any given input value.
-const getSuggestions = (value, list) => {
+/**
+ * getSuggestions
+ * This function tells react-autosuggest how to filter the suggestions. In this
+ * case, if the user input is found anywhere in any of the libraries' name,
+ * return the library. This is to "search" even if the user doesn't start with
+ * the library's first name.
+ */
+const getSuggestions = (value: string, list: LibraryListObject[]) => {
   const inputValue = value.trim().toLowerCase();
-  const inputLength = inputValue.length;
-
-  return inputLength === 0
-    ? []
-    : list.filter(
-        (l) => l.label.toLowerCase().slice(0, inputLength) === inputValue
-      );
+  const findInString = (l) => l.label.toLowerCase().indexOf(inputValue) !== -1;
+  return inputValue.length === 0 ? [] : list.filter(findInString);
 };
-
-// When suggestion is clicked, Autosuggest needs to populate the input
-// based on the clicked suggestion. Teach Autosuggest how to calculate the
-// input value for every given suggestion.
-const getSuggestionValue = (suggestion) => {
-  return suggestion.label;
-};
-
-// Use your imagination to render suggestions.
-const renderSuggestion = (suggestion) => {
-  return <div>{suggestion.label}</div>;
-};
+/**
+ * getSuggestionValue
+ * All we need is the label of the library object as the value.
+ */
+const getSuggestionValue = (suggestion: LibraryListObject) => suggestion.label;
+/**
+ * renderSuggestion
+ * How to display each suggestion which gets rendered in a list item element.
+ */
+const renderSuggestion = (suggestion: LibraryListObject) => (
+  <div>{suggestion.label}</div>
+);
 
 /**
  * LibraryListForm
@@ -63,69 +59,43 @@ const LibraryListForm = ({
   };
   // Autosuggest will call this function every time you need to update suggestions.
   // You already implemented this logic above, so just use it.
-  const onSuggestionsFetchRequested = ({ value }) => {
+  const onSuggestionsFetchRequested = ({ value }) =>
     setSuggestions(getSuggestions(value, libraryList));
-  };
 
   // Autosuggest will call this function every time you need to clear suggestions.
-  const onSuggestionsClearRequested = () => {
-    setSuggestions([]);
-  };
+  const onSuggestionsClearRequested = () => setSuggestions([]);
   // Autosuggest will pass through all these props to the input.
   const inputProps = {
-    placeholder: "Type a library name",
+    placeholder: "Type a library name, e.g. Stavros Niarchos",
     value,
     onChange,
+    // Pass in the `react-hook-form` register function so it can handle this
+    // form element's state for us.
     ref: register(),
   };
 
-  const renderInputComponent = (inputProps) => {
-    return (
-      <FormField
-        other={inputProps}
-        id="librarylist-suggest-test"
-        type="text"
-        label="Home Library:"
-        fieldName="libraryListSuggest"
-        isRequired
-        instructionText="Select your home library from the list."
-      />
-    );
-  };
+  const renderInputComponent = (inputProps) => (
+    <FormField
+      id="librarylist-autosuggest"
+      type="text"
+      label="Home Library:"
+      fieldName="homeLibraryCode"
+      isRequired={false}
+      instructionText="Select your home library from the list. Start by typing the name of the library."
+      {...inputProps}
+    />
+  );
 
   return (
-    <>
-      <Autosuggest
-        suggestions={suggestions}
-        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
-        onSuggestionsClearRequested={onSuggestionsClearRequested}
-        getSuggestionValue={getSuggestionValue}
-        renderSuggestion={renderSuggestion}
-        inputProps={inputProps}
-        renderInputComponent={renderInputComponent}
-      />
-      {/* <Label htmlFor="homeLibrarySelect" id="homeLibrarylabel">
-        Home Library:
-      </Label>
-      <Select
-        isRequired={false}
-        helperTextId="homeLibraryHelperText"
-        id="homeLibrarySelect"
-        labelId="homeLibrarylabel"
-        name="homeLibraryCode"
-        selectedOption={defaultValue}
-        ref={register()}
-      >
-        {libraryList.map((library) => (
-          <option key={library.value} value={library.value}>
-            {library.label}
-          </option>
-        ))}
-      </Select>
-      <HelperErrorText id="homeLibraryHelperText" isError={false}>
-        Select your home library from the list.
-      </HelperErrorText> */}
-    </>
+    <Autosuggest
+      suggestions={suggestions}
+      onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+      onSuggestionsClearRequested={onSuggestionsClearRequested}
+      getSuggestionValue={getSuggestionValue}
+      renderSuggestion={renderSuggestion}
+      inputProps={inputProps}
+      renderInputComponent={renderInputComponent}
+    />
   );
 };
 

--- a/src/components/LibraryListForm.tsx
+++ b/src/components/LibraryListForm.tsx
@@ -1,10 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Label,
   Select,
   HelperErrorText,
 } from "@nypl/design-system-react-components";
 import { useFormContext } from "react-hook-form";
+import Autosuggest from "react-autosuggest";
+import FormField from "./FormField";
 
 export interface LibraryListObject {
   value: string;
@@ -15,6 +17,30 @@ interface LibraryListFormProps {
   libraryList: LibraryListObject[];
   defaultValue: string;
 }
+
+// Teach Autosuggest how to calculate suggestions for any given input value.
+const getSuggestions = (value, list) => {
+  const inputValue = value.trim().toLowerCase();
+  const inputLength = inputValue.length;
+
+  return inputLength === 0
+    ? []
+    : list.filter(
+        (l) => l.label.toLowerCase().slice(0, inputLength) === inputValue
+      );
+};
+
+// When suggestion is clicked, Autosuggest needs to populate the input
+// based on the clicked suggestion. Teach Autosuggest how to calculate the
+// input value for every given suggestion.
+const getSuggestionValue = (suggestion) => {
+  return suggestion.label;
+};
+
+// Use your imagination to render suggestions.
+const renderSuggestion = (suggestion) => {
+  return <div>{suggestion.label}</div>;
+};
 
 /**
  * LibraryListForm
@@ -27,10 +53,58 @@ const LibraryListForm = ({
   libraryList = [],
   defaultValue,
 }: LibraryListFormProps) => {
+  const [value, setValue] = useState(defaultValue);
+  const [suggestions, setSuggestions] = useState([]);
+
   const { register } = useFormContext();
+
+  const onChange = (event, { newValue }) => {
+    setValue(newValue);
+  };
+  // Autosuggest will call this function every time you need to update suggestions.
+  // You already implemented this logic above, so just use it.
+  const onSuggestionsFetchRequested = ({ value }) => {
+    setSuggestions(getSuggestions(value, libraryList));
+  };
+
+  // Autosuggest will call this function every time you need to clear suggestions.
+  const onSuggestionsClearRequested = () => {
+    setSuggestions([]);
+  };
+  // Autosuggest will pass through all these props to the input.
+  const inputProps = {
+    placeholder: "Type a library name",
+    value,
+    onChange,
+    ref: register(),
+  };
+
+  const renderInputComponent = (inputProps) => {
+    return (
+      <FormField
+        other={inputProps}
+        id="librarylist-suggest-test"
+        type="text"
+        label="Home Library:"
+        fieldName="libraryListSuggest"
+        isRequired
+        instructionText="Select your home library from the list."
+      />
+    );
+  };
+
   return (
     <>
-      <Label htmlFor="homeLibrarySelect" id="homeLibrarylabel">
+      <Autosuggest
+        suggestions={suggestions}
+        onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
+        getSuggestionValue={getSuggestionValue}
+        renderSuggestion={renderSuggestion}
+        inputProps={inputProps}
+        renderInputComponent={renderInputComponent}
+      />
+      {/* <Label htmlFor="homeLibrarySelect" id="homeLibrarylabel">
         Home Library:
       </Label>
       <Select
@@ -50,7 +124,7 @@ const LibraryListForm = ({
       </Select>
       <HelperErrorText id="homeLibraryHelperText" isError={false}>
         Select your home library from the list.
-      </HelperErrorText>
+      </HelperErrorText> */}
     </>
   );
 };

--- a/src/components/LibraryListForm.tsx
+++ b/src/components/LibraryListForm.tsx
@@ -86,6 +86,12 @@ const LibraryListForm = ({
     />
   );
 
+  const renderSuggestionsContainer = ({ containerProps, children }) => (
+    <div {...containerProps} aria-label="List of library name suggestions.">
+      {children}
+    </div>
+  );
+
   return (
     <Autosuggest
       suggestions={suggestions}
@@ -95,6 +101,7 @@ const LibraryListForm = ({
       renderSuggestion={renderSuggestion}
       inputProps={inputProps}
       renderInputComponent={renderInputComponent}
+      renderSuggestionsContainer={renderSuggestionsContainer}
     />
   );
 };

--- a/src/components/LibraryListForm.tsx
+++ b/src/components/LibraryListForm.tsx
@@ -14,36 +14,12 @@ interface LibraryListFormProps {
 }
 
 /**
- * getSuggestions
- * This function tells react-autosuggest how to filter the suggestions. In this
- * case, if the user input is found anywhere in any of the libraries' name,
- * return the library. This is to "search" even if the user doesn't start with
- * the library's first name.
- */
-const getSuggestions = (value: string, list: LibraryListObject[]) => {
-  const inputValue = value.trim().toLowerCase();
-  const findInString = (l) => l.label.toLowerCase().indexOf(inputValue) !== -1;
-  return inputValue.length === 0 ? [] : list.filter(findInString);
-};
-/**
- * getSuggestionValue
- * All we need is the label of the library object as the value.
- */
-const getSuggestionValue = (suggestion: LibraryListObject) => suggestion.label;
-/**
- * renderSuggestion
- * How to display each suggestion which gets rendered in a list item element.
- */
-const renderSuggestion = (suggestion: LibraryListObject) => (
-  <div>{suggestion.label}</div>
-);
-
-/**
  * LibraryListForm
- * Renders a complete label, select, and description text form field that
+ * Renders a complete label, input, and description text form field that
  * allows patrons to select their home library from the `libraryList` prop.
  * This component depends on the react-hook-form library to process updates on
- * the select element and for form values.
+ * the select element and for form values. Also uses `react-autosuggest` to
+ * render suggestions when a patron starts to type a library name.
  */
 const LibraryListForm = ({
   libraryList = [],
@@ -51,18 +27,42 @@ const LibraryListForm = ({
 }: LibraryListFormProps) => {
   const [value, setValue] = useState(defaultValue);
   const [suggestions, setSuggestions] = useState([]);
-
   const { register } = useFormContext();
 
   const onChange = (event, { newValue }) => {
     setValue(newValue);
   };
-  // Autosuggest will call this function every time you need to update suggestions.
-  // You already implemented this logic above, so just use it.
+  /**
+   * getSuggestions
+   * This function tells react-autosuggest how to filter the suggestions. In this
+   * case, if the user input is found anywhere in any of the libraries' name,
+   * return the library. This is to "search" even if the user doesn't start with
+   * the library's first name.
+   */
+  const getSuggestions = (value: string, list: LibraryListObject[]) => {
+    const inputValue = value.trim().toLowerCase();
+    const findInString = (l) =>
+      l.label.toLowerCase().indexOf(inputValue) !== -1;
+    return inputValue.length === 0 ? [] : list.filter(findInString);
+  };
+  /**
+   * getSuggestionValue
+   * All we need is the label of the library object as the value.
+   */
+  const getSuggestionValue = (suggestion: LibraryListObject) =>
+    suggestion.label;
+  /**
+   * renderSuggestion
+   * How to display each suggestion which gets rendered in a list item element.
+   */
+  const renderSuggestion = (suggestion: LibraryListObject) => (
+    <div>{suggestion.label}</div>
+  );
+  // Autosuggest will call this function every time suggestions need to be
+  // updated.
   const onSuggestionsFetchRequested = ({ value }) =>
     setSuggestions(getSuggestions(value, libraryList));
-
-  // Autosuggest will call this function every time you need to clear suggestions.
+  // Clear suggestions.
   const onSuggestionsClearRequested = () => setSuggestions([]);
   // Autosuggest will pass through all these props to the input.
   const inputProps = {
@@ -73,7 +73,10 @@ const LibraryListForm = ({
     // form element's state for us.
     ref: register(),
   };
-
+  /**
+   * renderInputComponent
+   * This is the custom component we want to render for the form field.
+   */
   const renderInputComponent = (inputProps) => (
     <FormField
       id="librarylist-autosuggest"
@@ -85,7 +88,11 @@ const LibraryListForm = ({
       {...inputProps}
     />
   );
-
+  /**
+   * renderSuggestionsContainer
+   * To solve an accessibility issue, we render the autosuggest container
+   * with an `aria-label`.
+   */
   const renderSuggestionsContainer = ({ containerProps, children }) => (
     <div {...containerProps} aria-label="List of library name suggestions.">
       {children}

--- a/src/styles/components/_autosuggest.scss
+++ b/src/styles/components/_autosuggest.scss
@@ -1,58 +1,55 @@
 .react-autosuggest__container {
-  // position: relative;
-  // display: inline;
+  position: relative;
+  width: 100%;
 }
 
 .react-autosuggest__input {
-  // width: 618px;
-  // height: 34px;
+  margin-bottom: unset;
   padding: 10px 0;
-  // font-size: 16px;
-  // border: 1px solid #aaa;
 }
 
-// .react-autosuggest__input--focused {
-//    outline: none;
-// }
+.react-autosuggest__input--focused {
+   outline: none;
+}
 
 .react-autosuggest__input--open {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  width: 100%;
 }
 
 .react-autosuggest__suggestions-container {
   display: none;
+  width: 100%;
 }
 
 .react-autosuggest__suggestions-container--open {
+  background-color: var(--ui-white);
   display: block;
-  position: absolute;
-  width: 618px;
-  border: 1px solid #aaa;
-  background-color: #fff;
-  font-family: Helvetica, sans-serif;
+  top: 80px;
+  margin-top: 2px;
   font-weight: 300;
-  font-size: 16px;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
+  outline: 1px solid var(--ui-gray-light);
+  position: absolute;
+  width: 100%;
   z-index: 2;
 }
 
 .react-autosuggest__suggestions-list {
+  list-style-type: none;
   margin: 0;
   padding: 0;
-  list-style-type: none;
 }
 
 .react-autosuggest__suggestion {
   cursor: pointer;
-  padding: 10px;
+  padding: var(--space-xs);
 }
 
 .react-autosuggest__suggestion--highlighted {
-  background-color: #ddd;
+  background-color: var(--ui-gray-light);
 }
 
 .auto-suggest-bottom {
-  padding: .5em;
+  padding: var(--space-xs);
 }

--- a/src/styles/components/_autosuggest.scss
+++ b/src/styles/components/_autosuggest.scss
@@ -1,0 +1,58 @@
+.react-autosuggest__container {
+  // position: relative;
+  // display: inline;
+}
+
+.react-autosuggest__input {
+  // width: 618px;
+  // height: 34px;
+  padding: 10px 0;
+  // font-size: 16px;
+  // border: 1px solid #aaa;
+}
+
+// .react-autosuggest__input--focused {
+//    outline: none;
+// }
+
+.react-autosuggest__input--open {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.react-autosuggest__suggestions-container {
+  display: none;
+}
+
+.react-autosuggest__suggestions-container--open {
+  display: block;
+  position: absolute;
+  width: 618px;
+  border: 1px solid #aaa;
+  background-color: #fff;
+  font-family: Helvetica, sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  z-index: 2;
+}
+
+.react-autosuggest__suggestions-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.react-autosuggest__suggestion {
+  cursor: pointer;
+  padding: 10px;
+}
+
+.react-autosuggest__suggestion--highlighted {
+  background-color: #ddd;
+}
+
+.auto-suggest-bottom {
+  padding: .5em;
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -17,6 +17,7 @@
 @import 'components/confirmation';
 @import 'components/errorBox';
 @import 'components/accordion';
+@import 'components/autosuggest';
 
 html {
   @include font-settings;

--- a/src/utils/FormValidationUtils.tsx
+++ b/src/utils/FormValidationUtils.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import React from "react";
+import ilsLibraryList from "../data/ilsLibraryList";
 
 function isDate(
   input,
@@ -145,4 +146,18 @@ function renderServerValidationError(object) {
   return errorMessages;
 }
 
-export { isDate, renderServerValidationError };
+/**
+ * findLibraryCode
+ * Find the code for a library by searching for its name in the `ilsLibraryList`
+ * array. If no object is found, return the default value of "eb" for
+ * "e-branch" or "simplye" (interchangeable names);
+ * @param libraryName Name of library to find in the list.
+ */
+function findLibraryCode(libraryName: string) {
+  const library = ilsLibraryList.find(
+    (library) => library.label === libraryName
+  );
+  return library?.value || "eb";
+}
+
+export { isDate, renderServerValidationError, findLibraryCode };

--- a/src/utils/FormValidationUtils.tsx
+++ b/src/utils/FormValidationUtils.tsx
@@ -153,7 +153,7 @@ function renderServerValidationError(object) {
  * "e-branch" or "simplye" (interchangeable names);
  * @param libraryName Name of library to find in the list.
  */
-function findLibraryCode(libraryName: string) {
+function findLibraryCode(libraryName?: string) {
   const library = ilsLibraryList.find(
     (library) => library.label === libraryName
   );

--- a/src/utils/__tests__/FormValidationUtils.test.tsx
+++ b/src/utils/__tests__/FormValidationUtils.test.tsx
@@ -1,0 +1,16 @@
+import { findLibraryCode } from "../FormValidationUtils";
+
+describe("findLibraryCode", () => {
+  // `eb` is the default value describing the "E-Branch" or "SimplyE" library.
+  test("it returns `eb` as the default value", () => {
+    expect(findLibraryCode()).toEqual("eb");
+  });
+
+  test("it returns the value code for a library name", () => {
+    // Spot checking random libraries. Check "/src/data/ilLibraryList.ts" for a
+    // full mapping of library name to library code.
+    expect(findLibraryCode("Melrose Branch")).toEqual("me");
+    expect(findLibraryCode("Pelham Bay Branch")).toEqual("pm");
+    expect(findLibraryCode("West Farms Branch")).toEqual("wf");
+  });
+});


### PR DESCRIPTION
Resolves [DQ-351](https://jira.nypl.org/browse/DQ-351). 

This implements the [`react-autosuggest`](https://github.com/moroshko/react-autosuggest) library to use for the home library form value. This converts the `select` form element into the DS `Input` and `Label` components along with `react-autosuggest`'s list element suggestions container.

Default view:
<img width="683" alt="Screen Shot 2020-08-04 at 1 48 29 PM" src="https://user-images.githubusercontent.com/1280564/89328418-5b477880-d65b-11ea-9ab0-bcedba517eae.png">

When the user starts typing:
<img width="689" alt="Screen Shot 2020-08-04 at 10 44 25 AM" src="https://user-images.githubusercontent.com/1280564/89328441-65697700-d65b-11ea-9e5a-4573b79facde.png">

Note: this is also part of [DS #307](https://github.com/NYPL/nypl-design-system/pull/307) but is not a direct dependency. @helen I modified the CSS a bit because I think the Design Toolkit is making minor modifications.