### PR TITLE
Rendering no-js server side errors to the UI.

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -55,11 +55,13 @@ function MyApp<MyAppProps>({ Component, pageProps, userLocation, query }) {
   const { favIconPath, appTitle } = appConfig;
 
   let error;
-  // These errors are from the server-side query string.
+  // These errors are from the server-side query string form submission.
   if (!isEmpty(query.errors)) {
     const errorObject = JSON.parse(query.errors);
-    // If we already received a problem detail, just forward it. Otherwise,
-    // create a problem detail for the errors.
+    // If we already received a problem detail, just forward it. Problme
+    // details get sent when a request is sent to the NYPL Platform API.
+    // If we get simple errors from form field validation, create the problem
+    // detail for the errors.
     if (errorObject?.status) {
       error = errorObject;
     } else {
@@ -68,13 +70,16 @@ function MyApp<MyAppProps>({ Component, pageProps, userLocation, query }) {
         "invalid-request",
         "Invalid Request",
         "There were errors with your submission.",
-        JSON.parse(query.errors)
+        errorObject
       );
     }
     // We don't want to keep the errors in this object since it's
     // going to go into the app's store.
     delete query.errors;
   }
+  // These are results specifically from the `/library-card/api/create-patron`
+  // API endpoint, which makes a request to the NYPL Platform API. These are
+  // results from the server-side form submission.
   if (!isEmpty(query.results)) {
     formInitialStateCopy.results = JSON.parse(query.results);
   }
@@ -170,7 +175,6 @@ function MyApp<MyAppProps>({ Component, pageProps, userLocation, query }) {
               {...pageProps}
               pageTitles={pageTitles}
               policyType={query.policyType}
-              error={error}
             />
           </ApplicationContainer>
         </FormDataContextProvider>

--- a/src/components/ApiErrors/index.tsx
+++ b/src/components/ApiErrors/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import React from "react";
-import isEmpty from "lodash/isEmpty";
 import {
   renderErrorElements,
   createUsernameAnchor,

--- a/src/components/ApplicationContainer/index.tsx
+++ b/src/components/ApplicationContainer/index.tsx
@@ -11,6 +11,8 @@ const ApplicationContainer = ({ children, problemDetail }) => {
   const { errorObj } = state;
   const errorToDisplay = problemDetail ? problemDetail : errorObj;
 
+  // If there are errors, focus on the element that displays those errors,
+  // for client-side rendering.
   useEffect(() => {
     if (errorToDisplay) {
       errorSection.current.focus();

--- a/src/components/ApplicationContainer/index.tsx
+++ b/src/components/ApplicationContainer/index.tsx
@@ -1,24 +1,43 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Header, navConfig } from "@nypl/dgx-header-component";
 import Footer from "@nypl/dgx-react-footer";
 import Banner from "../Banner";
+import ApiErrors from "../ApiErrors";
+import useFormDataContext from "../../context/FormDataContext";
 
-const ApplicationContainer: React.FC = ({ children }) => (
-  <>
-    <Header skipNav={{ target: "main-content" }} navData={navConfig.current} />
-    <div className="nypl-library-card-app layout-container nypl-ds">
-      <main id="main-content" className="main main--with-sidebar">
-        <div className="content-header">
-          <Banner />
-        </div>
-        <div className="content-primary content-primary--with-sidebar-right">
-          {children}
-        </div>
-        <div className="content-secondary content-secondary--with-sidebar-right" />
-      </main>
-    </div>
-    <Footer />
-  </>
-);
+const ApplicationContainer = ({ children, problemDetail }) => {
+  const errorSection = React.createRef<HTMLDivElement>();
+  const { state } = useFormDataContext();
+  const { errorObj } = state;
+  const errorToDisplay = problemDetail ? problemDetail : errorObj;
+
+  useEffect(() => {
+    if (errorToDisplay) {
+      errorSection.current.focus();
+    }
+  }, [errorToDisplay]);
+
+  return (
+    <>
+      <Header
+        skipNav={{ target: "main-content" }}
+        navData={navConfig.current}
+      />
+      <div className="nypl-library-card-app layout-container nypl-ds">
+        <main id="main-content" className="main main--with-sidebar">
+          <div className="content-header">
+            <Banner />
+          </div>
+          <div className="content-primary content-primary--with-sidebar-right">
+            <ApiErrors ref={errorSection} problemDetail={errorToDisplay} />
+            {children}
+          </div>
+          <div className="content-secondary content-secondary--with-sidebar-right" />
+        </main>
+      </div>
+      <Footer />
+    </>
+  );
+};
 
 export default ApplicationContainer;

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -20,7 +20,6 @@ import {
 import PersonalFormFields from "../PersonalFormFields";
 import AccountFormFields from "../AccountFormFields";
 import RoutingLinks from "../RoutingLinks.tsx";
-import ApiErrors from "../ApiErrors";
 import styles from "./ReviewFormContainer.module.css";
 import AcceptTermsFormFields from "../AcceptTermsFormFields";
 import Loader from "../Loader";
@@ -33,7 +32,6 @@ import { lcaEvents } from "../../externals/gaUtils";
 function ReviewFormContainer() {
   const [isLoading, setIsLoading] = useState(false);
   const { handleSubmit } = useFormContext();
-  const errorSection = React.createRef<HTMLDivElement>();
   const { state, dispatch } = useFormDataContext();
   const { formValues, errorObj } = state;
   const router = useRouter();
@@ -54,7 +52,6 @@ function ReviewFormContainer() {
   // bad requests.
   useEffect(() => {
     if (errorObj) {
-      errorSection.current.focus();
       document.title = "Form Submission Error | NYPL";
       // When we display errors, we want to go into the "Edit" state so
       // that it's easier to go to input fields from the error messages.
@@ -303,7 +300,6 @@ function ReviewFormContainer() {
   return (
     <>
       <Loader isLoading={isLoading} />
-      <ApiErrors ref={errorSection} problemDetail={errorObj} />
 
       <div className={styles.formSection}>
         <h3>Personal Information</h3>


### PR DESCRIPTION
## Description

PRs #98 and #99 both set up the app to work when javascript is not available. One part that is missing is displaying any server-side errors (which was implemented before) to the UI. Before, validation errors displayed next to each form field thanks to `react-hook-form` and errors from the server only displayed on the "Review" page since that's where the API request is made. The errors in the "Review" page uses the `ApiErrors` component.

Since `react-hook-form` is used on the client-side, the `ApiErrors` component is reused to display errors for each form field on each page. That component still renders all errors on the "Review" page. This was done by moving that component to render at a higher level in the DOM tree so it covers all the pages.

Client-side errors:
<img width="931" alt="Screen Shot 2020-11-06 at 1 50 24 PM" src="https://user-images.githubusercontent.com/1280564/98403484-0ab73100-2037-11eb-99cb-5dcc9f3310bb.png">

Server-side errors:
<img width="1065" alt="Screen Shot 2020-11-06 at 1 32 50 PM" src="https://user-images.githubusercontent.com/1280564/98403491-0e4ab800-2037-11eb-9b36-12d7bd8b9666.png">


## Motivation and Context

Resolves [DQ-424](https://jira.nypl.org/browse/DQ-424). 

## How Has This Been Tested?

Locally with and without JS.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
