### PR TITLE
Reducing IP Location API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGE LOG
 
+### v0.6.5
+
+#### Updated
+
+- Updated when the Location API, the service that converts an IP address into a geolocation object, is called in the application flow.
+- Updated NYPL Design System to v0.19.1.
+
 ### v0.6.4
 
 #### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-library-card-app",
-  "version": "0.6.2",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2415,9 +2415,9 @@
       }
     },
     "@nypl/design-system-react-components": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.18.6.tgz",
-      "integrity": "sha512-Dw9QTg8PjYYCMnubONX7JkZcrDJgW2eJ0voNGUmml8YmSWBRdxPVwdfj8H5E1HjxJRQMSMD0rpdGg+ioaP5Ldw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@nypl/design-system-react-components/-/design-system-react-components-0.19.1.tgz",
+      "integrity": "sha512-SWwG5l+IVsrG4tqSRgW4UsPbL/b+5pqMrMCpXZi4OxHjTNgu7LTTTHxYt0rPAB4wOoxGh7WhlLcdjKU2SZEBIw==",
       "requires": {
         "he": "^1.2.0",
         "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nypl-library-card-app",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "NYPL Get A Library Card App",
   "main": "index.js",
   "scripts": {
@@ -38,7 +38,7 @@
   "dependencies": {
     "@axe-core/react": "^4.0.0",
     "@babel/preset-typescript": "^7.10.4",
-    "@nypl/design-system-react-components": "^0.18.6",
+    "@nypl/design-system-react-components": "^0.19.1",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.7",
     "@testing-library/jest-dom": "5.11.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -88,7 +88,7 @@ function MyApp<MyAppProps>({ Component, pageProps, query }) {
     ...query,
   };
   const initState = { ...formInitialStateCopy };
-  const pageTitles = getPageTitles("nyc");
+  const pageTitles = getPageTitles();
 
   return (
     <>

--- a/pages/location/index.tsx
+++ b/pages/location/index.tsx
@@ -1,14 +1,27 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Heading } from "@nypl/design-system-react-components";
 
 import AddressContainer from "../../src/components/AddressContainer";
 import { PageTitles } from "../../src/interfaces";
+import useFormDataContext from "../../src/context/FormDataContext";
+import IPLocationAPI from "../../src/utils/IPLocationAPI";
 
 interface PageProps {
   pageTitles: PageTitles;
+  location: string;
 }
 
-function AddressPage({ pageTitles }: PageProps) {
+function AddressPage({ pageTitles, location }: PageProps) {
+  const { state, dispatch } = useFormDataContext();
+  const { formValues } = state;
+  // Update the form values state with the user's location value.
+  useEffect(() => {
+    dispatch({
+      type: "SET_FORM_DATA",
+      value: { ...formValues, location },
+    });
+  }, []);
+
   return (
     <>
       <Heading level={2}>{pageTitles.address}</Heading>
@@ -17,7 +30,8 @@ function AddressPage({ pageTitles }: PageProps) {
   );
 }
 
-export async function getServerSideProps({ res, query }) {
+export async function getServerSideProps(context) {
+  const { query, res } = context;
   // We only want to show this from a form submission. If we are not coming
   // to the confirmation page from a successful form submission, then
   // redirect to the form page.
@@ -27,7 +41,14 @@ export async function getServerSideProps({ res, query }) {
     });
     res.end();
   }
-  return { props: {} };
+  // Get the user's IP address and convert it to an object that tells us if
+  // the user is in NYS/NYC. Will be `undefined` if the call to the IP/location
+  // conversion API fails or if there is no IP address.
+  let location = "";
+  if (context.req?.headers) {
+    location = await IPLocationAPI.getLocationFromIP(context);
+  }
+  return { props: { location } };
 }
 
 export default AddressPage;

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -1,24 +1,17 @@
 import React, { useEffect } from "react";
 import { Heading } from "@nypl/design-system-react-components";
-import IPLocationAPI from "../../src/utils/IPLocationAPI";
 import RoutingLinks from "../../src/components/RoutingLinks.tsx";
 import useFormDataContext from "../../src/context/FormDataContext";
 import { getCsrfToken } from "../../src/utils/utils";
 
-function HomePage({ policyType, csrfToken, location }) {
-  const { state, dispatch } = useFormDataContext();
-  const { formValues } = state;
+function HomePage({ policyType, csrfToken }) {
+  const { dispatch } = useFormDataContext();
   // When the app loads, get the CSRF token from the server and set it in
   // the app's state.
-  // Update the form values state with the user's location value.
   useEffect(() => {
     dispatch({
       type: "SET_CSRF_TOKEN",
       value: csrfToken,
-    });
-    dispatch({
-      type: "SET_FORM_DATA",
-      value: { ...formValues, location },
     });
   }, []);
 
@@ -69,16 +62,9 @@ function HomePage({ policyType, csrfToken, location }) {
 }
 
 export async function getServerSideProps(context) {
-  // Get the user's IP address and convert it to an object that tells us if
-  // the user is in NYS/NYC. Will be `undefined` if the call to the IP/location
-  // conversion API fails or if there is no IP address.
-  let location = "";
-  if (context.req?.headers) {
-    location = await IPLocationAPI.getLocationFromIP(context);
-  }
   const { csrfToken } = getCsrfToken(context.req, context.res);
   return {
-    props: { csrfToken, location },
+    props: { csrfToken },
   };
 }
 

--- a/src/utils/__tests__/utils.test.ts
+++ b/src/utils/__tests__/utils.test.ts
@@ -9,10 +9,8 @@ import cookieUtils from "../CookieUtils";
 jest.mock("../CookieUtils");
 
 describe("getPageTiles", () => {
-  test("it returns text saying there are 5 steps if the user is in nyc", () => {
-    const userLocation = "nyc";
-
-    expect(getPageTitles(userLocation)).toEqual({
+  test("it returns text saying there are 5 steps", () => {
+    expect(getPageTitles()).toEqual({
       personal: "Step 1 of 5: Personal Information",
       address: "Step 2 of 5: Address",
       workAddress: "Alternate Address",
@@ -20,24 +18,6 @@ describe("getPageTiles", () => {
       account: "Step 4 of 5: Customize Your Account",
       review: "Step 5 of 5: Confirm Your Information",
     });
-  });
-
-  test("it returns text saying there are 6 steps if the user is not in nyc", () => {
-    const sixStepTitles = {
-      personal: "Step 1 of 6: Personal Information",
-      address: "Step 2 of 6: Address",
-      workAddress: "Step 3 of 6: Alternate Address",
-      verification: "Step 4 of 6: Address Verification",
-      account: "Step 5 of 6: Customize Your Account",
-      review: "Step 6 of 6: Confirm Your Information",
-    };
-    const userLocationEmpty = "";
-    const userLocationUS = "us";
-    const userLocationNYS = "nys";
-
-    expect(getPageTitles(userLocationEmpty)).toEqual(sixStepTitles);
-    expect(getPageTitles(userLocationUS)).toEqual(sixStepTitles);
-    expect(getPageTitles(userLocationNYS)).toEqual(sixStepTitles);
   });
 });
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,32 +7,19 @@ import appConfig from "../../appConfig";
 /**
  * getPageTitles
  * Returns the page titles and updates the titles if the user is not in "nyc".
- * @param userLocation The user's location down to the most accurate detail.
- *  The default is an empty string.
  */
-export function getPageTitles(userLocation: string): PageTitles {
+export function getPageTitles(): PageTitles {
   // The "nyc" case is the only case when we don't need the work address from
   // users so we don't show it. The work address is needed for the empty,
   // "nys", and "us" cases. Now an extra page is added to the
   // form submission flow.
-  if (userLocation === "nyc") {
-    return {
-      personal: "Step 1 of 5: Personal Information",
-      address: "Step 2 of 5: Address",
-      // This step won't happen but the DS `Heading` component needs text.
-      workAddress: "Alternate Address",
-      verification: "Step 3 of 5: Address Verification",
-      account: "Step 4 of 5: Customize Your Account",
-      review: "Step 5 of 5: Confirm Your Information",
-    };
-  }
   return {
-    personal: "Step 1 of 6: Personal Information",
-    address: "Step 2 of 6: Address",
-    workAddress: "Step 3 of 6: Alternate Address",
-    verification: "Step 4 of 6: Address Verification",
-    account: "Step 5 of 6: Customize Your Account",
-    review: "Step 6 of 6: Confirm Your Information",
+    personal: "Step 1 of 5: Personal Information",
+    address: "Step 2 of 5: Address",
+    workAddress: "Alternate Address",
+    verification: "Step 3 of 5: Address Verification",
+    account: "Step 4 of 5: Customize Your Account",
+    review: "Step 5 of 5: Confirm Your Information",
   };
 }
 


### PR DESCRIPTION
## Description

We use IP Stack as a service to convert IP addresses to a geolocation object but they only provide 10k free requests per month. This is used to verify a patron is in NYC in order to get the proper Library account. Requests are used up quickly because patrons visit the homepage but don't complete the form. This means that requests are basically thrown away. This fixes that issue by calling the IP Location API on the address form page rather than the home page. If the user is past the personal form field, we can assume they'll continue filling out the form so it's better to call the service then.

This also updates DS to v0.19.1

## Motivation and Context

Resolves [DQ-457](https://jira.nypl.org/browse/DQ-457).

## How Has This Been Tested?

Locally with ngrok to test two cases where the location is empty and where the location is "nyc". That way, we can make sure that the "Alternate Address" page shows up.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
