### PR TITLE
Updating react-axe to @axe-core/react and how it's bundled into the app.

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,4 @@ OAUTH_PROVIDER_URL=https://isso.nypl.org/oauth/token
 OAUTH_CLIENT_ID=askTeammate
 OAUTH_CLIENT_SECRET=askTeammate
 IPSTACK_KEY=askTeammate
-NEXT_PUBLIC_USE_AXE='false'
+NEXT_PUBLIC_USE_AXE=false

--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,4 @@ OAUTH_PROVIDER_URL=URL to OAuth provider who guards the API Gateway (e.g: https:
 OAUTH_CLIENT_ID=The ID this app uses to auth to the OAuth provider above
 OAUTH_CLIENT_SECRET=The secret this app uses to auth to the OAuth provider above
 IPSTACK_KEY=key to api.ipstack service https://ipstack.com/
-NEXT_PUBLIC_USE_AXE='false' use 'true' if react-axe should be run while developing
+NEXT_PUBLIC_USE_AXE=false use 'true' if @axe-core/react should be run while developing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Updated the Dockerfile in preparation to use with AWS ECS.
 - Updated location for correct installion of npm packages.
+- Updated the `react-axe` package to `@axe-core/react` since the former is deprecated.
 
 ### v0.6.7
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Configuration can be adjusted via `.travis.yml`, located at the root directory o
 
 ## Accessibility
 
-There are two ways to use the `react-axe` package for accessibility review while developing. This is the package of choice used in a few NYPL React applications. Only turn it on when needed and not while developing all the time because it uses a lot of browser resouces.
+There are two ways to use the `@axe-core/react` package for accessibility review while developing. This is the package of choice used in a few NYPL React applications. Only turn it on when needed and not while developing all the time because it uses a lot of browser resouces.
 
 1. Run `NEXT_PUBLIC_USE_AXE=true npm run dev`
 2. or update the `NEXT_PUBLIC_USE_AXE` environment variable in your `.env` file.

--- a/next.config.js
+++ b/next.config.js
@@ -16,9 +16,9 @@ module.exports = {
   },
   generateBuildId: async () => `${PROD_BUILD_ID}`,
   webpack: (config, { isServer, webpack }) => {
-    // react-axe should only be bundled when NEXT_PUBLIC_USE_AXE=true
-    !NEXT_PUBLIC_USE_AXE &&
-      config.plugins.push(new webpack.IgnorePlugin(/react-axe$/));
+    // @axe-core/react should only be bundled when NEXT_PUBLIC_USE_AXE=true
+    !(NEXT_PUBLIC_USE_AXE === "true") &&
+      config.plugins.push(new webpack.IgnorePlugin(/@axe-core\/react$/));
     // Fixes npm packages that depend on `fs` module since
     // we can't depend on this in the client-side code.
     if (!isServer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,18 +91,20 @@
       }
     },
     "@axe-core/react": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.0.0.tgz",
-      "integrity": "sha512-/hwpydX/JkP+uWfHd4pFAAq0hgGbdmEf4m3SPuhacgjkVwmYhmltAPHXShswcKhys086jKJ402CGmy/BKNF9og==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.1.0.tgz",
+      "integrity": "sha512-S5DtZFIoAdUgLNJIIFiz6Bnaf3Dzul5X+TYPT9+0z/Po3d1jlTCQq2SVKfZceVsiw5jcTr4owaS2pNWz82c7GA==",
+      "dev": true,
       "requires": {
-        "axe-core": "^4.0.1",
+        "axe-core": "^4.1.1",
         "requestidlecallback": "^0.3.0"
       },
       "dependencies": {
         "axe-core": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
-          "integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA=="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+          "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
+          "dev": true
         }
       }
     },
@@ -11808,16 +11810,6 @@
         "shallow-equal": "^1.2.1"
       }
     },
-    "react-axe": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/react-axe/-/react-axe-3.5.4.tgz",
-      "integrity": "sha512-5xNO0QVCCEZnJiyhAGox0MGFyclgU3XL8se+5H+whdxV1VTtA9/uux9BSCF5mGNSgtSZkb+tQtrOaF+zGf/oWw==",
-      "dev": true,
-      "requires": {
-        "axe-core": "^3.5.0",
-        "requestidlecallback": "^0.3.0"
-      }
-    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -12298,7 +12290,8 @@
     "requestidlecallback": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU="
+      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/issues"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.1.0",
     "@testing-library/jest-dom": "5.11.4",
     "@testing-library/react": "^10.4.7",
     "@testing-library/react-hooks": "^3.4.1",
@@ -48,11 +49,9 @@
     "husky": "^4.2.3",
     "jest": "^26.1.0",
     "jest-axe": "^3.5.0",
-    "react-axe": "^3.5.2",
     "react-test-renderer": "^16.13.1"
   },
   "dependencies": {
-    "@axe-core/react": "^4.0.0",
     "@babel/preset-typescript": "^7.10.4",
     "@nypl/design-system-react-components": "^0.19.1",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -40,11 +40,12 @@ if (!isServerRendered()) {
   gaUtils.setupAnalytics(isProduction);
 }
 
-// Only run react-axe in the client-side and when the flag is set.
-if (appConfig.useAxe === "true" && !isServerRendered()) {
+// Only run @axe-core/react in the client-side in production
+// and when the flag is set.
+if (appConfig.useAxe === "true" && !isProduction && !isServerRendered()) {
   const ReactDOM = require("react-dom");
-  const axe = require("react-axe");
-  axe(React, ReactDOM, 1000);
+  const axe = require("@axe-core/react");
+  axe(React, ReactDOM, 1000, {});
 }
 
 function MyApp<MyAppProps>({ Component, pageProps, query }) {


### PR DESCRIPTION
## Description

Updates the `react-axe` package (deprecated) to `@axe-core/react`. This also updates how it's bundled through webpack to reduce the total bundle size. The first load js bundle went from 750kb to 659kb which isn't a lot but good to not have an unnecessary package into the production build.

## Motivation and Context

Resolves [DQ-464](https://jira.nypl.org/browse/DQ-464).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
