### PR TITLE
Breaking out the radio button location form section into its own comp…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,9 +2817,9 @@
       "integrity": "sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ=="
     },
     "@nypl/design-system-react-components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.9.0.tgz",
-      "integrity": "sha512-QKYFwYB48rw2hKHtz2QugaETw4dUWz72txU0uW+Oewy5RWHqm4Yg9cpm/2TivodlHUUS81dc/O9KLERVC+Sh8Q==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.10.1.tgz",
+      "integrity": "sha512-AMDcHVYcfeV+Lfd7insH7IW6IpOrz1cZTgTUSMI9SmWJY/NiuqduGF+Ca11N2qmLAylCZLoaKbD4UxwckZRdlw==",
       "requires": {
         "he": "^1.2.0",
         "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@nypl/design-system-react-components": "^0.9.0",
+    "@nypl/design-system-react-components": "^0.10.1",
     "@nypl/design-toolkit": "0.1.37",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.7",

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -19,6 +19,7 @@ import { Address } from "../interfaces";
 import useParamsContext from "../context/ParamsContext";
 import useFormDataContext from "../context/FormDataContext";
 import AgeForm from "./AgeForm";
+import LocationForm from "./LocationForm";
 
 // The interface for the react-hook-form state data object.
 interface FormInput {
@@ -108,6 +109,7 @@ const LibraryCardForm = () => {
     dispatch({ type: "SET_FORM_ERRORS", value: null });
     // Render the loading component.
     dispatch({ type: "SET_IS_LOADING", value: true });
+    console.log(formData);
 
     const agencyType = getPatronAgencyType(formData.location);
     axios
@@ -232,59 +234,7 @@ const LibraryCardForm = () => {
 
         <h3>Address</h3>
 
-        <div className="nypl-radiobutton-field">
-          <fieldset>
-            <legend id="radiobutton-location">
-              I live, work, go to school, or pay property taxes at an address
-              in: <span className="nypl-required-field"> Required</span>
-            </legend>
-            <label id="radiobutton-location_nyc" htmlFor="location-nyc">
-              <input
-                aria-labelledby="radiobutton-location radiobutton-location_nyc"
-                id="location-nyc"
-                type="radio"
-                name="location"
-                value="nyc"
-                ref={register()}
-              />
-              New York City (All five boroughs)
-            </label>
-            <label id="radiobutton-location_nys" htmlFor="location-nys">
-              <input
-                aria-labelledby="radiobutton-location radiobutton-location_nys"
-                id="location-nys"
-                type="radio"
-                name="location"
-                value="nys"
-                ref={register()}
-              />
-              New York State (Outside NYC)
-            </label>
-            <label id="radiobutton-location_us" htmlFor="location-us">
-              <input
-                aria-labelledby="radiobutton-location radiobutton-location_us"
-                id="location-us"
-                type="radio"
-                name="location"
-                value="us"
-                // For radio buttons or for grouped inputs, the validation
-                // config goes in the last element.
-                ref={register({
-                  required: errorMessages.location,
-                })}
-              />
-              United States (Visiting NYC)
-            </label>
-          </fieldset>
-        </div>
-
-        <p className="nypl-address-note">
-          If your address is outside the United States, please use our{" "}
-          <a href="https://catalog.nypl.org/selfreg/patonsite">
-            alternate form
-          </a>
-          .
-        </p>
+        <LocationForm errorMessage={errorMessages.location} />
 
         <AddressForm
           type={AddressTypes.Home}

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -110,7 +110,6 @@ const LibraryCardForm = () => {
     dispatch({ type: "SET_FORM_ERRORS", value: null });
     // Render the loading component.
     dispatch({ type: "SET_IS_LOADING", value: true });
-    console.log(formData);
 
     formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
 

--- a/src/components/LocationForm.tsx
+++ b/src/components/LocationForm.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import {
+  Input,
+  Label,
+  InputTypes,
+  HelperErrorText,
+} from "@nypl/design-system-react-components";
+
+interface LocationFormProps {
+  errorMessage: string;
+  // Currently not used but will be set in the future and that
+  // value will be the default.
+  ipLocation?: string;
+}
+
+interface LocationInput {
+  value: string;
+  label: string;
+  ref: (ref: HTMLInputElement) => void;
+}
+
+/**
+ * LocationForm
+ * Renders a radio button form to select a user location.
+ */
+const LocationForm = ({ errorMessage, ipLocation = "" }: LocationFormProps) => {
+  const [stateValue, setStateValue] = useState(ipLocation);
+  const { register, errors } = useFormContext();
+  const fieldName = "location";
+  const legendId = `radio-legend-${fieldName}`;
+  const errorText = errors?.location?.message;
+
+  const onChange = (e) => setStateValue(e.target?.value);
+  const locationInputs: LocationInput[] = [
+    {
+      value: "nyc",
+      label: "New York City (All five boroughs)",
+      ref: register(),
+    },
+    {
+      value: "nys",
+      label: "New York State (Outside NYC)",
+      ref: register(),
+    },
+    {
+      value: "us",
+      label: "United States (Visiting NYC)",
+      // For radio buttons or for grouped inputs, the validation ref config for
+      // react-hook-form goes in the last input element.
+      ref: register({
+        required: errorMessage,
+      }),
+    },
+  ];
+  const createInput = (value, label, ref) => {
+    const checked = value === stateValue;
+    const labelId = `radio-${fieldName}-${value}`;
+    const inputId = `${fieldName}-${value}`;
+    return (
+      <div key={value} className="radio-field">
+        <Input
+          className="radio-input"
+          aria-labelledby={`${legendId} ${labelId}`}
+          id={inputId}
+          type={InputTypes.radio}
+          attributes={{
+            name: fieldName,
+            "aria-checked": checked,
+            defaultChecked: checked,
+            onChange,
+          }}
+          value={value}
+          ref={ref}
+        />
+        <Label id={labelId} htmlFor={`input-${inputId}`}>
+          {label}
+        </Label>
+      </div>
+    );
+  };
+  const createRadioForm = (inputList: LocationInput[]) =>
+    inputList.map((input) => createInput(input.value, input.label, input.ref));
+
+  return (
+    <>
+      <p className="nypl-address-note">
+        If your address is outside the United States, please use our{" "}
+        <a href="https://catalog.nypl.org/selfreg/patonsite">alternate form</a>.
+      </p>
+      {errorText && (
+        <HelperErrorText isError={errorText}>{errorText}</HelperErrorText>
+      )}
+      <fieldset>
+        <legend id={legendId}>
+          I live, work, go to school, or pay property taxes at an address in:
+          <span className="required-field"> Required</span>
+        </legend>
+        {createRadioForm(locationInputs)}
+      </fieldset>
+    </>
+  );
+};
+
+export default LocationForm;

--- a/src/components/__tests__/LocationForm.test.tsx
+++ b/src/components/__tests__/LocationForm.test.tsx
@@ -34,7 +34,6 @@ describe("LocationForm", () => {
       wrapper: TestHookFormProvider,
     });
 
-    // const select = screen.getByRole("combobox");
     expect(screen.getByLabelText(nyc)).toBeInTheDocument();
     expect(screen.getByLabelText(nys)).toBeInTheDocument();
     expect(screen.getByLabelText(us)).toBeInTheDocument();

--- a/src/components/__tests__/LocationForm.test.tsx
+++ b/src/components/__tests__/LocationForm.test.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import "@testing-library/jest-dom/extend-expect";
+import LocationForm from "../LocationForm";
+import { TestHookFormProvider } from "../../../testHelper/utils";
+
+expect.extend(toHaveNoViolations);
+
+describe("LocationForm", () => {
+  const errorMessage = "Please select an address option.";
+  const nyc = "New York City (All five boroughs)";
+  const nys = "New York State (Outside NYC)";
+  const us = "United States (Visiting NYC)";
+
+  test("passes accessibility checks", async () => {
+    const { container } = render(<LocationForm errorMessage={errorMessage} />, {
+      wrapper: TestHookFormProvider,
+    });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test("renders an alternate form link", () => {
+    render(<LocationForm errorMessage={errorMessage} />, {
+      wrapper: TestHookFormProvider,
+    });
+
+    expect(screen.getByText("alternate form")).toBeInTheDocument();
+  });
+
+  test("renders three radio buttons", () => {
+    render(<LocationForm errorMessage={errorMessage} />, {
+      wrapper: TestHookFormProvider,
+    });
+
+    // const select = screen.getByRole("combobox");
+    expect(screen.getByLabelText(nyc)).toBeInTheDocument();
+    expect(screen.getByLabelText(nys)).toBeInTheDocument();
+    expect(screen.getByLabelText(us)).toBeInTheDocument();
+  });
+
+  test("updates the value selected", async () => {
+    render(<LocationForm errorMessage={errorMessage} />, {
+      wrapper: TestHookFormProvider,
+    });
+
+    let radio = screen.getByLabelText(nyc) as HTMLInputElement;
+
+    expect(radio.value).toBe("nyc");
+
+    await fireEvent.change(radio, { target: { value: "nys" } });
+    expect(radio.value).toBe("nys");
+
+    await fireEvent.change(radio, { target: { value: "us" } });
+    expect(radio.value).toBe("us");
+  });
+
+  test("renders an error message if there is one from react-hook-form", () => {
+    const reactHookFormErrors = {
+      location: {
+        message: errorMessage,
+      },
+    };
+    render(
+      <TestHookFormProvider errors={reactHookFormErrors}>
+        <LocationForm errorMessage={errorMessage} />
+      </TestHookFormProvider>
+    );
+
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+});

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -30,6 +30,33 @@ html {
   }
 }
 
+fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+
+  .radio-input {
+    width: auto;
+  }
+
+  .radio-field {
+    margin: 10px 0;
+    border: 1px solid var(--ui-gray-medium);
+    padding: 20px;
+
+    label {
+      display: inline-block;
+      margin: 0 20px;
+    }
+  }
+}
+
+.required-field {
+  color: var(--ui-error);
+  font-size: 0.9rem;
+  font-weight: 400;
+}
+
 .emailSubscription-wrapper {
   line-height: 1 !important;
 }


### PR DESCRIPTION
Resolves [DQ-353](https://jira.nypl.org/browse/DQ-353).

Structural update that breaks out the location radio button form section into its own component. I removed some of the classes from the Design Toolkit and added minor styling. This depends on [Design System #319](https://github.com/NYPL/nypl-design-system/pull/319) so a version bump will come soon once that's merged.

One thing, the list of input/label fields are not in a `ul` and `li` because the recommended practice is to use divs:
- https://a11y-style-guide.com/style-guide/section-forms.html#kssref-forms-radio-buttons
- https://designsystem.digital.gov/components/form-controls/#radio-buttons
- https://www.w3.org/WAI/tutorials/forms/grouping/