### PR TITLE
Don't include react-axe in the production bundle.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ PATRON_VALIDATION_URL=The URL used to validate people's usernames and addresses 
 OAUTH_PROVIDER_URL=URL to OAuth provider who guards the API Gateway (e.g: https://isso.nypl.org/oauth/token)
 OAUTH_CLIENT_ID=The ID this app uses to auth to the OAuth provider above
 OAUTH_CLIENT_SECRET=The secret this app uses to auth to the OAuth provider above
-USE_AXE_ENV='false' use 'true' if react-axe should be run while developing
+TEST_AXE_ENV='false' use 'true' if react-axe should be run while developing
 PORT=3001
 IPSTACK_KEY=key to api.ipstack service https://ipstack.com/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added `react-testing-library` for UI testing.
 - Added the `UsernameValidationForm` component to check for username availability in the ILS right away instead of waiting for the complete form to be submitted.
 - Added the `LibraryListForm` component which renders a drop down list of libraries for patrons to select their home library.
+- Added IP address server-side lookup and an API call to IP Stack to verify the user's location.
 
 ### v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ The `production` branch should be what's running in the production environment.
 
 There are two ways to use the `react-axe` package for accessibility review while developing. This is the package of choice used in a few NYPL React applications. Only turn it on when needed and not while developing all the time because it uses a lot of browser resouces.
 
-1. Run `USE_AXE_ENV=true npm run dev`
-2. or update the `USE_AXE_ENV` environment variable in your `.env` file.
+1. Run `TEST_AXE_ENV=true npm run dev`
+2. or update the `TEST_AXE_ENV` environment variable in your `.env` file.
 
 ### AWS Elastic Beanstalk
 

--- a/appConfig.js
+++ b/appConfig.js
@@ -10,6 +10,8 @@ export default {
   clientId: process.env.OAUTH_CLIENT_ID,
   clientSecret: process.env.OAUTH_CLIENT_SECRET,
   ipStackKey: process.env.IPSTACK_KEY,
+  testAxeEnv: process.env.TEST_AXE_ENV,
+  nodeEnv: process.env.NODE_ENV,
   agencyType: {
     default: "198",
     nys: "199",

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 module.exports = {
-  webpack: (config, { isServer }) => {
-    // Fixes npm packages that depend on `fs` module
+  webpack: (config, { isServer, webpack }) => {
+    // react-axe should only be bundled when REACT_AXE=true
+    !process.env.TEST_AXE_ENV &&
+      config.plugins.push(new webpack.IgnorePlugin(/react-axe$/));
+    // Fixes npm packages that depend on `fs` module since
+    // we can't depend on this in the client-side code.
     if (!isServer) {
       config.node = {
         fs: "empty",

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   webpack: (config, { isServer, webpack }) => {
-    // react-axe should only be bundled when REACT_AXE=true
+    // react-axe should only be bundled when TEST_AXE_ENV=true
     !process.env.TEST_AXE_ENV &&
       config.plugins.push(new webpack.IgnorePlugin(/react-axe$/));
     // Fixes npm packages that depend on `fs` module since

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,6 +10,7 @@ import appConfig from "../appConfig";
 import { FormInputData } from "../src/interfaces";
 import ApplicationContainer from "../src/components/ApplicationContainer";
 import IPLocationAPI from "../src/utils/IPLocationAPI";
+import enableAxe from "../src/utils/axe";
 
 interface MyAppProps {
   Component: any;
@@ -28,7 +29,7 @@ function isServerRendered(): boolean {
 // TODO: This is using an older NYPL GA package and should be updated later.
 if (!isServerRendered()) {
   if (!window["ga"]) {
-    const isProd = process.env.NODE_ENV === "production";
+    const isProd = appConfig.nodeEnv === "production";
     const gaOpts = { debug: !isProd, titleCase: false };
 
     ga.gaUtils.initialize(ga.config.google.code(isProd), gaOpts);
@@ -37,15 +38,9 @@ if (!isServerRendered()) {
   ga.gaUtils.trackPageview(window.location.pathname);
 }
 
-// Accessibility helper that outputs to the console on dev and test
-// environment only and client-side only.
-// https://github.com/dequelabs/react-axe
-if (process.env.TEST_AXE_ENV === "true" && !isServerRendered()) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const ReactDOM = require("react-dom");
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const axe = require("react-axe");
-  axe(React, ReactDOM, 1000);
+// Only run react-axe in the client-side and when the flag is set.
+if (appConfig.testAxeEnv === "true" && !isServerRendered()) {
+  enableAxe();
 }
 
 function MyApp<MyAppProps>({ Component, pageProps, userLocation }) {

--- a/src/utils/axe.ts
+++ b/src/utils/axe.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import * as React from "react";
+
+/**
+ * Accessibility helper that outputs to the console on dev and test
+ * environment only and client-side only.
+ * @see https://github.com/dequelabs/react-axe
+ */
+export default async function enableAxe() {
+  const ReactDOM = require("react-dom");
+  const axe = require("react-axe");
+  axe(React, ReactDOM, 1000);
+}


### PR DESCRIPTION
## Description

Removing react-axe from the dist bundle.

## Motivation and Context

Resolves [DQ-372](https://jira.nypl.org/browse/DQ-372). Just a minor optimization. The bundle went from 565kb for the first load javascript to 437kb.

## How Has This Been Tested?

Run `npm run build` with and without the next.js configuration to see the difference.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
