### PR TITLE
Updating the Review page when js is not enabled.

### DIFF
--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -12,7 +12,7 @@ import LibraryListFormFields from "../LibraryListFormFields";
 function AccountInformationForm() {
   const { register, errors, getValues } = useFormContext();
   const { state } = useFormDataContext();
-  const [showPin, setShowPin] = useState(false);
+  const [showPin, setShowPin] = useState(true);
   const [clientSide, setClientSide] = useState(false);
   const { formValues } = state;
   const originalPin = getValues("pin");
@@ -67,7 +67,7 @@ function AccountInformationForm() {
             (val.length === 4 && val === originalPin) ||
             errorMessages.verifyPin,
         })}
-        defaultValue={formValues.pin}
+        defaultValue={formValues.verifyPin}
       />
 
       {clientSide && (

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -318,7 +318,8 @@ export async function callPatronAPI(
   if (tokenObject && tokenObject.access_token) {
     const token = tokenObject.access_token;
     const patronData = constructPatronObject(data);
-    // Used for testing:
+    // Used for testing when we don't want to create real accounts,
+    // just return a mocked account data.
     // return Promise.resolve({
     //   status: 200,
     //   type: "card-granted",


### PR DESCRIPTION
## Description

This has a similar pattern to PR #103 whereby there's a `clientSide` flag that helps renders features that work with javascript when components render on the client. For the Review page, this is the PIN display and toggle checkbox, and mostly the "Edit" buttons.

The problem is that we can't toggle the form from "edit" to "view" mode without javascript. I was thinking of just having the form be in "edit" mode by default so users can edit their values there and then submit the form, but it changes the Review page's structure drastically. Since each section is it's own toggleable `<form>` that updates the app's state, having a `<form>` wrapper around everything doesn't work since you cannot have a form within another form. Currently, the "edit" button in the Address section takes the user to the "Location" page where the address values can be updated so I kept this pattern. Now, each "edit" button in the Review page links to its respective page where those values can be edited and the user's form values get carried over through the URL query params. When there's javascript, those links turn into buttons that can toggle between the "view" and "edit" modes.

## Motivation and Context

Resolves [DQ-429](https://jira.nypl.org/browse/DQ-429).

## How Has This Been Tested?

Locally.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
