### PR TITLE
PIN field update for with and without javascript.

### DIFF
--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 
 import FormField from "../FormField";
@@ -13,6 +13,7 @@ function AccountInformationForm() {
   const { register, errors, getValues } = useFormContext();
   const { state } = useFormDataContext();
   const [showPin, setShowPin] = useState(false);
+  const [clientSide, setClientSide] = useState(false);
   const { formValues } = state;
   const originalPin = getValues("pin");
 
@@ -22,6 +23,16 @@ function AccountInformationForm() {
   };
   const update = () => setShowPin(!showPin);
   const pinType = showPin ? "text" : "password";
+
+  // When the component renders on the client-side, we want to turn the password
+  // "text" input into a "password" type so that the PIN is visible by default.
+  // Keep track when it's rendering on the client so that the "Show PIN"
+  // checkbox is rendered as well - it's not needed without javascript since
+  // you can't toggle without javascript.
+  useEffect(() => {
+    setClientSide(true);
+    setShowPin(false);
+  }, []);
 
   return (
     <>
@@ -59,16 +70,18 @@ function AccountInformationForm() {
         defaultValue={formValues.pin}
       />
 
-      <Checkbox
-        checkboxId="showPIN"
-        name="showPIN"
-        labelOptions={checkBoxLabelOptions}
-        isSelected={false}
-        attributes={{
-          defaultChecked: showPin,
-          onClick: update,
-        }}
-      />
+      {clientSide && (
+        <Checkbox
+          checkboxId="showPIN"
+          name="showPIN"
+          labelOptions={checkBoxLabelOptions}
+          isSelected={false}
+          attributes={{
+            defaultChecked: showPin,
+            onClick: update,
+          }}
+        />
+      )}
 
       <LibraryListFormFields libraryList={ilsLibraryList} />
     </>

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -12,7 +12,7 @@ import LibraryListFormFields from "../LibraryListFormFields";
 function AccountInformationForm() {
   const { register, errors, getValues } = useFormContext();
   const { state } = useFormDataContext();
-  const [showPin, setShowPin] = useState(false);
+  const [showPin, setShowPin] = useState(true);
   const [clientSide, setClientSide] = useState(false);
   const { formValues } = state;
   const originalPin = getValues("pin");
@@ -67,7 +67,7 @@ function AccountInformationForm() {
             (val.length === 4 && val === originalPin) ||
             errorMessages.verifyPin,
         })}
-        defaultValue={formValues.pin}
+        defaultValue={formValues.verifyPin}
       />
 
       {clientSide && (

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -318,7 +318,8 @@ export async function callPatronAPI(
   if (tokenObject && tokenObject.access_token) {
     const token = tokenObject.access_token;
     const patronData = constructPatronObject(data);
-    // Used for testing:
+    // Used for testing when we don't want to create real accounts,
+    // just return a mocked account data.
     // return Promise.resolve({
     //   status: 200,
     //   type: "card-granted",


### PR DESCRIPTION
## Description

The PIN field can be toggled form an input type of "text" to "password" so that the value can be visible to the user. This is the only way it can be done (as in, it can't be done with CSS) so with no javascript, this doesn't work. To "fix" this, the PIN field is just shown by default and the "Show PIN" toggle checkbox is not rendered. When javascript kicks in on the client side, the PIN field turns into a "password" field and the toggle checkbox is rendered.

## Motivation and Context

Resolves [DQ-430](https://jira.nypl.org/browse/DQ-430). To cover accessibility for the Account page without javascript.

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
