### PR TITLE
Address selection

### DIFF
--- a/pages/__tests__/library-card_address.test.tsx
+++ b/pages/__tests__/library-card_address.test.tsx
@@ -68,7 +68,12 @@ describe("AddressPage", () => {
       addressResponse: {
         home: {
           cardType: "standard",
-          address: undefined,
+          address: {
+            line1: "1234 61st",
+            city: "Woodside",
+            state: "NY",
+            zip: "11377",
+          },
           addresses: [
             {
               line1: "1234 61st",
@@ -98,10 +103,9 @@ describe("AddressPage", () => {
     expect(screen.getByText("Home Address")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We have found alternate home addresses. Please choose the correct address:"
+        "We have found an alternate home address. Please choose which is correct:"
       )
     ).toBeInTheDocument();
-    expect(screen.getByText("1234 61st")).toBeInTheDocument();
     expect(screen.getByText("Woodside, NY 11377")).toBeInTheDocument();
 
     expect(screen.getByText("5678 61st")).toBeInTheDocument();
@@ -161,7 +165,12 @@ describe("AddressPage", () => {
       addressResponse: {
         home: {
           cardType: "standard",
-          address: undefined,
+          address: {
+            line1: "1234 61st",
+            city: "Woodside",
+            state: "NY",
+            zip: "11377",
+          },
           addresses: [
             {
               line1: "1234 61st",
@@ -181,7 +190,12 @@ describe("AddressPage", () => {
         },
         work: {
           cardType: "standard",
-          address: undefined,
+          address: {
+            line1: "476 5th Ave",
+            city: "New York",
+            state: "NY",
+            zip: "10018",
+          },
           addresses: [
             {
               line1: "476 5th Ave",
@@ -210,10 +224,9 @@ describe("AddressPage", () => {
     expect(screen.getByText("Home Address")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We have found alternate home addresses. Please choose the correct address:"
+        "We have found an alternate home address. Please choose which is correct:"
       )
     ).toBeInTheDocument();
-    expect(screen.getByText("1234 61st")).toBeInTheDocument();
     expect(screen.getByText("Woodside, NY 11377")).toBeInTheDocument();
 
     expect(screen.getByText("5678 61st")).toBeInTheDocument();
@@ -222,10 +235,9 @@ describe("AddressPage", () => {
     expect(screen.getByText("Work Address")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We have found alternate work addresses. Please choose the correct address:"
+        "We have found an alternate work address. Please choose which is correct:"
       )
     ).toBeInTheDocument();
-    expect(screen.getByText("476 5th Ave")).toBeInTheDocument();
     expect(screen.getByText("New York, NY 10018")).toBeInTheDocument();
 
     expect(screen.getByText("1111 1st Ave")).toBeInTheDocument();

--- a/pages/library-card/address/index.tsx
+++ b/pages/library-card/address/index.tsx
@@ -1,29 +1,88 @@
-import React from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/router";
 import useFormDataContext from "../../../src/context/FormDataContext";
-import { useFormContext } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { Input, Label, InputTypes } from "@nypl/design-system-react-components";
 
 /**
  * AddressPage
  * Main page component for the "address review" page.
  */
 function AddressPage() {
-  const { handleSubmit } = useFormContext();
+  const [homeAddressSelect, setHomeAddressSelect] = useState("");
+  const [workAddressSelect, setWorkAddressSelect] = useState("");
+  const { handleSubmit, register } = useForm();
   const { state, dispatch } = useFormDataContext();
   const { formValues, addressResponse } = state;
   const router = useRouter();
 
+  const onChangeHome = (e) => setHomeAddressSelect(e.target?.value);
+  const onChangeWork = (e) => setWorkAddressSelect(e.target?.value);
   const homeAddress = addressResponse?.home;
   const workAddress = addressResponse?.work;
+  console.log("homeAddress", homeAddress);
+
   const submitForm = (formData) => {
+    console.log("formData", formData);
+    let updatedFormValues;
+    const home = formData["home-address-select"];
+    const work = formData["work-address-select"];
+    if (home) {
+      const idx = parseInt(home.split("-")[1], 10);
+      const selectedHomeAddress = homeAddress.addresses[idx];
+      const updatedSelectedHomeAddress = {};
+      Object.keys(selectedHomeAddress).forEach((key) => {
+        updatedSelectedHomeAddress[`home-${key}`] = selectedHomeAddress[key];
+      });
+      updatedFormValues = {
+        ...formValues,
+        ...updatedSelectedHomeAddress,
+      };
+    } else {
+      const selectedHomeAddress = homeAddress.address;
+      const updatedSelectedHomeAddress = {};
+      Object.keys(selectedHomeAddress).forEach((key) => {
+        updatedSelectedHomeAddress[`home-${key}`] = selectedHomeAddress[key];
+      });
+      updatedFormValues = {
+        ...formValues,
+        ...updatedSelectedHomeAddress,
+      };
+    }
+
+    if (work) {
+      const idx = parseInt(work.split("-")[1], 10);
+      const selectedWorkAddress = workAddress.addresses[idx];
+      const updatedSelectedWorkAddress = {};
+      Object.keys(selectedWorkAddress).forEach((key) => {
+        updatedSelectedWorkAddress[`work-${key}`] = selectedWorkAddress[key];
+      });
+      updatedFormValues = {
+        ...updatedFormValues,
+        ...updatedSelectedWorkAddress,
+      };
+    } else if (workAddress) {
+      const selectedWorkAddress = workAddress.address;
+      const updatedSelectedWorkAddress = {};
+      Object.keys(selectedWorkAddress).forEach((key) => {
+        updatedSelectedWorkAddress[`work-${key}`] = selectedWorkAddress[key];
+      });
+      updatedFormValues = {
+        ...updatedFormValues,
+        ...updatedSelectedWorkAddress,
+      };
+    }
+
+    console.log("updatedFormValues", updatedFormValues);
+
     // Merge any updates, specifically to the address value, and continue to
     // the next page. For now, it's only setting up the dispatch.
-    dispatch({
-      type: "SET_FORM_DATA",
-      value: { ...formData, ...formValues },
-    });
+    // dispatch({
+    //   type: "SET_FORM_DATA",
+    //   value: updatedFormValues,
+    // });
 
-    router.push("/library-card/review");
+    // router.push("/library-card/review");
   };
 
   return (
@@ -32,29 +91,69 @@ function AddressPage() {
         <h2>Confirm your Address</h2>
         <form onSubmit={handleSubmit(submitForm)}>
           <h3>Home Address</h3>
-          {homeAddress?.addresses && (
+          {homeAddress?.addresses?.length > 0 && (
             <>
+              <div className="original-address">
+                <p>Address submitted:</p>
+                <span>
+                  {homeAddress.address.line1} {homeAddress.address.line2}
+                </span>
+                <br />
+                <span>
+                  {homeAddress.address.city}, {homeAddress.address.state}
+                </span>{" "}
+                <span>{homeAddress.address.zip}</span>
+              </div>
               <p>
-                We have found alternate home addresses. Please choose the
-                correct address:
+                We have found an alternate home address. Please choose which is
+                correct:
               </p>
-              <ul>
-                {homeAddress.addresses.map((address, idx) => (
-                  <li key={idx}>
-                    <span>
-                      {address.line1} {address.line2}
-                    </span>
-                    <br />
-                    <span>
-                      {address.city}, {address.state} {address.zip}
-                    </span>
-                  </li>
-                ))}
+              <ul className="multiple-address-list">
+                {homeAddress.addresses.map((address, idx) => {
+                  const selected = `home-${idx}`;
+                  const checked = selected === homeAddressSelect;
+                  const checkedClass = checked ? "checked" : "";
+                  return (
+                    <li
+                      key={`home-${idx}`}
+                      className={`radio-field ${checkedClass}`}
+                    >
+                      <Label
+                        id={`home-${idx}-label`}
+                        htmlFor={`input-home-${idx}`}
+                      >
+                        <Input
+                          className="radio-input"
+                          aria-labelledby={`home-${idx}-label`}
+                          id={`home-${idx}`}
+                          type={InputTypes.radio}
+                          attributes={{
+                            name: "home-address-select",
+                            "aria-checked": checked,
+                            defaultChecked: checked,
+                            onChange: onChangeHome,
+                          }}
+                          value={selected}
+                          ref={register()}
+                        />
+                        <div>
+                          <span>
+                            {address.line1} {address.line2}
+                          </span>
+                          <br />
+                          <span>
+                            {address.city}, {address.state} {address.zip}
+                          </span>
+                        </div>
+                      </Label>
+                    </li>
+                  );
+                })}
               </ul>
             </>
           )}
-          {homeAddress?.address?.line1 && (
-            <>
+          {!homeAddress.addresses && homeAddress?.address?.line1 && (
+            <div className="original-address">
               <span>
                 {homeAddress.address.line1} {homeAddress.address.line2}
               </span>
@@ -63,35 +162,16 @@ function AddressPage() {
                 {homeAddress.address.city}, {homeAddress.address.state}
               </span>{" "}
               <span>{homeAddress.address.zip}</span>
-            </>
+            </div>
           )}
 
           {(workAddress?.addresses || workAddress?.address) && (
             <h3>Work Address</h3>
           )}
-          {workAddress?.addresses?.length > 0 ? (
+          {workAddress?.addresses?.length > 0 && (
             <>
-              <p>
-                We have found alternate work addresses. Please choose the
-                correct address:
-              </p>
-              <ul>
-                {workAddress.addresses.map((address, idx) => (
-                  <li key={idx}>
-                    <span>
-                      {address.line1} {address.line2}
-                    </span>
-                    <br />
-                    <span>
-                      {address.city}, {address.state} {address.zip}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </>
-          ) : (
-            workAddress?.address?.line1 && (
-              <>
+              <div className="original-address">
+                <p>Address submitted:</p>
                 <span>
                   {workAddress.address.line1} {workAddress.address.line2}
                 </span>
@@ -100,8 +180,66 @@ function AddressPage() {
                   {workAddress.address.city}, {workAddress.address.state}
                 </span>{" "}
                 <span>{workAddress.address.zip}</span>
-              </>
-            )
+              </div>
+              <p>
+                We have found an alternate work address. Please choose which is
+                correct:
+              </p>
+              <ul className="multiple-address-list">
+                {workAddress.addresses.map((address, idx) => {
+                  const selected = `work-${idx}`;
+                  const checked = selected === workAddressSelect;
+                  const checkedClass = checked ? "checked" : "";
+                  return (
+                    <li
+                      key={`work-${idx}`}
+                      className={`radio-field ${checkedClass}`}
+                    >
+                      <Label
+                        id={`work-${idx}-label`}
+                        htmlFor={`input-work-${idx}`}
+                      >
+                        <Input
+                          className="radio-input"
+                          aria-labelledby={`work-${idx}-label`}
+                          id={`work-${idx}`}
+                          type={InputTypes.radio}
+                          attributes={{
+                            name: "work-address-select",
+                            "aria-checked": checked,
+                            defaultChecked: checked,
+                            onChange: onChangeWork,
+                          }}
+                          value={selected}
+                          ref={register()}
+                        />
+                        <div>
+                          <span>
+                            {address.line1} {address.line2}
+                          </span>
+                          <br />
+                          <span>
+                            {address.city}, {address.state} {address.zip}
+                          </span>
+                        </div>
+                      </Label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          )}
+          {!workAddress.addresses && workAddress?.address?.line1 && (
+            <div className="original-address">
+              <span>
+                {workAddress.address.line1} {workAddress.address.line2}
+              </span>
+              <br />
+              <span>
+                {workAddress.address.city}, {workAddress.address.state}
+              </span>{" "}
+              <span>{workAddress.address.zip}</span>
+            </div>
           )}
 
           <div>

--- a/pages/library-card/address/index.tsx
+++ b/pages/library-card/address/index.tsx
@@ -10,10 +10,16 @@ import { Address } from "../../../src/interfaces";
  * Main page component for the "address review" page.
  */
 function AddressPage() {
+  // Keep track of the user's selection of the preferred home
+  // and/or work address.
   const [homeAddressSelect, setHomeAddressSelect] = useState("");
   const [workAddressSelect, setWorkAddressSelect] = useState("");
+  // Use react-hook-form for the new radio button input form.
   const { handleSubmit, register } = useForm();
   const { state, dispatch } = useFormDataContext();
+  // The `addressResponse` is the value from Service Objects through the NYPL
+  // Platform API.
+  // The `formValues` object holds all the submitted user values.
   const { formValues, addressResponse } = state;
   const router = useRouter();
 
@@ -22,11 +28,16 @@ function AddressPage() {
   const homeAddress = addressResponse?.home;
   const workAddress = addressResponse?.work;
 
-  const extractUpdatedAddressValues = (address, addressType) => {
+  /**
+   * extractUpdatedAddressValues
+   * Returns an object with either the home or work address values from a
+   * larger data object.
+   */
+  const extractUpdatedAddressValues = (data, addressType) => {
     const updatedValues = {};
-    if (address) {
-      Object.keys(address).forEach((key) => {
-        updatedValues[`${addressType}-${key}`] = address[key];
+    if (data) {
+      Object.keys(data).forEach((key) => {
+        updatedValues[`${addressType}-${key}`] = data[key];
       });
     }
     return updatedValues;
@@ -79,7 +90,7 @@ function AddressPage() {
     // the next page.
     dispatch({
       type: "SET_FORM_DATA",
-      // Updating the existing submitted values with the selected valid address.
+      // Update the existing submitted values with the selected valid address.
       value: {
         ...formValues,
         ...updatedSelectedHomeAddress,
@@ -87,12 +98,17 @@ function AddressPage() {
       },
     });
 
+    // Finally, go to the review page.
     router.push("/library-card/review");
   };
 
-  const renderOriginalAddress = (address: Address) => (
-    <div className="original-address">
-      <p>Address submitted:</p>
+  /**
+   * renderValidatedAddress
+   * Temporary. Just renders the original address submitted by the user if
+   * the API response returned other valid addresses.
+   */
+  const renderValidatedAddress = (address: Address) => (
+    <div className="validated-address">
       <span>
         {address.line1} {address.line2}
       </span>
@@ -104,6 +120,12 @@ function AddressPage() {
     </div>
   );
 
+  /**
+   * renderMultipleAddresses
+   * Renders a list of alternate valid addresses from an invalid/ambiguous
+   * user submitted address. Each address is rendered inside a label/input
+   * combination so the user can select the right address.
+   */
   const renderMultipleAddresses = (
     addresses: Address[],
     addressType,
@@ -160,10 +182,11 @@ function AddressPage() {
         <h2>Confirm your Address</h2>
         <form onSubmit={handleSubmit(submitForm)}>
           <h3>Home Address</h3>
+
+          {/* If there are multiple addresses,
+          render the alternate addresses. */}
           {homeAddress?.addresses?.length > 0 && (
             <>
-              {renderOriginalAddress(homeAddress.address)}
-
               <p>
                 We have found an alternate home address. Please choose which is
                 correct:
@@ -177,17 +200,18 @@ function AddressPage() {
               )}
             </>
           )}
+          {/* Otherwise, just render the validated address. */}
           {!homeAddress.addresses &&
             homeAddress?.address?.line1 &&
-            renderOriginalAddress(homeAddress.address)}
+            renderValidatedAddress(homeAddress.address)}
 
           {(workAddress?.addresses || workAddress?.address) && (
             <h3>Work Address</h3>
           )}
+          {/* If there are multiple work addresses,
+          render the alternate addresses. */}
           {workAddress?.addresses?.length > 0 && (
             <>
-              {renderOriginalAddress(workAddress.address)}
-
               <p>
                 We have found an alternate work address. Please choose which is
                 correct:
@@ -201,9 +225,10 @@ function AddressPage() {
               )}
             </>
           )}
+          {/* If there is a validated work address, render it. */}
           {!workAddress.addresses &&
             workAddress?.address?.line1 &&
-            renderOriginalAddress(workAddress.address)}
+            renderValidatedAddress(workAddress.address)}
 
           <div>
             <input

--- a/pages/library-card/review/index.tsx
+++ b/pages/library-card/review/index.tsx
@@ -80,19 +80,21 @@ function ReviewPage() {
     // This is resetting any errors from previous submissions, if any.
     dispatch({ type: "SET_FORM_ERRORS", value: null });
 
+    const submitValues = { ...formData, ...formValues };
+
     // Convert the home library name to its code value.
-    formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
+    submitValues.homeLibraryCode = findLibraryCode(formValues.homeLibraryCode);
 
     // Update the global state.
     dispatch({
       type: "SET_FORM_DATA",
-      value: formData,
+      value: submitValues,
     });
 
     axios
       .post(
         "/api/create-patron",
-        formData
+        submitValues
         // {
         //    headers: { "csrf-token": csrfToken },
         // }

--- a/src/components/AddressForm.tsx
+++ b/src/components/AddressForm.tsx
@@ -27,7 +27,8 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
   // these functions are available to use.
   const { register, errors } = useFormContext();
   const MAXLENGTHSTATE = 2;
-  const MAXLENGTHZIP = 5;
+  const MINLENGTHZIP = 5;
+  const MAXLENGTHZIP = 10;
   // Only the home address is required. The work address is optional.
   const isRequired = type === AddressTypes.Home;
   /**
@@ -40,8 +41,17 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
    * @param length Max length of the field input.
    * @param field The key name of the field.
    */
-  const lengthValidation = (length, field) => (value) =>
-    !isRequired || value.length === length || errorMessages[field];
+  const lengthValidation = (max, field, min = undefined) => (value) => {
+    if (!min) {
+      return !isRequired || value.length === max || errorMessages[field];
+    }
+    return (
+      !isRequired ||
+      value.length === min ||
+      value.length === max ||
+      errorMessages[field]
+    );
+  };
 
   return (
     <>
@@ -109,9 +119,10 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
         fieldName={`${type}-zip`}
         isRequired={isRequired}
         errorState={errors}
+        minLength={MAXLENGTHZIP}
         maxLength={MAXLENGTHZIP}
         ref={register({
-          validate: lengthValidation(MAXLENGTHZIP, "zip"),
+          validate: lengthValidation(MAXLENGTHZIP, "zip", MINLENGTHZIP),
         })}
         defaultValue={formValues[`${type}-zip`]}
       />

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -16,6 +16,7 @@ interface FormFieldProps {
   className?: string;
   isRequired?: boolean;
   instructionText?: string;
+  minLength?: number;
   maxLength?: number;
   defaultValue?: any;
 }
@@ -37,6 +38,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
       className = "",
       isRequired = false,
       instructionText,
+      minLength,
       maxLength,
       defaultValue,
       // any extra input element attributes
@@ -67,6 +69,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
           aria-labelledby={`${id}-label ${ariaLabelledby}`}
           attributes={{
             ["aria-invalid"]: errorText ? "true" : "false",
+            minLength: minLength || null,
             maxLength: maxLength || null,
             name: fieldName,
             tabIndex: 0,

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -84,7 +84,6 @@ const LibraryCardForm = () => {
         if (error.response?.data?.work) {
           value.work = work;
         }
-        console.log("catch", value);
         dispatch({
           type: "SET_ADDRESSES_VALUE",
           value,

--- a/src/components/LibraryCardForm.tsx
+++ b/src/components/LibraryCardForm.tsx
@@ -84,6 +84,7 @@ const LibraryCardForm = () => {
         if (error.response?.data?.work) {
           value.work = work;
         }
+        console.log("catch", value);
         dispatch({
           type: "SET_ADDRESSES_VALUE",
           value,

--- a/src/components/__tests__/AddressForm.test.tsx
+++ b/src/components/__tests__/AddressForm.test.tsx
@@ -12,22 +12,14 @@ const addressErrorMessages: Address = {
   line1: "Please enter a valid street address.",
   city: "Please enter a valid city.",
   state: "Please enter a 2-character state abbreviation.",
-  zip: "Please enter a 5-digit postal code.",
+  zip: "Please enter a 5 or 9-digit postal code.",
 };
 // The `errors` object shape from `react-hook-form`.
 const reactHookFormErrors = {
-  "home-line1": {
-    message: "Please enter a valid street address.",
-  },
-  "home-city": {
-    message: "Please enter a valid city.",
-  },
-  "home-state": {
-    message: "Please enter a 2-character state abbreviation.",
-  },
-  "home-zip": {
-    message: "Please enter a 5-digit postal code.",
-  },
+  "home-line1": { message: addressErrorMessages.line1 },
+  "home-city": { message: addressErrorMessages.city },
+  "home-state": { message: addressErrorMessages.state },
+  "home-zip": { message: addressErrorMessages.zip },
 };
 
 describe("AddressForm", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,11 +10,15 @@ export interface FormInputData {
   "home-city": string;
   "home-state": string;
   "home-zip": string;
+  "home-hasBeenValidated": boolean;
+  "home-isResidential": string;
   "work-line1": string;
   "work-line2": string;
   "work-city": string;
   "work-state": string;
   "work-zip": string;
+  "work-hasBeenValidated": boolean;
+  "work-isResidential": string;
   username: string;
   pin: string;
   ecommunicationsPref: boolean;

--- a/src/styles/components/_address_review.scss
+++ b/src/styles/components/_address_review.scss
@@ -1,0 +1,29 @@
+.original-address {
+  margin: 0 0 20px;
+}
+
+.multiple-address-list {
+  display: flex;
+  padding: 0;
+  justify-content: space-between;
+  list-style: none;
+
+  li {
+    border: 1px solid var(--ui-gray-medium);
+
+    &.checked {
+      background: var(--ui-gray-medium);
+    }
+  }
+
+  .label {
+    display: flex;
+    align-items: center;
+    padding: 30px;
+    cursor: pointer;
+  }
+
+  .input {
+    margin-right: 20px;
+  }
+}

--- a/src/styles/components/_address_review.scss
+++ b/src/styles/components/_address_review.scss
@@ -1,4 +1,4 @@
-.original-address {
+.validated-address {
   margin: 0 0 20px;
 }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -19,6 +19,7 @@
 @import 'components/accordion';
 @import 'components/autosuggest';
 @import 'components/review_page';
+@import 'components/address_review';
 
 html {
   @include font-settings;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -115,6 +115,7 @@ const constructPatronObject = (object) => {
     policyType,
     ageGate,
     homeLibraryCode,
+    acceptTerms,
   } = object;
 
   const addresses: Addresses = constructAddresses(object);
@@ -154,13 +155,13 @@ const constructPatronObject = (object) => {
     errorObj = { ...errorObj, zip: "Postal Code field is empty." };
   }
 
-  if (
-    !isEmpty(addresses.home.zip) &&
-    (!isNumeric(addresses.home.zip) ||
-      !isLength(addresses.home.zip, { min: 5, max: 5 }))
-  ) {
-    errorObj = { ...errorObj, zip: "Please enter a 5-digit postal code." };
-  }
+  // if (
+  //   !isEmpty(addresses.home.zip) &&
+  //   (!isNumeric(addresses.home.zip) ||
+  //     !isLength(addresses.home.zip, { min: 5, max: 10 }))
+  // ) {
+  //   errorObj = { ...errorObj, zip: "Please enter a 5 or 9-digit postal code." };
+  // }
 
   // if (isEmpty(email)) {
   //   errorObj = { ...errorObj, email: 'Email field is empty.' };
@@ -220,6 +221,7 @@ const constructPatronObject = (object) => {
     usernameHasBeenValidated: usernameHasBeenValidatedBool,
     policyType: policyType || "simplye",
     homeLibraryCode,
+    acceptTerms,
   };
 };
 

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -17,7 +17,7 @@ const errorMessages = {
     line1: "Please enter a valid street address.",
     city: "Please enter a valid city.",
     state: "Please enter a 2-character state abbreviation.",
-    zip: "Please enter a 5-digit postal code.",
+    zip: "Please enter a 5 or 9-digit postal code.",
   } as Address,
 };
 


### PR DESCRIPTION
Resolves [DQ-366](https://jira.nypl.org/browse/DQ-366).

This adds on to the address review page. Before, the submitted address was validated and rendered as it was returned by Service Objects. If the submitted address was vague, multiple alternate addresses were returned and listed. This PR makes it so the user can select one of the alternate addresses and that value gets added on to the data object that is used to submit to create a patron.

Note: The `pages/library-card/address/index.tsx` page is long and I did not break it up into smaller components because the design isn't done yet. Once I get a better idea of how it should appear, it'll be easier to refactor and break up the large page into smaller components.

1) Home and (optional) work address were validated and returned by the API through Service Objects:
<img width="385" alt="Screen Shot 2020-09-01 at 11 09 45 AM" src="https://user-images.githubusercontent.com/1280564/91869731-39361b80-ec44-11ea-81b0-e7df5397fe6e.png">

2) If there are multiple, the radio button select UI comes up:
<img width="737" alt="Screen Shot 2020-09-01 at 11 08 33 AM" src="https://user-images.githubusercontent.com/1280564/91869837-5834ad80-ec44-11ea-9c48-a5efa9c1ebf3.png">


@killerpuppytails @marcuswashington , in the review page, there's an option to edit the address:
<img width="542" alt="Screen Shot 2020-09-01 at 11 15 16 AM" src="https://user-images.githubusercontent.com/1280564/91870246-ce391480-ec44-11ea-9c6a-333d66385d4d.png">

but I don't think this makes sense if in this address review page they have to select an address or if the address has already been validated by Service Objects. Pointing this out because I think the review page should be updated so that a user _can't_ edit their address once they are there.
