### PR TITLE
Adding workaround hook to get better scroll behavior

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ import ApplicationContainer from "../src/components/ApplicationContainer";
 import IPLocationAPI from "../src/utils/IPLocationAPI";
 import enableAxe from "../src/utils/axe";
 import { ParamsContextProvider } from "../src/context/ParamsContext";
+import useRouterScroll from "../src/hooks/useRouterScroll";
 
 interface MyAppProps {
   Component: any;
@@ -38,6 +39,7 @@ if (appConfig.useAxe === "true" && !isServerRendered()) {
 }
 
 function MyApp<MyAppProps>({ Component, pageProps, userLocation, query }) {
+  useRouterScroll({ top: 640 });
   const formMethods = useForm<FormInputData>({ mode: "onBlur" });
   // TODO: Work on CSRF token auth.
   const csrfToken = "";

--- a/src/hooks/useRouterScroll.tsx
+++ b/src/hooks/useRouterScroll.tsx
@@ -1,0 +1,44 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+// NOTE: This hook was copied from workaround code provided by nextjs
+// in https://github.com/vercel/next.js/issues/3249.
+
+/**
+ * React hook that forces a scroll reset to a particular set of coordinates
+ * in the document after `next/router` finishes transitioning to a new page
+ * client side. It smoothly scrolls back to the top by default.
+ *
+ * @see https://github.com/vercel/next.js/issues/3249
+ * @see https://github.com/vercel/next.js/issues/15206
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions
+ * @param {ScrollOptions} [options={}] Hook options.
+ * @param {ScrollBehavior} [options.behavior='smooth'] Specifies whether the
+ * scrolling should animate smoothly, or happen instantly in a single jump.
+ * @param {number} [options.left=0] Specifies the number of pixels along the
+ * X axis to scroll the window.
+ * @param {number} [options.top=0] Specifies the number of pixels along the
+ * Y axis to scroll the window.
+ */
+function useRouterScroll({ left = 0, top = 0 } = {}) {
+  const router = useRouter();
+  useEffect(() => {
+    // Scroll to given coordinates when router finishes navigating
+    // This fixes an inconsistent behaviour between `<Link/>` and `next/router`
+    // See https://github.com/vercel/next.js/issues/3249
+    const handleRouteChangeComplete = () => {
+      setTimeout(() => {
+        window.scrollTo({ top, left, behavior: "smooth" });
+      }, 300);
+    };
+
+    router.events.on("routeChangeComplete", handleRouteChangeComplete);
+
+    // If the component is unmounted, unsubscribe from the event
+    return () => {
+      router.events.off("routeChangeComplete", handleRouteChangeComplete);
+    };
+  }, [left, top]);
+}
+
+export default useRouterScroll;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -11,6 +11,9 @@
 @import 'components/congrats_page';
 
 // Global rules
+.content-primary {
+  margin: 30px 0;
+}
 
 .form-field {
   margin: 10px 0;


### PR DESCRIPTION
## Description

The workaround hook is provided by Next. Next's `Link` component correctly scrolls to the top of each page when routing, but the programmatic routing does not (when calling `router.push("url")`). So this just listens and scrolls to the top of the main content on the page whenever the routing is complete. I added a slight delay because of the API call going into the confirmation page.

## Motivation and Context

Resolves [DQ-400](https://jira.nypl.org/browse/DQ-400). Routing between pages was jumpy when submitting each page's form. This sort of fixes it until there's a better implementation by Next.

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
