### PR TITLE
Address review page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4031,6 +4031,17 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "optional": true
     },
+    "array.prototype.map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.4"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -7072,6 +7083,32 @@
         "string.prototype.trimstart": "^1.0.1"
       }
     },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -9380,6 +9417,11 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -9521,6 +9563,11 @@
         "is-extglob": "^1.0.0"
       }
     },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+    },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -9627,6 +9674,11 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -9635,8 +9687,7 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-svg": {
       "version": "3.0.0",
@@ -9803,6 +9854,20 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "iterate-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+    },
+    "iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "requires": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
       }
     },
     "jest": {
@@ -16220,6 +16285,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "promise.allsettled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+      "requires": {
+        "array.prototype.map": "^1.0.1",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "iterate-value": "^1.0.0"
+      }
     },
     "prompts": {
       "version": "2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4031,17 +4031,6 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "optional": true
     },
-    "array.prototype.map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
-      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.4"
-      }
-    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -7083,32 +7072,6 @@
         "string.prototype.trimstart": "^1.0.1"
       }
     },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
-    },
-    "es-get-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
-      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
-      "requires": {
-        "es-abstract": "^1.17.4",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        }
-      }
-    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -9417,11 +9380,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -9563,11 +9521,6 @@
         "is-extglob": "^1.0.0"
       }
     },
-    "is-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
-    },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -9674,11 +9627,6 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
-    "is-set": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -9687,7 +9635,8 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -9854,20 +9803,6 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
-      }
-    },
-    "iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
-    },
-    "iterate-value": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-      "requires": {
-        "es-get-iterator": "^1.0.2",
-        "iterate-iterator": "^1.0.1"
       }
     },
     "jest": {
@@ -16285,18 +16220,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-    },
-    "promise.allsettled": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
-      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
-      "requires": {
-        "array.prototype.map": "^1.0.1",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "iterate-value": "^1.0.0"
-      }
     },
     "prompts": {
       "version": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "lodash": "4.17.15",
     "moment": "2.24.0",
     "next": "^9.4.4",
-    "promise.allsettled": "^1.0.2",
     "qs": "6.9.3",
     "react": "16.13.1",
     "react-autosuggest": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "lodash": "4.17.15",
     "moment": "2.24.0",
     "next": "^9.4.4",
+    "promise.allsettled": "^1.0.2",
     "qs": "6.9.3",
     "react": "16.13.1",
     "react-autosuggest": "^10.0.2",

--- a/pages/__tests__/library-card_address.test.tsx
+++ b/pages/__tests__/library-card_address.test.tsx
@@ -4,35 +4,246 @@ import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import AddressPage from "../library-card/address";
-import { FormDataContextProvider } from "../../src/context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../src/context/FormDataContext";
 import { TestHookFormProvider } from "../../testHelper/utils";
 
 expect.extend(toHaveNoViolations);
 
-describe("AddressPage", () => {
-  let container;
-  beforeEach(() => {
-    const utils = render(
-      <FormDataContextProvider>
+describe("AddressPage a11y test", () => {
+  test("passes axe", async () => {
+    const { container } = render(
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider>
           <AddressPage />
         </TestHookFormProvider>
       </FormDataContextProvider>
     );
 
-    container = utils.container;
-  });
-
-  test("passes axe", async () => {
     expect(await axe(container)).toHaveNoViolations();
   });
+});
 
+describe("AddressPage", () => {
   test("renders a title and decription", () => {
+    render(
+      <FormDataContextProvider initState={formInitialState}>
+        <TestHookFormProvider>
+          <AddressPage />
+        </TestHookFormProvider>
+      </FormDataContextProvider>
+    );
     expect(screen.getByText("Confirm your Address")).toBeInTheDocument();
+  });
+
+  test("renders a home address", async () => {
+    const initState = {
+      ...formInitialState,
+      addressResponse: {
+        home: {
+          cardType: "standard",
+          address: {
+            line1: "1234 61st",
+            city: "Woodside",
+            state: "NY",
+            zip: "11377",
+          },
+          addresses: undefined,
+          message: "",
+          reason: "",
+        },
+        work: {},
+      },
+    };
+    render(
+      <FormDataContextProvider initState={initState}>
+        <TestHookFormProvider>
+          <AddressPage />
+        </TestHookFormProvider>
+      </FormDataContextProvider>
+    );
+
+    expect(screen.getByText("Home Address")).toBeInTheDocument();
+    expect(screen.getByText("1234 61st")).toBeInTheDocument();
+    expect(screen.getByText("Woodside, NY")).toBeInTheDocument();
+    expect(screen.getByText("11377")).toBeInTheDocument();
+  });
+
+  test("renders multiple home addresses", async () => {
+    const initState = {
+      ...formInitialState,
+      addressResponse: {
+        home: {
+          cardType: "standard",
+          address: undefined,
+          addresses: [
+            {
+              line1: "1234 61st",
+              city: "Woodside",
+              state: "NY",
+              zip: "11377",
+            },
+            {
+              line1: "5678 61st",
+              city: "Woodside",
+              state: "NY",
+              zip: "11388",
+            },
+          ],
+          message: "",
+          reason: "",
+        },
+        work: {},
+      },
+    };
+    render(
+      <FormDataContextProvider initState={initState}>
+        <TestHookFormProvider>
+          <AddressPage />
+        </TestHookFormProvider>
+      </FormDataContextProvider>
+    );
+
+    expect(screen.getByText("Home Address")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We have found an alternate address for you. Please choose which is correct:"
+        "We have found alternate home addresses. Please choose the correct address:"
       )
     ).toBeInTheDocument();
+    expect(screen.getByText("1234 61st")).toBeInTheDocument();
+    expect(screen.getByText("Woodside, NY 11377")).toBeInTheDocument();
+
+    expect(screen.getByText("5678 61st")).toBeInTheDocument();
+    expect(screen.getByText("Woodside, NY 11388")).toBeInTheDocument();
+  });
+
+  test("renders an optional work address", async () => {
+    const initState = {
+      ...formInitialState,
+      addressResponse: {
+        home: {
+          cardType: "standard",
+          address: {
+            line1: "1234 61st",
+            city: "Woodside",
+            state: "NY",
+            zip: "11377",
+          },
+          addresses: undefined,
+          message: "",
+          reason: "",
+        },
+        work: {
+          cardType: "standard",
+          address: {
+            line1: "476 5th Ave",
+            city: "New York",
+            state: "NY",
+            zip: "10018",
+          },
+          addresses: undefined,
+          message: "",
+          reason: "",
+        },
+      },
+    };
+    render(
+      <FormDataContextProvider initState={initState}>
+        <TestHookFormProvider>
+          <AddressPage />
+        </TestHookFormProvider>
+      </FormDataContextProvider>
+    );
+
+    expect(screen.getByText("Home Address")).toBeInTheDocument();
+    expect(screen.getByText("1234 61st")).toBeInTheDocument();
+    expect(screen.getByText("Woodside, NY")).toBeInTheDocument();
+    expect(screen.getByText("11377")).toBeInTheDocument();
+
+    expect(screen.getByText("Work Address")).toBeInTheDocument();
+    expect(screen.getByText("476 5th Ave")).toBeInTheDocument();
+    expect(screen.getByText("New York, NY")).toBeInTheDocument();
+    expect(screen.getByText("10018")).toBeInTheDocument();
+  });
+
+  test("renders multiple optional work addresses", async () => {
+    const initState = {
+      ...formInitialState,
+      addressResponse: {
+        home: {
+          cardType: "standard",
+          address: undefined,
+          addresses: [
+            {
+              line1: "1234 61st",
+              city: "Woodside",
+              state: "NY",
+              zip: "11377",
+            },
+            {
+              line1: "5678 61st",
+              city: "Woodside",
+              state: "NY",
+              zip: "11388",
+            },
+          ],
+          message: "",
+          reason: "",
+        },
+        work: {
+          cardType: "standard",
+          address: undefined,
+          addresses: [
+            {
+              line1: "476 5th Ave",
+              city: "New York",
+              state: "NY",
+              zip: "10018",
+            },
+            {
+              line1: "1111 1st Ave",
+              city: "New York",
+              state: "NY",
+              zip: "10001",
+            },
+          ],
+          message: "",
+          reason: "",
+        },
+      },
+    };
+    render(
+      <FormDataContextProvider initState={initState}>
+        <TestHookFormProvider>
+          <AddressPage />
+        </TestHookFormProvider>
+      </FormDataContextProvider>
+    );
+
+    expect(screen.getByText("Home Address")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "We have found alternate home addresses. Please choose the correct address:"
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("1234 61st")).toBeInTheDocument();
+    expect(screen.getByText("Woodside, NY 11377")).toBeInTheDocument();
+
+    expect(screen.getByText("5678 61st")).toBeInTheDocument();
+    expect(screen.getByText("Woodside, NY 11388")).toBeInTheDocument();
+
+    expect(screen.getByText("Work Address")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "We have found alternate work addresses. Please choose the correct address:"
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("476 5th Ave")).toBeInTheDocument();
+    expect(screen.getByText("New York, NY 10018")).toBeInTheDocument();
+
+    expect(screen.getByText("1111 1st Ave")).toBeInTheDocument();
+    expect(screen.getByText("New York, NY 10001")).toBeInTheDocument();
   });
 });

--- a/pages/__tests__/library-card_review.test.tsx
+++ b/pages/__tests__/library-card_review.test.tsx
@@ -4,7 +4,10 @@ import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import ReviewPage from "../library-card/review";
-import { FormDataContextProvider } from "../../src/context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../src/context/FormDataContext";
 import { TestHookFormProvider } from "../../testHelper/utils";
 
 expect.extend(toHaveNoViolations);
@@ -13,7 +16,7 @@ describe("ReviewPage", () => {
   let container;
   beforeEach(() => {
     const utils = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider>
           <ReviewPage />
         </TestHookFormProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,10 @@ import "@nypl/design-system-react-components/dist/styles.css";
 import { config, gaUtils } from "dgx-react-ga";
 import Head from "next/head";
 import { useForm, FormProvider } from "react-hook-form";
-import { FormDataContextProvider } from "../src/context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../src/context/FormDataContext";
 import "../src/styles/main.scss";
 import appConfig from "../appConfig";
 import { FormInputData } from "../src/interfaces";
@@ -107,7 +110,7 @@ export default function MyApp<MyAppProps>({ Component, pageProps }) {
         <meta name="csrf-token" content={csrfToken} />
       </Head>
       <FormProvider {...formMethods}>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <ApplicationContainer>
             <Component {...pageProps} />
           </ApplicationContainer>

--- a/pages/api/address.ts
+++ b/pages/api/address.ts
@@ -1,24 +1,24 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import {
   initializeAppAuth,
-  validateUsername,
+  validateAddress,
   runMiddleware,
   cors,
 } from "../../src/utils/api";
 
 /**
- * username
+ * address
  * @param req - Next request object
  * @param res - Next response object
  */
-async function username(req: NextApiRequest, res: NextApiResponse) {
+async function address(req: NextApiRequest, res: NextApiResponse) {
   // Run the request through the middleware.
   await runMiddleware(req, res, cors);
   // Initialize the authentication for the app.
   // TODO: set a better path for using an CSRF token.
   await initializeAppAuth(req, res);
-  // Now, we can call the NYPL Platform API to validate the patron's username.
-  await validateUsername(req, res);
+  // Now, we can call the NYPL Platform API to validate the patron's address.
+  await validateAddress(req, res);
 }
 
-export default username;
+export default address;

--- a/pages/library-card/address/index.tsx
+++ b/pages/library-card/address/index.tsx
@@ -3,19 +3,6 @@ import { useRouter } from "next/router";
 import useFormDataContext from "../../../src/context/FormDataContext";
 import { useFormContext } from "react-hook-form";
 
-const addressKeys = [
-  "home-line1",
-  "home-line2",
-  "home-city",
-  "home-state",
-  "home-zip",
-  "work-line1",
-  "work-line2",
-  "work-city",
-  "work-state",
-  "work-zip",
-];
-
 /**
  * AddressPage
  * Main page component for the "address review" page.
@@ -23,9 +10,12 @@ const addressKeys = [
 function AddressPage() {
   const { handleSubmit } = useFormContext();
   const { state, dispatch } = useFormDataContext();
-  const { formValues } = state;
+  const { formValues, addressResponse } = state;
   const router = useRouter();
 
+  console.log("addressResponse", addressResponse);
+  const homeAddress = addressResponse?.home;
+  const workAddress = addressResponse?.work;
   const submitForm = (formData) => {
     // Merge any updates, specifically to the address value, and continue to
     // the next page. For now, it's only setting up the dispatch.
@@ -42,21 +32,73 @@ function AddressPage() {
       <div className="nypl-column-half nypl-column-offset-one">
         <h2>Confirm your Address</h2>
         <form onSubmit={handleSubmit(submitForm)}>
-          <h3>
-            We have found an alternate address for you. Please choose which is
-            correct:
-          </h3>
-          {/* Just dummy HTML to render all the values. Eventually we'll
-          just need the address data to display any updates. */}
-          <ul>
-            {addressKeys.map((k) => (
-              <li key={k}>
-                {k}: {formValues[k]}
-              </li>
-            ))}
-          </ul>
+          <h3>Home Address</h3>
+          {homeAddress?.addresses ? (
+            <>
+              <p>
+                We have found an alternate address for you. Please choose which
+                is correct:
+              </p>
+              <ul>
+                {homeAddress.addresses.map((address, idx) => (
+                  <li key={idx}>
+                    {address["line1"]}
+                    {address["line2"]}
+                    <br />
+                    {address["city"]}, {address["state"]} {address["zip"]}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <>
+              {homeAddress.address["line1"]}
+              {homeAddress.address["line2"]}
+              <br />
+              {homeAddress.address["city"]}, {homeAddress.address["state"]}{" "}
+              {homeAddress.address["zip"]}
+            </>
+          )}
 
-          <input className="nypl-request-button" type="submit" value="Review" />
+          {(workAddress?.addresses || workAddress?.address) && (
+            <h3>Work Address</h3>
+          )}
+          {workAddress?.addresses ? (
+            <>
+              <p>
+                We have found an alternate address for you. Please choose which
+                is correct:
+              </p>
+              <ul>
+                {workAddress.addresses.map((address, idx) => (
+                  <li key={idx}>
+                    {address["line1"]}
+                    {address["line2"]}
+                    <br />
+                    {address["city"]}, {address["state"]} {address["zip"]}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            workAddress?.address && (
+              <>
+                {workAddress.address["line1"]}
+                {workAddress.address["line2"]}
+                <br />
+                {workAddress.address["city"]}, {workAddress.address["state"]}{" "}
+                {workAddress.address["zip"]}
+              </>
+            )
+          )}
+
+          <div>
+            <input
+              className="nypl-request-button"
+              type="submit"
+              value="Review"
+            />
+          </div>
         </form>
       </div>
     </div>

--- a/pages/library-card/address/index.tsx
+++ b/pages/library-card/address/index.tsx
@@ -13,7 +13,6 @@ function AddressPage() {
   const { formValues, addressResponse } = state;
   const router = useRouter();
 
-  console.log("addressResponse", addressResponse);
   const homeAddress = addressResponse?.home;
   const workAddress = addressResponse?.work;
   const submitForm = (formData) => {
@@ -33,61 +32,74 @@ function AddressPage() {
         <h2>Confirm your Address</h2>
         <form onSubmit={handleSubmit(submitForm)}>
           <h3>Home Address</h3>
-          {homeAddress?.addresses ? (
+          {homeAddress?.addresses && (
             <>
               <p>
-                We have found an alternate address for you. Please choose which
-                is correct:
+                We have found alternate home addresses. Please choose the
+                correct address:
               </p>
               <ul>
                 {homeAddress.addresses.map((address, idx) => (
                   <li key={idx}>
-                    {address["line1"]}
-                    {address["line2"]}
+                    <span>
+                      {address.line1} {address.line2}
+                    </span>
                     <br />
-                    {address["city"]}, {address["state"]} {address["zip"]}
+                    <span>
+                      {address.city}, {address.state} {address.zip}
+                    </span>
                   </li>
                 ))}
               </ul>
             </>
-          ) : (
+          )}
+          {homeAddress?.address?.line1 && (
             <>
-              {homeAddress.address["line1"]}
-              {homeAddress.address["line2"]}
+              <span>
+                {homeAddress.address.line1} {homeAddress.address.line2}
+              </span>
               <br />
-              {homeAddress.address["city"]}, {homeAddress.address["state"]}{" "}
-              {homeAddress.address["zip"]}
+              <span>
+                {homeAddress.address.city}, {homeAddress.address.state}
+              </span>{" "}
+              <span>{homeAddress.address.zip}</span>
             </>
           )}
 
           {(workAddress?.addresses || workAddress?.address) && (
             <h3>Work Address</h3>
           )}
-          {workAddress?.addresses ? (
+          {workAddress?.addresses?.length > 0 ? (
             <>
               <p>
-                We have found an alternate address for you. Please choose which
-                is correct:
+                We have found alternate work addresses. Please choose the
+                correct address:
               </p>
               <ul>
                 {workAddress.addresses.map((address, idx) => (
                   <li key={idx}>
-                    {address["line1"]}
-                    {address["line2"]}
+                    <span>
+                      {address.line1} {address.line2}
+                    </span>
                     <br />
-                    {address["city"]}, {address["state"]} {address["zip"]}
+                    <span>
+                      {address.city}, {address.state} {address.zip}
+                    </span>
                   </li>
                 ))}
               </ul>
             </>
           ) : (
-            workAddress?.address && (
+            workAddress?.address?.line1 && (
               <>
-                {workAddress.address["line1"]}
-                {workAddress.address["line2"]}
+                <span>
+                  {workAddress.address.line1} {workAddress.address.line2}
+                </span>
                 <br />
-                {workAddress.address["city"]}, {workAddress.address["state"]}{" "}
-                {workAddress.address["zip"]}
+                <span>
+                  {workAddress.address.city}, {workAddress.address.state}
+                </span>{" "}
+                <span>{workAddress.address.zip}</span>
               </>
             )
           )}

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -17,6 +17,7 @@ import PersonalInformationForm from "./PersonalInformationForm";
 import AccountForm from "./AccountForm";
 import AcceptTermsForm from "./AcceptTermsForm";
 import { errorMessages } from "../utils/formDataUtils";
+import { AddressRenderType, AddressResponse } from "../interfaces";
 
 const LibraryCardForm = () => {
   const { state, dispatch } = useFormDataContext();
@@ -62,52 +63,26 @@ const LibraryCardForm = () => {
     axios
       .post("/api/address", { formData })
       .then((response) => {
-        console.log("then response", response);
-        const home = response.data?.home;
-        const work = response.data?.work;
+        const home: AddressRenderType = response.data?.home;
+        const work: AddressRenderType = response.data?.work;
         // Update the global address state values with ...
         dispatch({
           type: "SET_ADDRESSES_VALUE",
-          value: {
-            home: {
-              cardType: home.cardType,
-              address: home.address,
-              addresses: home.addresses,
-              message: home.message,
-              reason: home.reason,
-            },
-            work: {
-              cardType: work.cardType,
-              address: work.address,
-              addresses: work.addresses,
-              message: work.message,
-              reason: work.reason,
-            },
-          },
+          value: { home, work } as AddressResponse,
         });
       })
       .catch((error) => {
-        let value = { home: {}, work: {} };
-        console.log("catch error", error.response?.data);
-        const home = error.response?.data?.home;
-        const work = error.response?.data?.work;
+        let value: AddressResponse = {
+          home: {} as AddressRenderType,
+          work: {} as AddressRenderType,
+        };
+        const home: AddressRenderType = error.response?.data?.home;
+        const work: AddressRenderType = error.response?.data?.work;
         if (error.response?.data?.home) {
-          value.home = {
-            cardType: home.cardType,
-            address: home.address,
-            addresses: home.addresses,
-            message: home.message,
-            reason: home.reason,
-          };
+          value.home = home;
         }
         if (error.response?.data?.work) {
-          value.work = {
-            cardType: work.cardType,
-            address: work.address,
-            addresses: work.addresses,
-            message: work.message,
-            reason: work.reason,
-          };
+          value.work = work;
         }
         dispatch({
           type: "SET_ADDRESSES_VALUE",

--- a/src/components/__tests__/AcceptTermsForm.test.tsx
+++ b/src/components/__tests__/AcceptTermsForm.test.tsx
@@ -5,7 +5,10 @@ import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import { TestHookFormProvider } from "../../../testHelper/utils";
 import AcceptTermsForm from "../AcceptTermsForm";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -13,7 +16,7 @@ describe("AcceptTermsForm", () => {
   beforeEach(() => {
     render(
       <TestHookFormProvider>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <AcceptTermsForm />
         </FormDataContextProvider>
       </TestHookFormProvider>
@@ -52,7 +55,7 @@ describe("Accessibility check", () => {
   test("passes axe", async () => {
     const { container } = render(
       <TestHookFormProvider>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <AcceptTermsForm />
         </FormDataContextProvider>
       </TestHookFormProvider>

--- a/src/components/__tests__/AccountForm.test.tsx
+++ b/src/components/__tests__/AccountForm.test.tsx
@@ -5,7 +5,10 @@ import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import { TestHookFormProvider } from "../../../testHelper/utils";
 import AccountForm from "../AccountForm";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -13,7 +16,7 @@ describe("AccountForm", () => {
   beforeEach(() => {
     render(
       <TestHookFormProvider>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <AccountForm />
         </FormDataContextProvider>
       </TestHookFormProvider>
@@ -37,7 +40,7 @@ describe("AccountForm Accessibility check", () => {
   test("passes axe", async () => {
     const { container } = render(
       <TestHookFormProvider>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <AccountForm />
         </FormDataContextProvider>
       </TestHookFormProvider>

--- a/src/components/__tests__/AddressForm.test.tsx
+++ b/src/components/__tests__/AddressForm.test.tsx
@@ -5,7 +5,10 @@ import "@testing-library/jest-dom/extend-expect";
 import AddressForm, { AddressTypes } from "../AddressForm";
 import { TestHookFormProvider } from "../../../testHelper/utils";
 import { Address } from "../../interfaces";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -34,7 +37,7 @@ const reactHookFormErrors = {
 describe("AddressForm", () => {
   test("it passes accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AddressForm
           type={AddressTypes.Home}
           errorMessages={addressErrorMessages}
@@ -49,7 +52,7 @@ describe("AddressForm", () => {
 
   test("it passess accessibilty checks with error messages", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider errors={reactHookFormErrors}>
           <AddressForm
             type={AddressTypes.Home}
@@ -64,7 +67,7 @@ describe("AddressForm", () => {
 
   test("it should render five fields", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AddressForm
           type={AddressTypes.Home}
           errorMessages={addressErrorMessages}
@@ -96,7 +99,7 @@ describe("AddressForm", () => {
 
   test("it should render five optional fields for the work address", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AddressForm
           type={AddressTypes.Work}
           errorMessages={addressErrorMessages}
@@ -124,7 +127,7 @@ describe("AddressForm", () => {
 
   test("it should render any error messages for required fields", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider errors={reactHookFormErrors}>
           <AddressForm
             type={AddressTypes.Home}

--- a/src/components/__tests__/AgeForm.test.tsx
+++ b/src/components/__tests__/AgeForm.test.tsx
@@ -4,7 +4,10 @@ import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import AgeForm from "../AgeForm";
 import { TestHookFormProvider } from "../../../testHelper/utils";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -26,7 +29,7 @@ const reactHookFormErrors = {
 describe("AgeForm", () => {
   test("it passes accessibility checks for the field input", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AgeForm errorMessages={noHookFormErrors} />
       </FormDataContextProvider>,
       {
@@ -38,7 +41,7 @@ describe("AgeForm", () => {
 
   test("it passes accessibility checks for the checkbox input", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AgeForm policyType="simplye" errorMessages={noHookFormErrors} />
       </FormDataContextProvider>,
       {
@@ -50,7 +53,7 @@ describe("AgeForm", () => {
 
   test("it renders an input field with the default webApplicant policyType", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AgeForm errorMessages={noHookFormErrors} />
       </FormDataContextProvider>,
       {
@@ -73,7 +76,7 @@ describe("AgeForm", () => {
 
   test("it renders a checkbox with the simplye policyType", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AgeForm policyType="simplye" errorMessages={noHookFormErrors} />
       </FormDataContextProvider>,
       {
@@ -96,7 +99,7 @@ describe("AgeForm", () => {
 
   test("updates the age gate checkbox", async () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <AgeForm policyType="simplye" errorMessages={noHookFormErrors} />
       </FormDataContextProvider>,
       {
@@ -114,7 +117,7 @@ describe("AgeForm", () => {
 
   test("it should render a webApplicant error message", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider errors={reactHookFormErrors}>
           <AgeForm errorMessages={ageFormErrorMessages} />
         </TestHookFormProvider>
@@ -127,7 +130,7 @@ describe("AgeForm", () => {
 
   test("it should render a simplye error message", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider errors={reactHookFormErrors}>
           <AgeForm policyType="simplye" errorMessages={ageFormErrorMessages} />
         </TestHookFormProvider>

--- a/src/components/__tests__/LibraryListForm.test.tsx
+++ b/src/components/__tests__/LibraryListForm.test.tsx
@@ -5,7 +5,10 @@ import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import LibraryListForm, { LibraryListObject } from "../LibraryListForm";
 import { TestHookFormProvider } from "../../../testHelper/utils";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -18,7 +21,7 @@ const libraryList: LibraryListObject[] = [
 describe("LibraryListForm", () => {
   test("passes accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LibraryListForm libraryList={libraryList} />
       </FormDataContextProvider>,
       {
@@ -30,7 +33,7 @@ describe("LibraryListForm", () => {
 
   test("renders a label, input, and description", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LibraryListForm libraryList={libraryList} />
       </FormDataContextProvider>,
       {
@@ -50,7 +53,7 @@ describe("LibraryListForm", () => {
 
   test("it updates the selected value from the dropdown", async () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LibraryListForm libraryList={libraryList} />
       </FormDataContextProvider>,
       {
@@ -87,7 +90,7 @@ describe("LibraryListForm", () => {
 
   test("it shows the suggestions", async () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LibraryListForm libraryList={libraryList} />
       </FormDataContextProvider>,
       {

--- a/src/components/__tests__/LocationForm.test.tsx
+++ b/src/components/__tests__/LocationForm.test.tsx
@@ -5,7 +5,10 @@ import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import LocationForm from "../LocationForm";
 import { TestHookFormProvider } from "../../../testHelper/utils";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -17,7 +20,7 @@ describe("LocationForm", () => {
 
   test("passes accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LocationForm errorMessage={errorMessage} />
       </FormDataContextProvider>,
       {
@@ -29,7 +32,7 @@ describe("LocationForm", () => {
 
   test("renders an alternate form link", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LocationForm errorMessage={errorMessage} />
       </FormDataContextProvider>,
       {
@@ -42,7 +45,7 @@ describe("LocationForm", () => {
 
   test("renders three radio buttons", () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LocationForm errorMessage={errorMessage} />
       </FormDataContextProvider>,
       {
@@ -57,7 +60,7 @@ describe("LocationForm", () => {
 
   test("updates the value selected", async () => {
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <LocationForm errorMessage={errorMessage} />
       </FormDataContextProvider>,
       {
@@ -83,7 +86,7 @@ describe("LocationForm", () => {
       },
     };
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider errors={reactHookFormErrors}>
           <LocationForm errorMessage={errorMessage} />
         </TestHookFormProvider>

--- a/src/components/__tests__/PersonalInformationForm.test.tsx
+++ b/src/components/__tests__/PersonalInformationForm.test.tsx
@@ -5,7 +5,10 @@ import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import { TestHookFormProvider } from "../../../testHelper/utils";
 import PersonalInformationForm from "../PersonalInformationForm";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -13,7 +16,7 @@ describe("PersonalInformationForm", () => {
   beforeEach(() => {
     render(
       <TestHookFormProvider>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <PersonalInformationForm />
         </FormDataContextProvider>
       </TestHookFormProvider>
@@ -43,7 +46,7 @@ describe("Accessibility check", () => {
   test("passes axe", async () => {
     const { container } = render(
       <TestHookFormProvider>
-        <FormDataContextProvider>
+        <FormDataContextProvider initState={formInitialState}>
           <PersonalInformationForm />
         </FormDataContextProvider>
       </TestHookFormProvider>

--- a/src/components/__tests__/UsernameValidationForm.test.tsx
+++ b/src/components/__tests__/UsernameValidationForm.test.tsx
@@ -11,7 +11,10 @@ expect.extend(toHaveNoViolations);
 jest.mock("axios");
 
 import UsernameValidationForm from "../UsernameValidationForm";
-import { FormDataContextProvider } from "../../context/FormDataContext";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../../context/FormDataContext";
 
 describe("UsernameValidationForm", () => {
   beforeEach(() => {
@@ -20,7 +23,7 @@ describe("UsernameValidationForm", () => {
 
   test("passes accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <UsernameValidationForm />
       </FormDataContextProvider>,
       {
@@ -33,7 +36,7 @@ describe("UsernameValidationForm", () => {
 
   test("renders the basic label, input, and helper text elements", async () => {
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <UsernameValidationForm />
       </FormDataContextProvider>,
       {
@@ -73,7 +76,7 @@ describe("UsernameValidationForm", () => {
     const mockWatch = jest.fn().mockReturnValue(true);
     let mockGetValues = jest.fn().mockReturnValue(tooShort);
     const { rerender } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider getValues={mockGetValues} watch={mockWatch}>
           <UsernameValidationForm />
         </TestHookFormProvider>
@@ -88,7 +91,7 @@ describe("UsernameValidationForm", () => {
     // Now let's mock another invalid value.
     mockGetValues = jest.fn().mockReturnValue(invalid);
     rerender(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider getValues={mockGetValues} watch={mockWatch}>
           <UsernameValidationForm />
         </TestHookFormProvider>
@@ -102,7 +105,7 @@ describe("UsernameValidationForm", () => {
     // Mock a valid value.
     mockGetValues = jest.fn().mockReturnValue(justRight);
     rerender(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider getValues={mockGetValues} watch={mockWatch}>
           <UsernameValidationForm />
         </TestHookFormProvider>
@@ -124,7 +127,7 @@ describe("UsernameValidationForm", () => {
     const mockGetValues = jest.fn().mockReturnValue("notAvailableUsername");
 
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider watch={mockWatch} getValues={mockGetValues}>
           <UsernameValidationForm />
         </TestHookFormProvider>
@@ -166,7 +169,7 @@ describe("UsernameValidationForm", () => {
     const mockGetValues = jest.fn().mockReturnValue("availableUsername");
 
     const { container } = render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider watch={mockWatch} getValues={mockGetValues}>
           <UsernameValidationForm />
         </TestHookFormProvider>
@@ -214,7 +217,7 @@ describe("UsernameValidationForm", () => {
     // the `errors` object that react-hook-form returns so we are both, setting
     // it up and returning it.
     render(
-      <FormDataContextProvider>
+      <FormDataContextProvider initState={formInitialState}>
         <TestHookFormProvider errors={errors} getValues={mockGetValues}>
           <UsernameValidationForm />
         </TestHookFormProvider>

--- a/src/context/FormDataContext.tsx
+++ b/src/context/FormDataContext.tsx
@@ -1,6 +1,12 @@
-import React, { useReducer } from "react";
+import React, { useReducer, PropsWithChildren } from "react";
 import { formReducer } from "../reducers";
-import { FormDataContextType, FormData, FormInputData } from "../interfaces";
+import {
+  FormDataContextType,
+  FormData,
+  FormInputData,
+  AddressRenderType,
+  AddressResponse,
+} from "../interfaces";
 
 // Default initial values.
 export const formInitialState: FormData = {
@@ -11,17 +17,27 @@ export const formInitialState: FormData = {
     ecommunicationsPref: true,
     policyType: "webApplicant",
   } as FormInputData,
+  addressResponse: {
+    home: {} as AddressRenderType,
+    work: {} as AddressRenderType,
+  } as AddressResponse,
 };
+
+interface FormDataType {
+  initState: FormData;
+}
 
 const FormDataContext = React.createContext<FormDataContextType | undefined>(
   undefined
 );
 
-export const FormDataContextProvider: React.FC = ({ children }) => {
+export const FormDataContextProvider: React.FC<PropsWithChildren<
+  FormDataType
+>> = ({ initState, children }) => {
   // Keep track of the API results and errors from a form submission as global
   // data in the app. It is exposed to the pages through context. Use
   // the `dispatch` function to update the state properties.
-  const [state, dispatch] = useReducer(formReducer, formInitialState);
+  const [state, dispatch] = useReducer(formReducer, initState);
   return (
     <FormDataContext.Provider value={{ state, dispatch }}>
       {children}

--- a/src/context/__tests__/FormDataContext.test.tsx
+++ b/src/context/__tests__/FormDataContext.test.tsx
@@ -13,9 +13,12 @@ const initState: FormData = {
     ecommunicationsPref: true,
     policyType: "webApplicant",
   } as FormInputData,
+  addressResponse: {},
 };
 const contextWrapper = () => ({ children }) => (
-  <FormDataContextProvider>{children}</FormDataContextProvider>
+  <FormDataContextProvider initState={initState}>
+    {children}
+  </FormDataContextProvider>
 );
 
 describe("ParamsContext", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,6 +51,43 @@ export interface Address {
   city: string;
   state: string;
   zip: string;
+  isResidential?: boolean;
+  hasBeenValidated?: boolean;
+}
+
+export interface Addresses {
+  home: Address;
+  work?: Address;
+}
+
+export interface AddressRequestData {
+  address: Address;
+  isWorkAddress: boolean;
+}
+
+export interface AddressAPIResponseData {
+  status: string;
+  success: boolean;
+  isWorkAddress: boolean;
+  cardType: null | string;
+  address?: Address;
+  originalAddress?: Address;
+  addresses?: Address[];
+  message?: string;
+  reason?: string;
+}
+
+export interface AddressRenderType {
+  address: Address | undefined;
+  addresses: Address[] | undefined;
+  message: string;
+  reason: string;
+  cardType?: null | string;
+}
+
+export interface AddressResponse {
+  home: AddressRenderType;
+  work: AddressRenderType;
 }
 
 export interface Params {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -80,6 +80,7 @@ export interface FormData {
   errorObj: {};
   csrfToken: string;
   formValues: FormInputData;
+  addressResponse: any;
 }
 
 export interface FormDataContextType {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -24,6 +24,12 @@ export function formReducer(state, action) {
         results: action.value,
       };
     }
+    case "SET_ADDRESSES_VALUE": {
+      return {
+        ...state,
+        addressResponse: action.value,
+      };
+    }
     default: {
       return state;
     }

--- a/src/utils/__tests__/api.test.ts
+++ b/src/utils/__tests__/api.test.ts
@@ -1,8 +1,9 @@
-import { constructAddresses, AddressesType } from "../api";
+import { constructAddresses } from "../api";
+import { Addresses } from "../../interfaces";
 
 describe("constructAddresses", () => {
   test("it returns an empty AddressType object with no input", () => {
-    const empty: AddressesType = constructAddresses();
+    const empty: Addresses = constructAddresses();
 
     expect(empty).toStrictEqual({ home: {}, work: {} });
   });
@@ -15,7 +16,7 @@ describe("constructAddresses", () => {
       "home-state": "NY",
       "home-zip": "11377",
     };
-    const addresses: AddressesType = constructAddresses(formData);
+    const addresses: Addresses = constructAddresses(formData);
 
     expect(addresses.home).toEqual({
       line1: "3747 61st St",
@@ -34,7 +35,7 @@ describe("constructAddresses", () => {
       "work-state": "NY",
       "work-zip": "10018",
     };
-    const addresses: AddressesType = constructAddresses(formData);
+    const addresses: Addresses = constructAddresses(formData);
 
     expect(addresses.work).toEqual({
       line1: "476 5th Avenue",
@@ -58,7 +59,7 @@ describe("constructAddresses", () => {
       "work-state": "NY",
       "work-zip": "10018",
     };
-    const addresses: AddressesType = constructAddresses(formData);
+    const addresses: Addresses = constructAddresses(formData);
 
     expect(addresses).toEqual({
       home: {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -5,15 +5,10 @@ import moment from "moment";
 import isEmpty from "lodash/isEmpty";
 import { isEmail, isAlphanumeric, isNumeric, isLength } from "validator";
 import Cors from "cors";
-import allSettled from "promise.allsettled";
 
 import config from "../../appConfig";
 import logger from "../logger/index";
 import { Address } from "../interfaces";
-import { homedir } from "os";
-import { isWorker } from "cluster";
-
-allSettled.shim();
 
 // Initializing the cors middleware
 export const cors = Cors({


### PR DESCRIPTION
Resolves [DQ-356](https://jira.nypl.org/browse/DQ-356). This is one part of the whole page which is calling the `/validations/address` endpoint to validate a home address and an optional work address and render it on the address review page (also, no designs for this page yet).

When presented with multiple addresses (if a vague one is entered), the user will have the option to select the correct one but that's another ticket (https://jira.nypl.org/browse/DQ-366). I didn't want this to get too big for the review.

After the first page of entering values, when the form is submitted the second page is the "address review" page (work address is optional):
<img width="349" alt="Screen Shot 2020-08-20 at 2 42 57 PM" src="https://user-images.githubusercontent.com/1280564/90813050-052e3280-e2f5-11ea-89ef-49b113b2df32.png">

If either the home or work address is considered to be ambiguous by Service Objects, multiple addresses will be returned:
<img width="617" alt="Screen Shot 2020-08-20 at 2 44 23 PM" src="https://user-images.githubusercontent.com/1280564/90813175-31e24a00-e2f5-11ea-90da-d8deb288c0ea.png">

I found the address "37 61st New York, NY 10018" to be ambiguous enough for testing. 
That's all for the address review page, for now, but the bulk of the work is creating the API function to make one or two API calls, merge the resolved or rejected data, and return it.

It's possible that either the home address or the work address return an error. If that happens, we don't want to throw an error from the API but rather resolve everything and throw our own error. For now, the returned result data is merged together and rendered on the page.