### PR TITLE
Bug fix for non-numeric postal codes.

### DIFF
--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 
 import FormField from "../FormField";
@@ -9,13 +9,22 @@ import { Checkbox } from "@nypl/design-system-react-components";
 import ilsLibraryList from "../../data/ilsLibraryList";
 import LibraryListFormFields from "../LibraryListFormFields";
 
-function AccountInformationForm() {
+interface AccountFormFieldsProps {
+  showPinOnLoad: boolean;
+}
+
+function AccountFormFields({ showPinOnLoad }: AccountFormFieldsProps) {
   const { register, errors, getValues } = useFormContext();
   const { state } = useFormDataContext();
   const [showPin, setShowPin] = useState(false);
   const { formValues } = state;
   const originalPin = getValues("pin");
 
+  useEffect(() => {
+    if (showPinOnLoad) {
+      setShowPin(true);
+    }
+  }, []);
   const checkBoxLabelOptions = {
     id: "showPinId",
     labelContent: <>Show PIN</>,
@@ -36,6 +45,9 @@ function AccountInformationForm() {
         isRequired
         errorState={errors}
         maxLength={4}
+        attributes={{
+          pattern: "[0-9]{4}",
+        }}
         ref={register({
           validate: (val) => val.length === 4 || errorMessages.pin,
         })}
@@ -51,12 +63,15 @@ function AccountInformationForm() {
         isRequired
         errorState={errors}
         maxLength={4}
+        attributes={{
+          pattern: "[0-9]{4}",
+        }}
         ref={register({
           validate: (val) =>
             (val.length === 4 && val === originalPin) ||
             errorMessages.verifyPin,
         })}
-        defaultValue={formValues.pin}
+        defaultValue={formValues.verifyPin}
       />
 
       <Checkbox
@@ -75,4 +90,4 @@ function AccountInformationForm() {
   );
 }
 
-export default AccountInformationForm;
+export default AccountFormFields;

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -20,6 +20,8 @@ function AccountFormFields({ showPinOnLoad }: AccountFormFieldsProps) {
   const { formValues } = state;
   const originalPin = getValues("pin");
 
+  // When the component loads, if we want to show the PIN by default,
+  // show it.
   useEffect(() => {
     if (showPinOnLoad) {
       setShowPin(true);

--- a/src/components/AddressFormFields/index.tsx
+++ b/src/components/AddressFormFields/index.tsx
@@ -114,6 +114,11 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
             errorState={errors}
             minLength={MINLENGTHZIP}
             maxLength={MAXLENGTHZIP}
+            instructionText="5 or 9-digit postal code"
+            attributes={{
+              // eslint-disable-next-line prettier/prettier
+              pattern: "([0-9]d{5})|([0-9]d{9})|([0-9]d{5}-[0-9]d{4})",
+            }}
             ref={register({
               validate: lengthValidation(MINLENGTHZIP, MAXLENGTHZIP, "zip"),
             })}

--- a/src/components/AddressFormFields/index.tsx
+++ b/src/components/AddressFormFields/index.tsx
@@ -116,7 +116,6 @@ const AddressForm = ({ type, errorMessages }: AddressFormProps) => {
             maxLength={MAXLENGTHZIP}
             instructionText="5 or 9-digit postal code"
             attributes={{
-              // eslint-disable-next-line prettier/prettier
               pattern: "([0-9]d{5})|([0-9]d{9})|([0-9]d{5}-[0-9]d{4})",
             }}
             ref={register({

--- a/src/components/FormField/index.tsx
+++ b/src/components/FormField/index.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable */
 import React from "react";
 import {
   Label,
   Input,
   InputTypes,
   HelperErrorText,
-  Checkbox,
 } from "@nypl/design-system-react-components";
 import styles from "./FormField.module.css";
 
@@ -21,6 +19,7 @@ interface FormFieldProps {
   minLength?: number;
   maxLength?: number;
   defaultValue?: any;
+  attributes?: any;
 }
 
 /**
@@ -44,7 +43,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
       maxLength,
       defaultValue,
       // any extra input element attributes
-      ...rest
+      attributes,
     },
     ref
   ) => {
@@ -60,7 +59,6 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
       helperText = errorText.message;
     }
     const ariaLabelledby = helperText ? `${id}-helperText` : "";
-
     if (type === "hidden") {
       return (
         <input
@@ -93,7 +91,7 @@ const FormField = React.forwardRef<HTMLInputElement, FormFieldProps>(
             name: fieldName,
             tabIndex: 0,
             defaultValue,
-            ...rest,
+            ...attributes,
           }}
           ref={ref}
         />

--- a/src/components/LibraryListFormFields/index.tsx
+++ b/src/components/LibraryListFormFields/index.tsx
@@ -84,7 +84,7 @@ const LibraryListForm = ({ libraryList = [] }: LibraryListFormProps) => {
       label="Select a home library:"
       fieldName="homeLibraryCode"
       isRequired={false}
-      {...inputProps}
+      attributes={{ ...inputProps }}
     />
   );
   /**

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -95,7 +95,7 @@ function ReviewFormContainer() {
    * is not being manipulated, just updated, so they can all use the same
    * function to set the global data.
    */
-  const editSectionInfo = (formData) => {
+  const editSectionInfo = (formData, editSectionFlag) => {
     if (formData.homeLibraryCode) {
       formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
     }
@@ -106,9 +106,9 @@ function ReviewFormContainer() {
         ...formData,
       },
     });
-    // Set all to false even though not all are on.
-    setEditPersonalInfoFlag(false);
-    setEditAccountInfoFlag(false);
+    // Set the appropriate passed function section to false so it can close
+    // independently of the others.
+    editSectionFlag(false);
   };
 
   /**
@@ -306,7 +306,11 @@ function ReviewFormContainer() {
         {!editPersonalInfoFlag ? (
           renderPersonalInformationValues()
         ) : (
-          <form onSubmit={handleSubmit(editSectionInfo)}>
+          <form
+            onSubmit={handleSubmit((formData) =>
+              editSectionInfo(formData, setEditPersonalInfoFlag)
+            )}
+          >
             <PersonalFormFields />
             {submitSectionButton}
           </form>
@@ -323,8 +327,12 @@ function ReviewFormContainer() {
         {!editAccountInfoFlag ? (
           renderAccountValues()
         ) : (
-          <form onSubmit={handleSubmit(editSectionInfo)}>
-            <AccountFormFields />
+          <form
+            onSubmit={handleSubmit((formData) =>
+              editSectionInfo(formData, setEditPersonalInfoFlag)
+            )}
+          >
+            <AccountFormFields showPinOnLoad />
             <AcceptTermsFormFields />
             {submitSectionButton}
           </form>


### PR DESCRIPTION
## Description

Previously, the validation did not complain about non-numeric postal codes or pin numbers. There's the `type="number"` attribute but the `min`/`max` attributes don't work for the number type. There's a different attribute that could work but it's not widely support. So one of the best bet is to rely on browser support with the `pattern` attribute and keep it a type of "text" and min/max length. You can still enter non-number characters but when you try to submit you'll get the popup (in firefox, safari, and chrome) that the value doesn't follow what the input field wants. So now you can't enter non-numeric values and go to the next screen, the browser validation stops you.

## Motivation and Context

Resolves [DQ-433](https://jira.nypl.org/browse/DQ-433). Found while QA testing and more details in the ticket.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
