### PR TITLE
Adding a provider wrapper component to make tests cleaner.

### DIFF
--- a/pages/__tests__/library-card_address.test.tsx
+++ b/pages/__tests__/library-card_address.test.tsx
@@ -4,22 +4,17 @@ import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import AddressPage from "../library-card/address";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../src/context/FormDataContext";
-import { TestHookFormProvider } from "../../testHelper/utils";
+import { TestProviderWrapper } from "../../testHelper/utils";
+import { formInitialState } from "../../src/context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
-describe("AddressPage a11y test", () => {
-  test("passes axe", async () => {
+describe("AddressPage accessibility", () => {
+  test("passes axe accessibility test", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider>
-          <AddressPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper>
+        <AddressPage />
+      </TestProviderWrapper>
     );
 
     expect(await axe(container)).toHaveNoViolations();
@@ -29,11 +24,9 @@ describe("AddressPage a11y test", () => {
 describe("AddressPage", () => {
   test("renders a title and decription", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider>
-          <AddressPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper>
+        <AddressPage />
+      </TestProviderWrapper>
     );
     expect(screen.getByText("Confirm your Address")).toBeInTheDocument();
   });
@@ -58,11 +51,9 @@ describe("AddressPage", () => {
       },
     };
     render(
-      <FormDataContextProvider initState={initState}>
-        <TestHookFormProvider>
-          <AddressPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper formDataState={initState}>
+        <AddressPage />
+      </TestProviderWrapper>
     );
 
     expect(screen.getByText("Home Address")).toBeInTheDocument();
@@ -99,11 +90,9 @@ describe("AddressPage", () => {
       },
     };
     render(
-      <FormDataContextProvider initState={initState}>
-        <TestHookFormProvider>
-          <AddressPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper formDataState={initState}>
+        <AddressPage />
+      </TestProviderWrapper>
     );
 
     expect(screen.getByText("Home Address")).toBeInTheDocument();
@@ -150,11 +139,9 @@ describe("AddressPage", () => {
       },
     };
     render(
-      <FormDataContextProvider initState={initState}>
-        <TestHookFormProvider>
-          <AddressPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper formDataState={initState}>
+        <AddressPage />
+      </TestProviderWrapper>
     );
 
     expect(screen.getByText("Home Address")).toBeInTheDocument();
@@ -215,11 +202,9 @@ describe("AddressPage", () => {
       },
     };
     render(
-      <FormDataContextProvider initState={initState}>
-        <TestHookFormProvider>
-          <AddressPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper formDataState={initState}>
+        <AddressPage />
+      </TestProviderWrapper>
     );
 
     expect(screen.getByText("Home Address")).toBeInTheDocument();

--- a/pages/__tests__/library-card_review.test.tsx
+++ b/pages/__tests__/library-card_review.test.tsx
@@ -4,11 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import ReviewPage from "../library-card/review";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../src/context/FormDataContext";
-import { TestHookFormProvider } from "../../testHelper/utils";
+import { TestProviderWrapper } from "../../testHelper/utils";
 
 expect.extend(toHaveNoViolations);
 
@@ -16,17 +12,15 @@ describe("ReviewPage", () => {
   let container;
   beforeEach(() => {
     const utils = render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider>
-          <ReviewPage />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper>
+        <ReviewPage />
+      </TestProviderWrapper>
     );
 
     container = utils.container;
   });
 
-  test("passes axe", async () => {
+  test("passes axe accessibility test", async () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,10 +3,7 @@ import "@nypl/design-system-react-components/dist/styles.css";
 import { config, gaUtils } from "dgx-react-ga";
 import Head from "next/head";
 import { useForm, FormProvider } from "react-hook-form";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../src/context/FormDataContext";
+import { FormDataContextProvider } from "../src/context/FormDataContext";
 import "../src/styles/main.scss";
 import appConfig from "../appConfig";
 import { FormInputData } from "../src/interfaces";
@@ -110,7 +107,7 @@ export default function MyApp<MyAppProps>({ Component, pageProps }) {
         <meta name="csrf-token" content={csrfToken} />
       </Head>
       <FormProvider {...formMethods}>
-        <FormDataContextProvider initState={formInitialState}>
+        <FormDataContextProvider>
           <ApplicationContainer>
             <Component {...pageProps} />
           </ApplicationContainer>

--- a/src/components/__tests__/AcceptTermsForm.test.tsx
+++ b/src/components/__tests__/AcceptTermsForm.test.tsx
@@ -3,23 +3,17 @@ import React from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
-import { TestHookFormProvider } from "../../../testHelper/utils";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 import AcceptTermsForm from "../AcceptTermsForm";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
 describe("AcceptTermsForm", () => {
   beforeEach(() => {
     render(
-      <TestHookFormProvider>
-        <FormDataContextProvider initState={formInitialState}>
-          <AcceptTermsForm />
-        </FormDataContextProvider>
-      </TestHookFormProvider>
+      <TestProviderWrapper>
+        <AcceptTermsForm />
+      </TestProviderWrapper>
     );
   });
 
@@ -51,14 +45,12 @@ describe("AcceptTermsForm", () => {
   });
 });
 
-describe("Accessibility check", () => {
-  test("passes axe", async () => {
+describe("AcceptTermsForm accessibility check", () => {
+  test("passes axe accessibility test", async () => {
     const { container } = render(
-      <TestHookFormProvider>
-        <FormDataContextProvider initState={formInitialState}>
-          <AcceptTermsForm />
-        </FormDataContextProvider>
-      </TestHookFormProvider>
+      <TestProviderWrapper>
+        <AcceptTermsForm />
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/src/components/__tests__/AccountForm.test.tsx
+++ b/src/components/__tests__/AccountForm.test.tsx
@@ -1,25 +1,19 @@
 /* eslint-disable */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
-import { TestHookFormProvider } from "../../../testHelper/utils";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 import AccountForm from "../AccountForm";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
 describe("AccountForm", () => {
   beforeEach(() => {
     render(
-      <TestHookFormProvider>
-        <FormDataContextProvider initState={formInitialState}>
-          <AccountForm />
-        </FormDataContextProvider>
-      </TestHookFormProvider>
+      <TestProviderWrapper>
+        <AccountForm />
+      </TestProviderWrapper>
     );
   });
 
@@ -36,14 +30,12 @@ describe("AccountForm", () => {
   });
 });
 
-describe("AccountForm Accessibility check", () => {
-  test("passes axe", async () => {
+describe("AccountForm accessibility check", () => {
+  test("passes axe accessibility test", async () => {
     const { container } = render(
-      <TestHookFormProvider>
-        <FormDataContextProvider initState={formInitialState}>
-          <AccountForm />
-        </FormDataContextProvider>
-      </TestHookFormProvider>
+      <TestProviderWrapper>
+        <AccountForm />
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/src/components/__tests__/AddressForm.test.tsx
+++ b/src/components/__tests__/AddressForm.test.tsx
@@ -3,12 +3,8 @@ import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import AddressForm, { AddressTypes } from "../AddressForm";
-import { TestHookFormProvider } from "../../../testHelper/utils";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 import { Address } from "../../interfaces";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
@@ -35,31 +31,26 @@ const reactHookFormErrors = {
 };
 
 describe("AddressForm", () => {
-  test("it passes accessibility checks", async () => {
+  test("it passes axe accessibility test", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AddressForm
           type={AddressTypes.Home}
           errorMessages={addressErrorMessages}
         />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
   test("it passess accessibilty checks with error messages", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider errors={reactHookFormErrors}>
-          <AddressForm
-            type={AddressTypes.Home}
-            errorMessages={addressErrorMessages}
-          />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper hookFormState={{ errors: reactHookFormErrors }}>
+        <AddressForm
+          type={AddressTypes.Home}
+          errorMessages={addressErrorMessages}
+        />
+      </TestProviderWrapper>
     );
 
     expect(await axe(container)).toHaveNoViolations();
@@ -67,15 +58,12 @@ describe("AddressForm", () => {
 
   test("it should render five fields", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AddressForm
           type={AddressTypes.Home}
           errorMessages={addressErrorMessages}
         />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     // Unfortunately, getByLabelText doesn't work for these label since the
@@ -99,15 +87,12 @@ describe("AddressForm", () => {
 
   test("it should render five optional fields for the work address", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AddressForm
           type={AddressTypes.Work}
           errorMessages={addressErrorMessages}
         />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     // Since none of the fields are required for the work address, we can
@@ -127,14 +112,12 @@ describe("AddressForm", () => {
 
   test("it should render any error messages for required fields", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider errors={reactHookFormErrors}>
-          <AddressForm
-            type={AddressTypes.Home}
-            errorMessages={addressErrorMessages}
-          />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper hookFormState={{ errors: reactHookFormErrors }}>
+        <AddressForm
+          type={AddressTypes.Home}
+          errorMessages={addressErrorMessages}
+        />
+      </TestProviderWrapper>
     );
 
     const line1Error = screen.getByText(

--- a/src/components/__tests__/AgeForm.test.tsx
+++ b/src/components/__tests__/AgeForm.test.tsx
@@ -3,11 +3,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import AgeForm from "../AgeForm";
-import { TestHookFormProvider } from "../../../testHelper/utils";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 
 expect.extend(toHaveNoViolations);
 
@@ -27,38 +23,29 @@ const reactHookFormErrors = {
 };
 
 describe("AgeForm", () => {
-  test("it passes accessibility checks for the field input", async () => {
+  test("it passes axe accessibility checks for the field input", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AgeForm errorMessages={noHookFormErrors} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  test("it passes accessibility checks for the checkbox input", async () => {
+  test("it passes axe accessibility checks for the checkbox input", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AgeForm policyType="simplye" errorMessages={noHookFormErrors} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
   test("it renders an input field with the default webApplicant policyType", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AgeForm errorMessages={noHookFormErrors} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     const description = screen.getByText("MM/DD/YYYY, including slashes");
@@ -76,12 +63,9 @@ describe("AgeForm", () => {
 
   test("it renders a checkbox with the simplye policyType", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AgeForm policyType="simplye" errorMessages={noHookFormErrors} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     const description = screen.queryByText("MM/DD/YYYY, including slashes");
@@ -99,12 +83,9 @@ describe("AgeForm", () => {
 
   test("updates the age gate checkbox", async () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <AgeForm policyType="simplye" errorMessages={noHookFormErrors} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
@@ -117,11 +98,9 @@ describe("AgeForm", () => {
 
   test("it should render a webApplicant error message", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider errors={reactHookFormErrors}>
-          <AgeForm errorMessages={ageFormErrorMessages} />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper hookFormState={{ errors: reactHookFormErrors }}>
+        <AgeForm errorMessages={ageFormErrorMessages} />
+      </TestProviderWrapper>
     );
 
     const inputError = screen.getByText(ageFormErrorMessages["birthdate"]);
@@ -130,11 +109,9 @@ describe("AgeForm", () => {
 
   test("it should render a simplye error message", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider errors={reactHookFormErrors}>
-          <AgeForm policyType="simplye" errorMessages={ageFormErrorMessages} />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper hookFormState={{ errors: reactHookFormErrors }}>
+        <AgeForm policyType="simplye" errorMessages={ageFormErrorMessages} />
+      </TestProviderWrapper>
     );
 
     const inputError = screen.getByText(ageFormErrorMessages["ageGate"]);

--- a/src/components/__tests__/ApplicationContainer.test.tsx
+++ b/src/components/__tests__/ApplicationContainer.test.tsx
@@ -9,7 +9,7 @@ import ApplicationContainer from "../ApplicationContainer";
 expect.extend(toHaveNoViolations);
 
 describe("ApplicationContainer", () => {
-  test("passes axe", async () => {
+  test("passes axe accessibility test", async () => {
     const { container } = render(<ApplicationContainer />);
 
     expect(await axe(container)).toHaveNoViolations();

--- a/src/components/__tests__/Confirmation.test.tsx
+++ b/src/components/__tests__/Confirmation.test.tsx
@@ -20,7 +20,7 @@ const formResults: FormResults = {
 };
 
 describe("Confirmation", () => {
-  test("passes axe", async () => {
+  test("passes axe accessibility test", async () => {
     const { container } = render(<Confirmation formResults={formResults} />);
 
     expect(await axe(container)).toHaveNoViolations();

--- a/src/components/__tests__/LibraryListForm.test.tsx
+++ b/src/components/__tests__/LibraryListForm.test.tsx
@@ -4,11 +4,7 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import LibraryListForm, { LibraryListObject } from "../LibraryListForm";
-import { TestHookFormProvider } from "../../../testHelper/utils";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 
 expect.extend(toHaveNoViolations);
 
@@ -19,26 +15,20 @@ const libraryList: LibraryListObject[] = [
 ];
 
 describe("LibraryListForm", () => {
-  test("passes accessibility checks", async () => {
+  test("passes axe accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LibraryListForm libraryList={libraryList} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
   test("renders a label, input, and description", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LibraryListForm libraryList={libraryList} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     expect(screen.getByLabelText("Home Library:")).toBeInTheDocument();
@@ -53,12 +43,9 @@ describe("LibraryListForm", () => {
 
   test("it updates the selected value from the dropdown", async () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LibraryListForm libraryList={libraryList} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     const input = screen.getByRole("textbox");
@@ -90,12 +77,9 @@ describe("LibraryListForm", () => {
 
   test("it shows the suggestions", async () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LibraryListForm libraryList={libraryList} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     const input = screen.getByRole("textbox");

--- a/src/components/__tests__/LocationForm.test.tsx
+++ b/src/components/__tests__/LocationForm.test.tsx
@@ -4,11 +4,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
 import LocationForm from "../LocationForm";
-import { TestHookFormProvider } from "../../../testHelper/utils";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 
 expect.extend(toHaveNoViolations);
 
@@ -18,26 +14,20 @@ describe("LocationForm", () => {
   const nys = "New York State (Outside NYC)";
   const us = "United States (Visiting NYC)";
 
-  test("passes accessibility checks", async () => {
+  test("passes axe accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LocationForm errorMessage={errorMessage} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });
 
   test("renders an alternate form link", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LocationForm errorMessage={errorMessage} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     expect(screen.getByText("alternate form")).toBeInTheDocument();
@@ -45,12 +35,9 @@ describe("LocationForm", () => {
 
   test("renders three radio buttons", () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LocationForm errorMessage={errorMessage} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     expect(screen.getByLabelText(nyc)).toBeInTheDocument();
@@ -60,12 +47,9 @@ describe("LocationForm", () => {
 
   test("updates the value selected", async () => {
     render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <LocationForm errorMessage={errorMessage} />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     let radio = screen.getByLabelText(nyc) as HTMLInputElement;
@@ -86,11 +70,9 @@ describe("LocationForm", () => {
       },
     };
     render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider errors={reactHookFormErrors}>
-          <LocationForm errorMessage={errorMessage} />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper hookFormState={{ errors: reactHookFormErrors }}>
+        <LocationForm errorMessage={errorMessage} />
+      </TestProviderWrapper>
     );
 
     expect(screen.getByText(errorMessage)).toBeInTheDocument();

--- a/src/components/__tests__/PersonalInformationForm.test.tsx
+++ b/src/components/__tests__/PersonalInformationForm.test.tsx
@@ -1,25 +1,19 @@
 /* eslint-disable */
 import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
-import { TestHookFormProvider } from "../../../testHelper/utils";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 import PersonalInformationForm from "../PersonalInformationForm";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
 
 expect.extend(toHaveNoViolations);
 
 describe("PersonalInformationForm", () => {
   beforeEach(() => {
     render(
-      <TestHookFormProvider>
-        <FormDataContextProvider initState={formInitialState}>
-          <PersonalInformationForm />
-        </FormDataContextProvider>
-      </TestHookFormProvider>
+      <TestProviderWrapper>
+        <PersonalInformationForm />
+      </TestProviderWrapper>
     );
   });
 
@@ -42,14 +36,12 @@ describe("PersonalInformationForm", () => {
   });
 });
 
-describe("Accessibility check", () => {
-  test("passes axe", async () => {
+describe("PersonalInformationForm Accessibility check", () => {
+  test("passes axe accessibility test", async () => {
     const { container } = render(
-      <TestHookFormProvider>
-        <FormDataContextProvider initState={formInitialState}>
-          <PersonalInformationForm />
-        </FormDataContextProvider>
-      </TestHookFormProvider>
+      <TestProviderWrapper>
+        <PersonalInformationForm />
+      </TestProviderWrapper>
     );
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/src/components/__tests__/UsernameValidationForm.test.tsx
+++ b/src/components/__tests__/UsernameValidationForm.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import "@testing-library/jest-dom/extend-expect";
-import { TestHookFormProvider } from "../../../testHelper/utils";
+import { TestProviderWrapper } from "../../../testHelper/utils";
 // `import` axios does not work so it must be required.
 const axios = require("axios");
 
@@ -11,24 +11,17 @@ expect.extend(toHaveNoViolations);
 jest.mock("axios");
 
 import UsernameValidationForm from "../UsernameValidationForm";
-import {
-  FormDataContextProvider,
-  formInitialState,
-} from "../../context/FormDataContext";
 
 describe("UsernameValidationForm", () => {
   beforeEach(() => {
     axios.mockClear();
   });
 
-  test("passes accessibility checks", async () => {
+  test("passes axe accessibility checks", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <UsernameValidationForm />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     expect(await axe(container)).toHaveNoViolations();
@@ -36,12 +29,9 @@ describe("UsernameValidationForm", () => {
 
   test("renders the basic label, input, and helper text elements", async () => {
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
+      <TestProviderWrapper>
         <UsernameValidationForm />
-      </FormDataContextProvider>,
-      {
-        wrapper: TestHookFormProvider,
-      }
+      </TestProviderWrapper>
     );
 
     const label = screen.getByText("Username");
@@ -76,11 +66,11 @@ describe("UsernameValidationForm", () => {
     const mockWatch = jest.fn().mockReturnValue(true);
     let mockGetValues = jest.fn().mockReturnValue(tooShort);
     const { rerender } = render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider getValues={mockGetValues} watch={mockWatch}>
-          <UsernameValidationForm />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper
+        hookFormState={{ getValues: mockGetValues, watch: mockWatch }}
+      >
+        <UsernameValidationForm />
+      </TestProviderWrapper>
     );
     let validateButton = screen.queryByRole("button");
 
@@ -91,11 +81,11 @@ describe("UsernameValidationForm", () => {
     // Now let's mock another invalid value.
     mockGetValues = jest.fn().mockReturnValue(invalid);
     rerender(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider getValues={mockGetValues} watch={mockWatch}>
-          <UsernameValidationForm />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper
+        hookFormState={{ getValues: mockGetValues, watch: mockWatch }}
+      >
+        <UsernameValidationForm />
+      </TestProviderWrapper>
     );
 
     validateButton = screen.queryByRole("button");
@@ -105,11 +95,11 @@ describe("UsernameValidationForm", () => {
     // Mock a valid value.
     mockGetValues = jest.fn().mockReturnValue(justRight);
     rerender(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider getValues={mockGetValues} watch={mockWatch}>
-          <UsernameValidationForm />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper
+        hookFormState={{ getValues: mockGetValues, watch: mockWatch }}
+      >
+        <UsernameValidationForm />
+      </TestProviderWrapper>
     );
 
     validateButton = screen.queryByRole("button");
@@ -127,11 +117,11 @@ describe("UsernameValidationForm", () => {
     const mockGetValues = jest.fn().mockReturnValue("notAvailableUsername");
 
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider watch={mockWatch} getValues={mockGetValues}>
-          <UsernameValidationForm />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper
+        hookFormState={{ getValues: mockGetValues, watch: mockWatch }}
+      >
+        <UsernameValidationForm />
+      </TestProviderWrapper>
     );
 
     const button = await screen.findByText("Check if username is available");
@@ -169,11 +159,11 @@ describe("UsernameValidationForm", () => {
     const mockGetValues = jest.fn().mockReturnValue("availableUsername");
 
     const { container } = render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider watch={mockWatch} getValues={mockGetValues}>
-          <UsernameValidationForm />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper
+        hookFormState={{ getValues: mockGetValues, watch: mockWatch }}
+      >
+        <UsernameValidationForm />
+      </TestProviderWrapper>
     );
 
     const button = await screen.findByText("Check if username is available");
@@ -217,11 +207,9 @@ describe("UsernameValidationForm", () => {
     // the `errors` object that react-hook-form returns so we are both, setting
     // it up and returning it.
     render(
-      <FormDataContextProvider initState={formInitialState}>
-        <TestHookFormProvider errors={errors} getValues={mockGetValues}>
-          <UsernameValidationForm />
-        </TestHookFormProvider>
-      </FormDataContextProvider>
+      <TestProviderWrapper hookFormState={{ getValues: mockGetValues, errors }}>
+        <UsernameValidationForm />
+      </TestProviderWrapper>
     );
     // Casting the returned value so we can access `value`.
     const input = screen.getByRole("textbox") as HTMLInputElement;

--- a/src/context/FormDataContext.tsx
+++ b/src/context/FormDataContext.tsx
@@ -23,8 +23,8 @@ export const formInitialState: FormData = {
   } as AddressResponse,
 };
 
-interface FormDataType {
-  initState: FormData;
+interface FormDataContextProps {
+  initState?: FormData;
 }
 
 const FormDataContext = React.createContext<FormDataContextType | undefined>(
@@ -32,8 +32,8 @@ const FormDataContext = React.createContext<FormDataContextType | undefined>(
 );
 
 export const FormDataContextProvider: React.FC<PropsWithChildren<
-  FormDataType
->> = ({ initState, children }) => {
+  FormDataContextProps
+>> = ({ initState = formInitialState, children }) => {
   // Keep track of the API results and errors from a form submission as global
   // data in the app. It is exposed to the pages through context. Use
   // the `dispatch` function to update the state properties.

--- a/src/context/ParamsContext.tsx
+++ b/src/context/ParamsContext.tsx
@@ -10,6 +10,10 @@ export const ParamsContextProvider: React.FC<{ params: Params }> = ({
   <ParamsContext.Provider value={params}>{children}</ParamsContext.Provider>
 );
 
+/**
+ * useParamsContext
+ * Custom context hook to get the URL query params in child components.
+ */
 export default function useParamsContext() {
   const context = React.useContext(ParamsContext);
   if (typeof context === "undefined") {

--- a/src/utils/__tests__/api.test.ts
+++ b/src/utils/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { constructAddresses } from "../api";
+import { constructAddresses, constructApiHeaders } from "../api";
 import { Addresses } from "../../interfaces";
 
 describe("constructAddresses", () => {
@@ -76,6 +76,20 @@ describe("constructAddresses", () => {
         state: "NY",
         zip: "10018",
       },
+    });
+  });
+});
+
+describe("constructApiHeaders", () => {
+  test("it returns authorization headers object", () => {
+    const headers = constructApiHeaders("token");
+
+    expect(headers).toEqual({
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token",
+      },
+      timeout: 10000,
     });
   });
 });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -41,9 +41,13 @@ const authConfig = {
   grant_type: "client_credentials",
 };
 
-const constructApiHeaders = (token = "", contentType = "application/json") => ({
+/**
+ * constructApiHeaders
+ * Creates the authorization header to use when calling the NYPL Platform API.
+ */
+export const constructApiHeaders = (token: string) => ({
   headers: {
-    "Content-Type": contentType,
+    "Content-Type": "application/json",
     Authorization: `Bearer ${token}`,
   },
   timeout: 10000,

--- a/testHelper/utils.tsx
+++ b/testHelper/utils.tsx
@@ -1,11 +1,21 @@
 import React from "react";
 import { useForm, FormProvider } from "react-hook-form";
+import {
+  FormDataContextProvider,
+  formInitialState,
+} from "../src/context/FormDataContext";
+import { FormData } from "../src/interfaces";
 
 interface MockMethods {
   errors?: {};
   // The types coming from `react-hook-form` for its functions.
   getValues?: () => { [x: string]: any };
   watch?: () => { [x: string]: any };
+}
+
+interface TestProviderType {
+  formDataState?: FormData;
+  hookFormState?: MockMethods;
 }
 
 /**
@@ -32,4 +42,22 @@ export const TestHookFormProvider: React.FC<MockMethods> = ({
     updatedMethods.watch = watch;
   }
   return <FormProvider {...updatedMethods}>{children}</FormProvider>;
+};
+
+/**
+ * TestProviderWrapper
+ * Wrapper component that wraps the child component with the
+ * `FormDataContextProvider` and the `TestHookFormProvider`. Allows props to
+ * pass to their respective providers to make tests look leaner.
+ */
+export const TestProviderWrapper: React.FC<TestProviderType> = ({
+  formDataState = formInitialState,
+  hookFormState,
+  children,
+}) => {
+  return (
+    <FormDataContextProvider initState={formDataState}>
+      <TestHookFormProvider {...hookFormState}>{children}</TestHookFormProvider>
+    </FormDataContextProvider>
+  );
 };


### PR DESCRIPTION
Resolves [DQ-367](https://jira.nypl.org/browse/DQ-367).

Did some cleanup and wrote more comments but the biggest change is writing the `TestProviderWrapper` component which wraps two context providers. It's to make writing tests easier since most components rely on both contexts.