### PR TITLE
No-javascript validation flow

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,7 @@ import IPLocationAPI from "../src/utils/IPLocationAPI";
 import enableAxe from "../src/utils/axe";
 import { getPageTitles } from "../src/utils/utils";
 import useRouterScroll from "../src/hooks/useRouterScroll";
+import { constructProblemDetail } from "../src/utils/formDataUtils";
 
 interface MyAppProps {
   Component: any;
@@ -53,14 +54,32 @@ function MyApp<MyAppProps>({ Component, pageProps, userLocation, query }) {
   const csrfToken = "";
   const { favIconPath, appTitle } = appConfig;
 
-  // TODO: Display the errors for individual pages.
-  let errors;
+  let error;
+  // These errors are from the server-side query string form submission.
   if (!isEmpty(query.errors)) {
-    errors = JSON.parse(query.errors);
+    const errorObject = JSON.parse(query.errors);
+    // If we already received a problem detail, just forward it. Problme
+    // details get sent when a request is sent to the NYPL Platform API.
+    // If we get simple errors from form field validation, create the problem
+    // detail for the errors.
+    if (errorObject?.status) {
+      error = errorObject;
+    } else {
+      error = constructProblemDetail(
+        400,
+        "invalid-request",
+        "Invalid Request",
+        "There were errors with your submission.",
+        errorObject
+      );
+    }
     // We don't want to keep the errors in this object since it's
     // going to go into the app's store.
     delete query.errors;
   }
+  // These are results specifically from the `/library-card/api/create-patron`
+  // API endpoint, which makes a request to the NYPL Platform API. These are
+  // results from the server-side form submission.
   if (!isEmpty(query.results)) {
     formInitialStateCopy.results = JSON.parse(query.results);
   }
@@ -151,7 +170,7 @@ function MyApp<MyAppProps>({ Component, pageProps, userLocation, query }) {
       </Head>
       <FormProvider {...formMethods}>
         <FormDataContextProvider initState={initState}>
-          <ApplicationContainer>
+          <ApplicationContainer problemDetail={error}>
             <Component
               {...pageProps}
               pageTitles={pageTitles}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -172,10 +172,9 @@ MyApp.getInitialProps = async ({ ctx }) => {
   if (ctx.req?.headers) {
     userLocation = await IPLocationAPI.getLocationFromIP(ctx);
   }
-  const query = ctx.query;
 
   // Send it to the component as a prop.
-  return { userLocation, query };
+  return { userLocation, query: ctx.query };
 };
 
 export default MyApp;

--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -25,6 +25,7 @@ import {
 async function serverSubmit(req: NextApiRequest, res: NextApiResponse) {
   // Run the request through the middleware.
   await runMiddleware(req, res, cors);
+  // Get a token to be able to call the NYPL API.
   await initializeAppAuth(req, res);
 
   let newSubmittedValues = { ...req.body };

--- a/pages/api/submit.ts
+++ b/pages/api/submit.ts
@@ -1,5 +1,21 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { runMiddleware, cors } from "../../src/utils/api";
+import isEmpty from "lodash/isEmpty";
+import {
+  runMiddleware,
+  cors,
+  initializeAppAuth,
+  callPatronAPI,
+} from "../../src/utils/api";
+import {
+  validatePersonalFormData,
+  validateAddressFormData,
+  validateAccountFormData,
+  constructAddresses,
+} from "../../src/utils/formDataUtils";
+import {
+  createQueryParams,
+  createNestedQueryParams,
+} from "../../src/utils/utils";
 
 /**
  * serverSubmit
@@ -9,6 +25,8 @@ import { runMiddleware, cors } from "../../src/utils/api";
 async function serverSubmit(req: NextApiRequest, res: NextApiResponse) {
   // Run the request through the middleware.
   await runMiddleware(req, res, cors);
+  await initializeAppAuth(req, res);
+
   let newSubmittedValues = { ...req.body };
   // All already submitted values are stored here so we dont run validations
   // on those values again.
@@ -19,44 +37,86 @@ async function serverSubmit(req: NextApiRequest, res: NextApiResponse) {
   delete newSubmittedValues.formValues;
   delete existingValues.newCard;
 
-  let page;
+  // The default is the current page. If there are no errors, then this gets
+  // updated and we can proceed to the next page.
+  let page = currentPage;
   let queryValues = "";
+  let addresses;
+  let results;
+  let errors;
 
-  // TODO: run values through validation. After the new form field values
-  // are validated, then merge all together:
-  newSubmittedValues = { ...newSubmittedValues, ...existingValues };
-  for (const [key, value] of Object.entries(newSubmittedValues)) {
-    queryValues += `&${key}=${value}`;
-  }
-  // A switch statement so later on we can do form value validation on specific
-  // fields based on the current page.
   switch (currentPage) {
     case "personal":
-      page = "location";
+      // Validate the form values for this specific step.
+      errors = validatePersonalFormData({}, newSubmittedValues);
+      if (isEmpty(errors)) {
+        page = "location";
+      }
       break;
     case "location":
-      page = "workAddress";
+      addresses = constructAddresses(newSubmittedValues);
+      errors = validateAddressFormData({}, addresses);
+      if (isEmpty(errors)) {
+        if (newSubmittedValues.location !== "nyc") {
+          page = "workAddress";
+        } else {
+          page = "account";
+        }
+      }
       break;
     case "workAddress":
-      page = "address-verification";
-      // TODO: Do address API call here.
-      break;
-    case "addressVerification":
-      page = "account";
+      // We need to add the existing home address values since
+      // `validateAddressFormData` checks for both home and work addresses.
+      addresses = constructAddresses({
+        ...newSubmittedValues,
+        ...existingValues,
+      });
+      errors = validateAddressFormData({}, addresses);
+      if (isEmpty(errors)) {
+        page = "account";
+      }
       break;
     case "account":
-      page = "review";
+      errors = validateAccountFormData({}, newSubmittedValues);
+      if (isEmpty(errors)) {
+        page = "review";
+      }
       break;
     case "review":
-      page = "congrats";
-      // TODO: Call the `createPatron` function with all the form values here.
+      try {
+        // All the data values are in the `existingValues` variable since
+        // no new data is submitted on the "review" page. When JS is not on,
+        // checkbox values are submitted as "on" and "off". We need to convert
+        // the values into booleans for the API to understand.
+        for (const [key, value] of Object.entries(existingValues)) {
+          if (value === "on") {
+            existingValues[key] = true;
+          } else if (value === "off") {
+            existingValues[key] = false;
+          }
+        }
+        // If the API call was successful and a patron account was created,
+        // go to the congrats page and display the results.
+        results = await callPatronAPI(existingValues);
+        page = "congrats";
+      } catch (error) {
+        errors = error;
+      }
       break;
     default:
       page = "new";
       break;
   }
 
-  return res.redirect(`/library-card/${page}?newCard=true${queryValues}`);
+  newSubmittedValues = { ...existingValues, ...newSubmittedValues };
+  queryValues =
+    createQueryParams(newSubmittedValues) +
+    createNestedQueryParams(errors, "errors") +
+    createNestedQueryParams(results, "results");
+
+  return res.redirect(
+    `/library-card/${page}?${encodeURI(`newCard=true${queryValues}`)}`
+  );
 }
 
 export default serverSubmit;

--- a/src/components/ApiErrors/index.tsx
+++ b/src/components/ApiErrors/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React from "react";
-import isEmpty from "lodash/isEmpty";
 import {
   renderErrorElements,
   createUsernameAnchor,

--- a/src/components/ApplicationContainer/index.tsx
+++ b/src/components/ApplicationContainer/index.tsx
@@ -1,24 +1,45 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Header, navConfig } from "@nypl/dgx-header-component";
 import Footer from "@nypl/dgx-react-footer";
 import Banner from "../Banner";
+import ApiErrors from "../ApiErrors";
+import useFormDataContext from "../../context/FormDataContext";
 
-const ApplicationContainer: React.FC = ({ children }) => (
-  <>
-    <Header skipNav={{ target: "main-content" }} navData={navConfig.current} />
-    <div className="nypl-library-card-app layout-container nypl-ds">
-      <main id="main-content" className="main main--with-sidebar">
-        <div className="content-header">
-          <Banner />
-        </div>
-        <div className="content-primary content-primary--with-sidebar-right">
-          {children}
-        </div>
-        <div className="content-secondary content-secondary--with-sidebar-right" />
-      </main>
-    </div>
-    <Footer />
-  </>
-);
+const ApplicationContainer = ({ children, problemDetail }) => {
+  const errorSection = React.createRef<HTMLDivElement>();
+  const { state } = useFormDataContext();
+  const { errorObj } = state;
+  const errorToDisplay = problemDetail ? problemDetail : errorObj;
+
+  // If there are errors, focus on the element that displays those errors,
+  // for client-side rendering.
+  useEffect(() => {
+    if (errorToDisplay) {
+      errorSection.current.focus();
+    }
+  }, [errorToDisplay]);
+
+  return (
+    <>
+      <Header
+        skipNav={{ target: "main-content" }}
+        navData={navConfig.current}
+      />
+      <div className="nypl-library-card-app layout-container nypl-ds">
+        <main id="main-content" className="main main--with-sidebar">
+          <div className="content-header">
+            <Banner />
+          </div>
+          <div className="content-primary content-primary--with-sidebar-right">
+            <ApiErrors ref={errorSection} problemDetail={errorToDisplay} />
+            {children}
+          </div>
+          <div className="content-secondary content-secondary--with-sidebar-right" />
+        </main>
+      </div>
+      <Footer />
+    </>
+  );
+};
 
 export default ApplicationContainer;

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -20,7 +20,6 @@ import {
 import PersonalFormFields from "../PersonalFormFields";
 import AccountFormFields from "../AccountFormFields";
 import RoutingLinks from "../RoutingLinks.tsx";
-import ApiErrors from "../ApiErrors";
 import styles from "./ReviewFormContainer.module.css";
 import AcceptTermsFormFields from "../AcceptTermsFormFields";
 import Loader from "../Loader";
@@ -33,7 +32,6 @@ import { lcaEvents } from "../../externals/gaUtils";
 function ReviewFormContainer() {
   const [isLoading, setIsLoading] = useState(false);
   const { handleSubmit } = useFormContext();
-  const errorSection = React.createRef<HTMLDivElement>();
   const { state, dispatch } = useFormDataContext();
   const { formValues, errorObj } = state;
   const router = useRouter();
@@ -54,7 +52,6 @@ function ReviewFormContainer() {
   // bad requests.
   useEffect(() => {
     if (errorObj) {
-      errorSection.current.focus();
       document.title = "Form Submission Error | NYPL";
       // When we display errors, we want to go into the "Edit" state so
       // that it's easier to go to input fields from the error messages.
@@ -303,7 +300,6 @@ function ReviewFormContainer() {
   return (
     <>
       <Loader isLoading={isLoading} />
-      <ApiErrors ref={errorSection} problemDetail={errorObj} />
 
       <div className={styles.formSection}>
         <h3>Personal Information</h3>

--- a/src/utils/__tests__/formDataUtils.test.ts
+++ b/src/utils/__tests__/formDataUtils.test.ts
@@ -9,6 +9,8 @@ import {
   constructAddresses,
   constructProblemDetail,
   validateAddressFormData,
+  validatePersonalFormData,
+  validateAccountFormData,
   validateFormData,
   constructPatronObject,
 } from "../formDataUtils";
@@ -275,6 +277,97 @@ describe("validateAddressFormData", () => {
           zip: errorMessages.address.zip,
         },
       },
+    });
+  });
+});
+
+describe("validatePersonalFormData", () => {
+  test("it should return errors for all bad fields", () => {
+    const data = {
+      firstName: "",
+      lastName: "",
+      birthdate: "",
+      email: "",
+      policyType: "webApplicant",
+    };
+
+    expect(validatePersonalFormData({}, data)).toEqual({
+      firstName: errorMessages.firstName,
+      lastName: errorMessages.lastName,
+      email: errorMessages.email,
+      birthdate: errorMessages.birthdate,
+    });
+  });
+
+  test("it should return an empty object since there are no errors", () => {
+    const data = {
+      firstName: "Tom",
+      lastName: "Nook",
+      birthdate: "01/01/1999",
+      email: "tomnook@acnh.com",
+      policyType: "webApplicant",
+    };
+
+    expect(validatePersonalFormData({}, data)).toEqual({});
+  });
+
+  test("it should add erros to the existing error object", () => {
+    const errors = { someKey: "some value" };
+    const data = {
+      firstName: "",
+      lastName: "Nook",
+      birthdate: "01/01/1999",
+      email: "tomnook@acnh.com",
+      policyType: "webApplicant",
+    };
+
+    expect(validatePersonalFormData(errors, data)).toEqual({
+      ...errors,
+      firstName: errorMessages.firstName,
+    });
+  });
+});
+
+describe("validateAccountFormData", () => {
+  test("it should return errors for all bad fields", () => {
+    const data = {
+      username: "",
+      pin: "",
+      verifyPin: "",
+      acceptTerms: "",
+    };
+
+    expect(validateAccountFormData({}, data)).toEqual({
+      username: errorMessages.username,
+      pin: errorMessages.pin,
+      verifyPin: errorMessages.verifyPin,
+      acceptTerms: errorMessages.acceptTerms,
+    });
+  });
+
+  test("it should return an empty object since there are no errors", () => {
+    const data = {
+      username: "tomnook",
+      pin: "1234",
+      verifyPin: "1234",
+      acceptTerms: true,
+    };
+
+    expect(validateAccountFormData({}, data)).toEqual({});
+  });
+
+  test("it should add erros to the existing error object", () => {
+    const errors = { someKey: "some value" };
+    const data = {
+      username: "",
+      pin: "1234",
+      verifyPin: "1234",
+      acceptTerms: true,
+    };
+
+    expect(validateAccountFormData(errors, data)).toEqual({
+      ...errors,
+      username: errorMessages.username,
     });
   });
 });

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
-import { getPageTitles } from "../utils";
+import {
+  getPageTitles,
+  createQueryParams,
+  createNestedQueryParams,
+} from "../utils";
 
 describe("getPageTiles", () => {
   test("it returns text saying there are 5 steps if the user is in nyc", () => {
@@ -30,5 +34,44 @@ describe("getPageTiles", () => {
     expect(getPageTitles(userLocationEmpty)).toEqual(sixStepTitles);
     expect(getPageTitles(userLocationUS)).toEqual(sixStepTitles);
     expect(getPageTitles(userLocationNYS)).toEqual(sixStepTitles);
+  });
+});
+
+describe("createQueryParams", () => {
+  test("it should return an empty string with an empty object", () => {
+    expect(createQueryParams({})).toEqual("");
+  });
+
+  test("it should return a url query string", () => {
+    const data = {
+      key1: "value1",
+      key2: "value2",
+      key3: "value3",
+    };
+    expect(createQueryParams(data)).toEqual(
+      "&key1=value1&key2=value2&key3=value3"
+    );
+  });
+});
+
+describe("createNestedQueryParams", () => {
+  test("it should return an empty string with an empty string or type argument", () => {
+    expect(createNestedQueryParams({}, "key")).toEqual("");
+    expect(createNestedQueryParams({ key: "somevalue" }, "")).toEqual("");
+  });
+
+  test("it should return a nested url query string", () => {
+    const data = {
+      key1: "value1",
+      key2: "value2",
+      key3: "value3",
+    };
+    expect(createNestedQueryParams(data, "results")).toEqual(
+      `&results=${JSON.stringify(data)}`
+    );
+
+    expect(createNestedQueryParams(data, "errors")).toEqual(
+      `&errors=${JSON.stringify(data)}`
+    );
   });
 });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -304,11 +304,16 @@ export async function validateUsername(
     );
 }
 
+/**
+ * callPatronAPI
+ * Make a validated call to the NYPL Patrons API endpoint to create a patron
+ * ILS account.
+ */
 export async function callPatronAPI(
   data,
   createPatronUrl = config.api.patron,
   appObj = app
-): Promise<any> {
+) {
   const tokenObject = appObj["tokenObject"];
   if (tokenObject && tokenObject.access_token) {
     const token = tokenObject.access_token;
@@ -381,11 +386,22 @@ export async function callPatronAPI(
   );
 }
 
-export async function createPatron(req, res) {
+/**
+ * createPatron
+ * Internally, this make a call to `createPatron` and the NYPL Patrons API to
+ * create a patron ILS account. This just returns that result as JSON for the
+ * `/library-card/api/create-patron` endpoint.
+ */
+export async function createPatron(
+  req,
+  res,
+  createPatronUrl = config.api.patron,
+  appObj = app
+) {
   const data = req.body;
 
   try {
-    const response = await callPatronAPI(data);
+    const response = await callPatronAPI(data, createPatronUrl, appObj);
     return res.json(response);
   } catch (error) {
     return res.status(error.status).json(error);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -285,6 +285,7 @@ export async function validateUsername(
       })
       .catch((err) => {
         return res.status(err.response.status).json({
+          status: err.response.status,
           ...err.response?.data,
         });
       });
@@ -303,45 +304,17 @@ export async function validateUsername(
     );
 }
 
-export async function createPatron(
-  req,
-  res,
+export async function callPatronAPI(
+  data,
   createPatronUrl = config.api.patron,
   appObj = app
-) {
+): Promise<any> {
   const tokenObject = appObj["tokenObject"];
   if (tokenObject && tokenObject.access_token) {
     const token = tokenObject.access_token;
-    const patronData = constructPatronObject(req.body);
-    if ((patronData as ProblemDetail).status === 400) {
-      logger.error("Invalid patron data");
-      return res.status(400).json(patronData);
-    }
-
-    // Just for testing purposes locally. Used to verify refs and focus are
-    // properly working but also to update the server response interface/type
-    // later on.
-    // return res.status(400).json({
-    //   status: 400,
-    //   response: {
-    //     type: "invalid-request",
-    //     title: "Invalid Request",
-    //     detail: "There were errors in the submission.",
-    //     error: {
-    //       firstName: "First Name field is empty.",
-    //       lastName: "Last Name field is empty.",
-    //       birthdate: "Date of Birth field is empty.",
-    //       line1: "Street Address field is empty.",
-    //       city: "City field is empty.",
-    //       state: "State field is empty.",
-    //       zip: "Postal Code field is empty.",
-    //       username: "Username field is empty.",
-    //       pin: "PIN field is empty.",
-    //     },
-    //   },
-    // });
-    // Uncomment to test routing to a confirmation page with test data.
-    // return res.status(200).json({
+    const patronData = constructPatronObject(data);
+    // Used for testing:
+    // return Promise.resolve({
     //   status: 200,
     //   type: "card-granted",
     //   link: "some-link",
@@ -353,18 +326,22 @@ export async function createPatron(
     //   patronId: 1234567,
     //   name: "Tom Nook",
     // });
+    if ((patronData as ProblemDetail).status === 400) {
+      logger.error("Invalid patron data");
+      return Promise.reject(patronData);
+    }
 
     return axios
       .post(createPatronUrl, patronData, constructApiHeaders(token))
       .then((result) => {
-        return res.json({
+        return Promise.resolve({
           status: result.data.status,
           name: (patronData as FormAPISubmission).name,
           ...result.data,
         });
       })
       .catch((err) => {
-        const status = err.response.status;
+        const status = err.response?.status;
         let serverError = null;
 
         // If the response from the Patron Creator Service
@@ -375,34 +352,42 @@ export async function createPatron(
         }
 
         const restOfErrors = serverError
-          ? { ...err.response.data, ...serverError }
-          : err.response.data;
+          ? { ...err.response?.data, ...serverError }
+          : err.response?.data;
 
         logger.error(
           `Error calling Card Creator API: ${
-            status === 403 ? "bad API call" : err.response.data.message
+            status === 403 ? "bad API call" : err.response?.data?.message
           }`
         );
-        return res.status(err.response.status).json({
-          status: err.response.status,
+        return Promise.reject({
+          status,
           ...restOfErrors,
         });
       });
   }
-
-  // Else return a no token error.
+  // Else return a "no token generated" error.
   const tokenGenerationError =
     "The access token could not be generated before calling the Card Creator API.";
 
   logger.error(tokenGenerationError);
-  return res
-    .status(500)
-    .json(
-      constructProblemDetail(
-        500,
-        "no-access-token",
-        "No Access Token",
-        tokenGenerationError
-      )
-    );
+  return Promise.reject(
+    constructProblemDetail(
+      500,
+      "no-access-token",
+      "No Access Token",
+      tokenGenerationError
+    )
+  );
+}
+
+export async function createPatron(req, res) {
+  const data = req.body;
+
+  try {
+    const response = await callPatronAPI(data);
+    return res.json(response);
+  } catch (error) {
+    return res.status(error.status).json(error);
+  }
 }

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -236,29 +236,15 @@ const validateAddressFormData = (initErrorObj, addresses: Addresses) => {
 };
 
 /**
- * validateFormData
- * Validates the form submission values and returns any errors. Internally, it
- * uses `validateAddressFormData` to validate home and work addresses.
+ * validatePersonalFormData
  */
-const validateFormData = (object, addresses) => {
-  const {
-    firstName,
-    lastName,
-    email,
-    birthdate,
-    ageGate,
-    policyType,
-    username,
-    pin,
-    verifyPin,
-    acceptTerms,
-  } = object;
-  let errorObj = {};
+const validatePersonalFormData = (initErrorObj, data) => {
+  let errorObj = { ...initErrorObj };
+  const { firstName, lastName, birthdate, ageGate, email, policyType } = data;
 
   if (isEmpty(firstName)) {
     errorObj = { ...errorObj, firstName: errorMessages.firstName };
   }
-
   if (isEmpty(lastName)) {
     errorObj = { ...errorObj, lastName: errorMessages.lastName };
   }
@@ -279,14 +265,19 @@ const validateFormData = (object, addresses) => {
       ageGate: errorMessages.ageGate,
     };
   }
-
-  if (!acceptTerms) {
-    errorObj = { ...errorObj, acceptTerms: errorMessages.acceptTerms };
-  }
-
   if (isEmpty(email) || !isEmail(email)) {
     errorObj = { ...errorObj, email: errorMessages.email };
   }
+
+  return errorObj;
+};
+
+/**
+ * validateAccountFormData
+ */
+const validateAccountFormData = (initErrorObj, data) => {
+  let errorObj = { ...initErrorObj };
+  const { username, pin, verifyPin, acceptTerms } = data;
 
   if (
     isEmpty(username) ||
@@ -306,8 +297,23 @@ const validateFormData = (object, addresses) => {
   if (isEmpty(verifyPin) || pin !== verifyPin) {
     errorObj = { ...errorObj, verifyPin: errorMessages.verifyPin };
   }
+  if (!acceptTerms) {
+    errorObj = { ...errorObj, acceptTerms: errorMessages.acceptTerms };
+  }
 
+  return errorObj;
+};
+
+/**
+ * validateFormData
+ * Validates the form submission values and returns any errors. Internally, it
+ * uses `validateAddressFormData` to validate home and work addresses.
+ */
+const validateFormData = (data, addresses) => {
+  // Initially, there are no errors so the first param is an empty object.
+  let errorObj = validatePersonalFormData({}, data);
   errorObj = validateAddressFormData(errorObj, addresses);
+  errorObj = validateAccountFormData(errorObj, data);
 
   return errorObj;
 };
@@ -379,7 +385,9 @@ export {
   constructAddresses,
   constructAddressType,
   constructProblemDetail,
-  validateAddressFormData,
-  validateFormData,
   constructPatronObject,
+  validateFormData,
+  validatePersonalFormData,
+  validateAddressFormData,
+  validateAccountFormData,
 };

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -237,6 +237,7 @@ const validateAddressFormData = (initErrorObj, addresses: Addresses) => {
 
 /**
  * validatePersonalFormData
+ * * Validates the firstName, lastName, birthdate, ageGate, and email fields.
  */
 const validatePersonalFormData = (initErrorObj, data) => {
   let errorObj = { ...initErrorObj };
@@ -274,6 +275,7 @@ const validatePersonalFormData = (initErrorObj, data) => {
 
 /**
  * validateAccountFormData
+ * Validates the username, pin, verifyPin, and acceptTerms fields.
  */
 const validateAccountFormData = (initErrorObj, data) => {
   let errorObj = { ...initErrorObj };
@@ -307,7 +309,9 @@ const validateAccountFormData = (initErrorObj, data) => {
 /**
  * validateFormData
  * Validates the form submission values and returns any errors. Internally, it
- * uses `validateAddressFormData` to validate home and work addresses.
+ * uses other functions to validate groups of data separately, to make it
+ * easier to validate data on a per page basis if it needs to, and then all at
+ * once here.
  */
 const validateFormData = (data, addresses) => {
   // Initially, there are no errors so the first param is an empty object.

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { PageTitles } from "../interfaces";
+import isEmpty from "lodash/isEmpty";
 
 /**
  * getPageTitles
@@ -31,6 +32,10 @@ export function getPageTitles(userLocation: string): PageTitles {
   };
 }
 
+/**
+ * createQueryParams
+ * Converts an object into key/value pairs to be use as url query params.
+ */
 export const createQueryParams = (obj) => {
   let query = "";
   for (const [key, value] of Object.entries(obj)) {
@@ -39,10 +44,17 @@ export const createQueryParams = (obj) => {
   return query;
 };
 
-export const createNestedQueryParams = (dataAsString = "", type) => {
+/**
+ * createNestedQueryParams
+ * Stringifies an object to be used as the value for a specified key in a url
+ * query param string. This makes it easier to group together errors and
+ * results and doesn't override any existing url queries if the same key name
+ * appears more than once.
+ */
+export const createNestedQueryParams = (dataAsString = {}, key) => {
   let query = "";
-  if (dataAsString) {
-    query = `&${type}=${JSON.stringify(dataAsString)}`;
+  if (!isEmpty(dataAsString) && key) {
+    query = `&${key}=${JSON.stringify(dataAsString)}`;
   }
   return query;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -30,3 +30,19 @@ export function getPageTitles(userLocation: string): PageTitles {
     review: "Step 6 of 6: Review Your Information",
   };
 }
+
+export const createQueryParams = (obj) => {
+  let query = "";
+  for (const [key, value] of Object.entries(obj)) {
+    query += `&${key}=${value}`;
+  }
+  return query;
+};
+
+export const createNestedQueryParams = (dataAsString = "", type) => {
+  let query = "";
+  if (dataAsString) {
+    query = `&${type}=${JSON.stringify(dataAsString)}`;
+  }
+  return query;
+};


### PR DESCRIPTION
## Description

This updates the no-js routing PR by adding the basic form validation functions through the form data. This is done on a per-page basis every time the user submits on a page. There is a `TODO` where the error is read and displayed but that's for the next PR. The validation is the simple "is the field empty or is it the specified length?" tests that get run on the client-side before making a call to create a patron. So now, each group of validation is broken up into separate functions to be able to test both individual pages and also all the data at once at the very end. The bulk of the work is still done in the `/library-card/api/submit` endpoint. What is **not** done is address validation from the "home/work address" page to the "address verification" page; this is more complicated and maybe not needed so for now it's left out.

As you go through the app when there is no javascript, on each form page submission, the submitted data goes through validation and then merged with any existing form values (from previous pages). If all is good, all that data gets converted into a URL query string. This may not be the best way to do this but for now this is fine.

If there are any errors on a specific page, the user stays on the same page and the errors get sent to the client. Rendering that error object is the next step.

End-to-end, submitting the form and creating an account works with and without javascript. One thing that I did encounter which I will need UX help is an error submission when creating an account. The previous pages don't do validations that involve API requests for addresses or the username. So if you are at the end and it turns out your username is not available, you get that message but you can't update your submission on that page. That's because the "display/edit" view for each form works with javascript. So that's something for the next PR when error messages get displayed.

## Motivation and Context

Resolves [DQ-425](https://jira.nypl.org/browse/DQ-425).

## How Has This Been Tested?

Locally with javascript turned off.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
