### PR TITLE
Updating logic for users in nyc but without an nyc address.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Updated
 
+- Updated the Work/Alternate Address page to appear if the device location is in NYS but the Home Address is not in NYC.
 - Updated Design System to v0.18.6.
 - Updated copy to clarify the Work Address page and form fields.
 

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -16,7 +16,6 @@ function HomePage({ policyType, csrfToken, location }) {
       type: "SET_CSRF_TOKEN",
       value: csrfToken,
     });
-    console.log("use effect", location);
     dispatch({
       type: "SET_FORM_DATA",
       value: { ...formValues, location },

--- a/src/components/AddressContainer/index.tsx
+++ b/src/components/AddressContainer/index.tsx
@@ -99,13 +99,14 @@ const AddressContainer = () => {
         // If we don't have a 403 error and need to start over, then do the
         // following check:
         // If the user is not in "nyc", then we ask the user for their
-        // work address information. If the user is in "nyc" and the home
+        // work address information. If the user is in "nys" and the home
         // address is not in "nyc", then we ask for their work address.
         // Otherwise, the home address is enough and we can go to the next step.
         if (nextUrl !== "/new") {
           if (
             formValues.location !== "nyc" ||
-            (formValues.location === "nyc" && !addressInNYC)
+            ((formValues.location === "nyc" || formValues.location === "nys") &&
+              !addressInNYC)
           ) {
             nextUrl = "/workAddress?newCard=true";
           } else {

--- a/src/components/AddressVerificationContainer/index.tsx
+++ b/src/components/AddressVerificationContainer/index.tsx
@@ -211,7 +211,7 @@ function AddressVerificationContainer() {
 
       {workAddress?.length > 0 && (
         <div className={styles.workAddressContainer}>
-          <Heading level={3}>Work Address</Heading>
+          <Heading level={3}>Alternate Address</Heading>
 
           {renderMultipleAddresses(
             workAddress,

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -15,7 +15,7 @@ describe("getPageTiles", () => {
     expect(getPageTitles(userLocation)).toEqual({
       personal: "Step 1 of 5: Personal Information",
       address: "Step 2 of 5: Address",
-      workAddress: "Work Address",
+      workAddress: "Alternate Address",
       verification: "Step 3 of 5: Address Verification",
       account: "Step 4 of 5: Customize Your Account",
       review: "Step 5 of 5: Confirm Your Information",
@@ -26,7 +26,7 @@ describe("getPageTiles", () => {
     const sixStepTitles = {
       personal: "Step 1 of 6: Personal Information",
       address: "Step 2 of 6: Address",
-      workAddress: "Step 3 of 6: Work Address",
+      workAddress: "Step 3 of 6: Alternate Address",
       verification: "Step 4 of 6: Address Verification",
       account: "Step 5 of 6: Customize Your Account",
       review: "Step 6 of 6: Confirm Your Information",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -20,7 +20,7 @@ export function getPageTitles(userLocation: string): PageTitles {
       personal: "Step 1 of 5: Personal Information",
       address: "Step 2 of 5: Address",
       // This step won't happen but the DS `Heading` component needs text.
-      workAddress: "Work Address",
+      workAddress: "Alternate Address",
       verification: "Step 3 of 5: Address Verification",
       account: "Step 4 of 5: Customize Your Account",
       review: "Step 5 of 5: Confirm Your Information",
@@ -29,12 +29,23 @@ export function getPageTitles(userLocation: string): PageTitles {
   return {
     personal: "Step 1 of 6: Personal Information",
     address: "Step 2 of 6: Address",
-    workAddress: "Step 3 of 6: Work Address",
+    workAddress: "Step 3 of 6: Alternate Address",
     verification: "Step 4 of 6: Address Verification",
     account: "Step 5 of 6: Customize Your Account",
     review: "Step 6 of 6: Confirm Your Information",
   };
 }
+
+export const nyCounties = ["richmond", "queens", "new york", "kings", "bronx"];
+export const nyCities = [
+  "new york",
+  "new york city",
+  "nyc",
+  "bronx",
+  "queens",
+  "brooklyn",
+  "staten island",
+];
 
 /**
  * createQueryParams


### PR DESCRIPTION
## Description

This update covers the case where the user's device says they are in NYS (including NYC) but they entered a home address that is not in NYC. This can happen for users who live outside NYC but they go to NYC to work. For this case, the Work/Alternate Address page should show up.

## Motivation and Context

Resolves [DQ-448](https://jira.nypl.org/browse/DQ-448).

## How Has This Been Tested?

Tested this with ngrok locally. I'm in NYC so my location is "nyc". I entered my address in the Home Address and did not get the Work/Alternate Address page. Then I entered an address from Philadelphia (and later Albany) and the Work/Alternate Address page came up. For this case, that page doesn't show a "Step x of x" since those are configured through the IP address location. Since this is forcing the Work/Alternate Address page to show up _after_ checking the entered home address, the "Step x of x" logic can't be updated. It really doesn't seem that noticeable to users anyway but just pointing it out.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
