### PR TITLE
Always display the home address

### DIFF
--- a/src/components/AccountForm/AccountForm.test.tsx
+++ b/src/components/AccountForm/AccountForm.test.tsx
@@ -70,4 +70,9 @@ describe("AccountForm", () => {
       screen.getByRole("textbox", { name: "Verify PIN Required" })
     ).toBeInTheDocument();
   });
+
+  test("renders the autosuggest dropdown", () => {
+    expect(screen.getByText("Home Library")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select a home library:")).toBeInTheDocument();
+  });
 });

--- a/src/components/AccountForm/index.tsx
+++ b/src/components/AccountForm/index.tsx
@@ -6,6 +6,8 @@ import UsernameValidationForm from "../UsernameValidationForm";
 import useFormDataContext from "../../context/FormDataContext";
 import { errorMessages } from "../../utils/formDataUtils";
 import { Checkbox } from "@nypl/design-system-react-components";
+import ilsLibraryList from "../../data/ilsLibraryList";
+import LibraryListForm from "../LibraryListForm";
 
 function AccountInformationForm() {
   const { register, errors, getValues } = useFormContext();
@@ -67,6 +69,8 @@ function AccountInformationForm() {
           onClick: update,
         }}
       />
+
+      <LibraryListForm libraryList={ilsLibraryList} />
     </>
   );
 }

--- a/src/components/AccountFormContainer/index.tsx
+++ b/src/components/AccountFormContainer/index.tsx
@@ -6,6 +6,7 @@ import useFormDataContext from "../../context/FormDataContext";
 import RoutingLinks from "../RoutingLinks.tsx";
 import AccountForm from "../AccountForm";
 import AcceptTermsForm from "../AcceptTermsForm";
+import { findLibraryCode } from "../../utils/formDataUtils";
 
 const AccountFormContainer = () => {
   const { state, dispatch } = useFormDataContext();
@@ -19,6 +20,8 @@ const AccountFormContainer = () => {
    * @param formData - data object returned from react-hook-form
    */
   const submitForm = (formData) => {
+    // Convert the home library name to its code value.
+    formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
     // Set the global form state...
     dispatch({
       type: "SET_FORM_DATA",

--- a/src/components/AddressForm/index.tsx
+++ b/src/components/AddressForm/index.tsx
@@ -21,7 +21,7 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
   // This component must be used within the `react-hook-form` provider so that
   // these functions are available to use.
   const { register, errors } = useFormContext();
-  const MAXLENGTHSTATE = 2;
+  const STATELENGTH = 2;
   const MINLENGTHZIP = 5;
   const MAXLENGTHZIP = 10;
   // Only the home address is required. The work address is optional.
@@ -36,7 +36,7 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
    * @param length Max length of the field input.
    * @param field The key name of the field.
    */
-  const lengthValidation = (max, field, min = undefined) => (value) => {
+  const lengthValidation = (min, max, field) => (value) => {
     if (!min) {
       return !isRequired || value.length <= max || errorMessages[field];
     }
@@ -96,9 +96,9 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
             fieldName={`${type}-state`}
             isRequired={isRequired}
             errorState={errors}
-            maxLength={MAXLENGTHSTATE}
+            maxLength={STATELENGTH}
             ref={register({
-              validate: lengthValidation(MAXLENGTHSTATE, "state"),
+              validate: lengthValidation(STATELENGTH, STATELENGTH, "state"),
             })}
             defaultValue={formValues[`${type}-state`]}
           />
@@ -115,7 +115,7 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
             minLength={MINLENGTHZIP}
             maxLength={MAXLENGTHZIP}
             ref={register({
-              validate: lengthValidation(MAXLENGTHZIP, "zip", MINLENGTHZIP),
+              validate: lengthValidation(MINLENGTHZIP, MAXLENGTHZIP, "zip"),
             })}
             defaultValue={formValues[`${type}-zip`]}
           />

--- a/src/components/LibraryListForm/LibraryListForm.module.css
+++ b/src/components/LibraryListForm/LibraryListForm.module.css
@@ -1,0 +1,6 @@
+.container {
+  border-top: 1px solid var(--ui-gray-medium);
+  border-bottom: 1px solid var(--ui-gray-medium);
+  margin: 10px 0 20px;
+  padding: 15px 0px 0px 0px;
+}

--- a/src/components/LibraryListForm/index.tsx
+++ b/src/components/LibraryListForm/index.tsx
@@ -5,6 +5,7 @@ import FormField from "../FormField";
 import useFormDataContext from "../../context/FormDataContext";
 import { findLibraryName } from "../../utils/formDataUtils";
 import { LibraryListObject } from "../../interfaces";
+import styles from "./LibraryListForm.module.css";
 
 interface LibraryListFormProps {
   libraryList: LibraryListObject[];
@@ -98,7 +99,7 @@ const LibraryListForm = ({ libraryList = [] }: LibraryListFormProps) => {
   );
 
   return (
-    <>
+    <div className={styles.container}>
       <h3>Home Library</h3>
       <p>
         Choosing a home library will help us make sure you&apos;re getting
@@ -116,7 +117,7 @@ const LibraryListForm = ({ libraryList = [] }: LibraryListFormProps) => {
         renderInputComponent={renderInputComponent}
         renderSuggestionsContainer={renderSuggestionsContainer}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/components/LocationAddressContainer/LocationAddressContainer.test.tsx
+++ b/src/components/LocationAddressContainer/LocationAddressContainer.test.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import React, { useRef } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import LocationAddressContainer from ".";
+import { TestProviderWrapper } from "../../../testHelper/utils";
+
+expect.extend(toHaveNoViolations);
+
+describe("LocationAddressContainer", () => {
+  test("passes axe accessibility checks", async () => {
+    const { container } = render(
+      <TestProviderWrapper>
+        <LocationAddressContainer scrollRef={null} />
+      </TestProviderWrapper>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  test("it renders three location radio input", async () => {
+    render(
+      <TestProviderWrapper>
+        <LocationAddressContainer scrollRef={null} />
+      </TestProviderWrapper>
+    );
+    expect(
+      screen.getByLabelText("New York City (All five boroughs)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("New York State (Outside NYC)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("United States (Visiting NYC)")
+    ).toBeInTheDocument();
+  });
+
+  test("it doesn't render any address fields since no location is selected", () => {
+    render(
+      <TestProviderWrapper>
+        <LocationAddressContainer scrollRef={null} />
+      </TestProviderWrapper>
+    );
+
+    expect(screen.queryByLabelText("Home Address")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Work Address")).not.toBeInTheDocument();
+  });
+
+  test("it renders home and work address fields", async () => {
+    render(
+      <TestProviderWrapper>
+        <LocationAddressContainer scrollRef={null} />
+      </TestProviderWrapper>
+    );
+
+    const radionyc = screen.getByLabelText(
+      "New York City (All five boroughs)",
+      {
+        selector: "input",
+      }
+    ) as HTMLInputElement;
+
+    await fireEvent.click(radionyc);
+
+    expect(radionyc).toBeChecked();
+    expect(screen.getByText("Home Address")).toBeInTheDocument();
+    expect(screen.getByText("Work Address")).toBeInTheDocument();
+  });
+});

--- a/src/components/LocationAddressContainer/LocationAddressContainer.test.tsx
+++ b/src/components/LocationAddressContainer/LocationAddressContainer.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import React, { useRef } from "react";
+import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { axe, toHaveNoViolations } from "jest-axe";
 import LocationAddressContainer from ".";

--- a/src/components/LocationAddressContainer/index.tsx
+++ b/src/components/LocationAddressContainer/index.tsx
@@ -6,10 +6,8 @@ import axios from "axios";
 import useFormDataContext from "../../context/FormDataContext";
 import AddressForm from "../AddressForm";
 import RoutingLinks from "../RoutingLinks.tsx";
-import LibraryListForm from "../LibraryListForm";
 import LocationForm from "../LocationForm";
-import ilsLibraryList from "../../data/ilsLibraryList";
-import { errorMessages, findLibraryCode } from "../../utils/formDataUtils";
+import { errorMessages } from "../../utils/formDataUtils";
 import { Accordion } from "@nypl/design-system-react-components";
 import {
   AddressRenderType,
@@ -38,8 +36,6 @@ const LocationAddressContainer = ({
    * @param formData - data object returned from react-hook-form
    */
   const submitForm = (formData) => {
-    // Convert the home library name to its code value.
-    formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
     // Set the global form state...
     dispatch({
       type: "SET_FORM_DATA",
@@ -104,13 +100,7 @@ const LocationAddressContainer = ({
    * home library. The two parameters are required to be explicit about what
    * fields will be rendered when the function is called.
    */
-  const addressFields = ({
-    work,
-    homeLibrary,
-  }: {
-    work: boolean;
-    homeLibrary: boolean;
-  }) => (
+  const addressFields = (displayWork: boolean) => (
     <>
       <div className={styles.addressSection}>
         <h3>Home Address</h3>
@@ -123,7 +113,7 @@ const LocationAddressContainer = ({
         />
       </div>
 
-      {work && (
+      {displayWork && (
         <div className={styles.addressSection}>
           <h3>Work Address</h3>
           <Accordion
@@ -137,8 +127,6 @@ const LocationAddressContainer = ({
           </Accordion>
         </div>
       )}
-
-      {homeLibrary && <LibraryListForm libraryList={ilsLibraryList} />}
     </>
   );
 
@@ -151,13 +139,13 @@ const LocationAddressContainer = ({
             value: "nyc",
             label: "New York City (All five boroughs)",
             ref: register(),
-            addressFields: addressFields({ work: true, homeLibrary: true }),
+            addressFields: addressFields(true),
           },
           {
             value: "nys",
             label: "New York State (Outside NYC)",
             ref: register(),
-            addressFields: addressFields({ work: true, homeLibrary: false }),
+            addressFields: addressFields(true),
           },
           {
             value: "us",
@@ -167,7 +155,7 @@ const LocationAddressContainer = ({
             ref: register({
               required: errorMessages.location,
             }),
-            addressFields: addressFields({ work: false, homeLibrary: false }),
+            addressFields: addressFields(false),
           },
         ]}
       />

--- a/src/components/LocationAddressContainer/index.tsx
+++ b/src/components/LocationAddressContainer/index.tsx
@@ -74,7 +74,7 @@ const LocationAddressContainer = ({
           value.home = {
             address: initialAddresses.home,
             addresses: [],
-            message: "",
+            detail: "",
           };
         }
         if (error.response?.data?.work) {
@@ -83,7 +83,7 @@ const LocationAddressContainer = ({
           value.work = {
             address: initialAddresses.work,
             addresses: [],
-            message: "",
+            detail: "",
           };
         }
         dispatch({

--- a/src/components/LocationAddressContainer/index.tsx
+++ b/src/components/LocationAddressContainer/index.tsx
@@ -30,7 +30,8 @@ const LocationAddressContainer = ({
   const { formValues } = state;
   const router = useRouter();
   // Specific functions and object from react-hook-form.
-  const { handleSubmit, register } = useFormContext();
+  const { handleSubmit, register, watch } = useFormContext();
+  const selectedLocation = watch("location");
 
   /**
    * submitForm
@@ -113,15 +114,13 @@ const LocationAddressContainer = ({
     <>
       <div className={styles.addressSection}>
         <h3>Home Address</h3>
-        <Accordion
-          id="home-address-accordion"
-          accordionLabel="If you live in NYC, please fill out the home address form."
-        >
-          <AddressForm
-            type={AddressTypes.Home}
-            errorMessages={errorMessages.address}
-          />
-        </Accordion>
+        {selectedLocation === "nyc" && (
+          <p>If you live in NYC, please fill out the home address form.</p>
+        )}
+        <AddressForm
+          type={AddressTypes.Home}
+          errorMessages={errorMessages.address}
+        />
       </div>
 
       {work && (
@@ -129,7 +128,7 @@ const LocationAddressContainer = ({
           <h3>Work Address</h3>
           <Accordion
             id="work-address-accordion"
-            accordionLabel="If you live in NYC, please fill out the work address form."
+            accordionLabel="If you work in NYC, please fill out the work address form."
           >
             <AddressForm
               type={AddressTypes.Work}

--- a/src/styles/components/autosuggest.scss
+++ b/src/styles/components/autosuggest.scss
@@ -3,10 +3,10 @@
 }
 
 .react-autosuggest__input {
-  padding: 10px 0 !important;
+  padding: 0 !important;
   border: none !important;
 }
 
 .react-autosuggest__suggestions-container--open {
-  top: 80px !important;
+  top: 67px !important;
 }


### PR DESCRIPTION
## Description

The home address fields should always display to the user and not be hidden behind an accordion component. Also added some tests that were missing.

## Motivation and Context

Resolves [DQ-417](https://jira.nypl.org/browse/DQ-417).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
