### PR TITLE
RENO-3108: Add Translations For Address And Account Page

### DIFF
--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -36,7 +36,7 @@ function HomePage({ policyType, csrfToken, lang }) {
           url: `/personal?newCard=true${queryParam}${
             lang !== "en" ? `&lang=${lang}` : ""
           }`,
-          text: t("home.button"),
+          text: t("button.start"),
         }}
       />
 

--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -5,13 +5,73 @@
         "part1": "إذا كان عمرك  عامًا ١٣  أو أكثر وتعيش أو تعمل أو تذهب إلى المدرسة أو تدفع ضرائب الملكية في ولاية نيويورك  ، فيمكنك الحصول على بطاقة مكتبة رقمية مجانية الآن باستخدام هذا استمارة عبر الإنترنت. يمكن لزوار ولاية نيويورك أيضًا استخدام هذا  استمارة لتقديم طلب للحصول على بطاقة مؤقتة.",
         "part2": "باستخدام بطاقة مكتبة رقمية ، يمكنك الوصول مجانًا إلى  مجموعة واسعة من الموارد الرقمية للمكتبة - بما في ذلك الكتب الإلكترونية وقواعد البيانات والموارد التعليمية والمزيد.",
         "part3": "بتقديم هذا الطلب، أنا أفهم وأوافق على <a href='https://www.nypl.org/help/library-card/terms-conditions'> شروط وأحكام حامل البطاقة</a>,  و أوافق على<a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'> قواعد ولوائح مكتبة نيويورك العامة. </a> تعلم المزيد عن استخدام المكتبة للمعلومات الشخصية,يرجى القراءة <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'> سياسة الخصوصية</a>  الخاصة بنا"
-      },
-      "button": "البدء"
+      }
     },
-    "address": {},
-    "alternateAddress": {},
-    "verifyAddress": {},
-    "account": {},
-    "confirm": {},
+    "personal": {
+      "title": "الخطوة ١ من ٥: المعلومات الشخصية",
+      "firstName": {
+        "label": "الاسم الأول"
+      },
+      "lastName": {
+        "label": "الاسم العائلة"
+      },
+      "birthdate": {
+        "label": "تاريخ الميلاد",
+        "instruction": "شهر/يوم/سنة, including slashes"
+      },
+      "email": {
+        "label": "Email Address",
+        "instruction": "مطلوب عنوان بريد إلكتروني لاستخدام العديد من مواردنا الرقمية ، مثل كتب الإلكترونية. إذا كنت لا ترغب أن تقديم عنوان بريد إلكتروني ،  فيمكنك تطبيق بطلب للحصول على بطاقة مادية باستخدام <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>استمارة البديل</a>. بمجرد ملئها ، يرجى زيارة أحد <a href='https://www.nypl.org/locations'>مواقعنا</a> مع إثبات الهوية وعنوان المنزل لاستلام بطاقتك."
+      },
+      "errorMessage": {
+        "firstName": "",
+        "lastName": "",
+        "birthdate": "",
+        "email": ""
+      },
+      "eCommunications": {
+        "labelText": "نعم، أرغب أن أتلقّي معلومات حول برامج وخدمات المكتبة عبر البريد الإلكتروني."
+      }
+    },
+    "location": {
+      "title": "الخطوة ٢ من ٥: العنوان ",
+      "description": "إذا كنت تعيش في مدينة نيويورك ، فيرجى إكمال نموذج عنوان المنزل.",
+      "address": {
+        "line1": {"label": "عنوان الشارع"},
+        "line2": {"label":"الشقة / الجناح"},
+        "city": {"label": "المدينة"},
+        "state": {"label": "الولاية", "instruction": "اختصار مكون من حرفين"},
+        "postalCode": {"label": "الرمز البريدي", "instruction": "٥ أو ٩ أرقام رمز بريدي"}
+      }
+    },
+    "verifyAddress": {
+      "title": "الخطوة ٣ من ٥: التحقق من العنوان",
+      "description": "يرجى تحديد العنوان الصحيح.",
+      "homeAddress": "عنوان المنزل",
+      "workAddress": "Alternate Address"
+    },
+    "account": {
+      "title": "الخطوة ٤ من ٥: تخصيص حسابك",
+      "username": {"label": "اسم المستخدم", "instruction": "٥-٢٥ حرفًا أبجديًا رقميًا. لا توجد حروفًا  خاصة.", "checkButton": "تحقق مما إذا كان اسم المستخدم متاحًا"},
+      "password": {"label": "رقم التعريف الشخصي", "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"},
+      "verifyPassword": {"label": "التحقق من رقم التعريف الشخصي", "instruction": "8-32 characters"},
+      "showPassword": "إظهار رقم التعريف الشخصي",
+      "selectLibrary": "حدد مكتبة مفضلة:",
+      "termsAndCondition": "نعم ، أوافق على الشروط والأحكام."
+    },
+    "review": {
+      "title": "الخطوة ٥ من ٥: قم بتأكيد المعلومات",
+      "description": "تأكد من صحة جميع المعلومات التي أدخلتها. إذا لزم الأمر ، لا يزال بإمكانك إجراء التغييرات قبل إرسال طلبك.",
+      "receiveNewsletter": "Receive information about NYPL's programs and services",
+      "yes": "نعم",
+      "no": "رقم"
+    },
+    "button": {
+      "start": "البدء",
+      "edit": "إتعديل",
+      "submit": "إرسال",
+      "next": "التالي",
+      "previous": "السابق"
+    },
     "confirmation": {}
   }

--- a/public/locales/bn/common.json
+++ b/public/locales/bn/common.json
@@ -5,13 +5,83 @@
         "part1": "আপনি যদি ১৩ বছর বা তার বেশী বয়সী হন এবং বসবাস করেন, কাজ করেন, স্কুলে যান, অথবা নিউ ইয়র্ক স্টেটে সম্পত্তি কর পরিশোধ করেন, তাহলে এই অনলাইন ফর্ম ব্যবহার করে আপনি এই মুহূর্তে একটি বিনামূল্যে ডিজিটাল লাইব্রেরী কার্ড পেতে পারেন। নিউ ইয়র্ক স্টেটে দর্শনার্থীরা ও অস্থায়ী কার্ডের জন্য আবেদন করতে এই ফর্ম ব্যবহার করতে পারেন।",
         "part2": "একটি ডিজিটাল লাইব্রেরী কার্ডের মাধ্যমে আপনি লাইব্রেরীর বিস্তৃত ডিজিটাল সম্পদে বিনামূল্যে প্রবেশাধিকার পাবেন- যার মধ্যে রয়েছে ই-বুক, ডাটাবেস, শিক্ষামূলক সম্পদ, এবং আরো অনেক কিছু।",
         "part3": "একটি আবেদন পত্র জমা দেওয়ার মাধ্যমে আপনি আমাদের <a href='https://www.nypl.org/help/library-card/terms-conditions'>কার্ডহোল্ডার শর্তাবলী</a> বুঝতে এবং সম্মত হন এবং আমাদের <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>নিয়ম ও বিধিমালায়</a> সম্মত হন। লাইব্রেরীর ব্যক্তিগত তথ্যের ব্যবহার সম্পর্কে আরও জানতে, অনুগ্রহ করে আমাদের <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>প্রাইভেসী নীতিমালা</a> পড়ুন।"
-      },
-      "button": "এবার শুরু করা যাক"
+      }
     },
-    "address": {},
-    "alternateAddress": {},
-    "verifyAddress": {},
-    "account": {},
-    "confirm": {},
+    "personal": {
+      "title": "পদক্ষেপ 1 of 5: ব্যক্তিগত তথ্য",
+      "firstName": {
+        "label": "প্রথম নাম"
+      },
+      "lastName": {
+        "label": "শেষ নাম"
+      },
+      "birthdate": {
+        "label": "জন্ম তারিখ",
+        "instruction": "মাস/ দিন /বছর , স্ল্যাশ সহ "
+      },
+      "email": {
+        "label": "ইমেইল ঠিকানা",
+        "instruction": "আমাদের অনেক ডিজিটাল সম্পদ, যেমন ই-বুক ব্যবহার করার জন্য একটি ইমেইল ঠিকানা প্রয়োজন। আপনি যদি একটি ইমেইল ঠিকানা প্রদান করতে না চান, আপনি আমাদের <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>বিকল্প ফর্ম</a>. ব্যবহার করে একটি ফিজিক্যাল কার্ডের জন্য আবেদন করতে পারেন। একবার পূরণ হয়ে গেলে, আপনার কার্ড তোলার জন্য পরিচয় এবং বাড়ির ঠিকানার প্রমাণ সহ অনুগ্রহ করে আমাদের যে কোন একটি <a href='https://www.nypl.org/locations'>স্থানে</a> যান।."
+      },
+      "errorMessage": {
+        "firstName": "",
+        "lastName": "",
+        "birthdate": "",
+        "email": ""
+      },
+      "eCommunications": {
+        "labelText": "হ্যাঁ, আমি এনওয়াইপিএল এর প্রোগ্রাম এবংসার্ভিসেস সম্পর্কে তথ্য পেতে চাই"
+      }
+    },
+    "location": {
+      "title": "5 এর ধাপ 2: ঠিকানা",
+      "description": "আপনি যদি NYC তে থাকেন তবে দয়া করে বাড়ির ঠিকানা ফর্মটি পূরণ করুন।",
+      "address": {
+        "line1": {"label": "রাস্তার ঠিকানা"},
+        "line2": {"label": "এপার্টমেন্ট / সুইট"},
+        "city": {"label": "শহর"},
+        "state":{"label": "স্টেট", "instruction": "২ অক্ষরের সংক্ষিপ্ত"},
+        "postalCode": {"label": "পোস্টাল কোড", "instruction": "৫ অথবা ৯ ডিজিটের পোস্টাল কোড"}
+      }
+    },
+    "verifyAddress": {
+      "title": "ধাপ 3 of 5: ঠিকানা ভেরিফিকেশন",
+      "description": "অনুগ্রহ করে সঠিক ঠিকানা নির্বাচন করুন।",
+      "homeAddress": "বাসার ঠিকানা",
+      "workAddress": "Alternate Address"
+    },
+    "account": {
+      "title": "5 এর ধাপ 4: আপনার অ্যাকাউন্ট কাস্টমাইজ করুন",
+      "username": {
+        "label": "ব্যবহারকারীর নাম",
+        "instruction": "৫-২৫ আলফানিউমেরিক অক্ষর। কোন বিশেষ অক্ষর নেই.",
+        "checkButton": "ব্যবহারকারীর নাম সুপ্রাপ্য কিনা পরীক্ষা করুন"
+      },
+      "password": {
+        "label": "পিন",
+        "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"
+      },
+      "verifyPassword": {
+        "label": "প্রয়োজনীয় পিন",
+        "instruction": "8-32 টি সংখ্যা"
+      },
+      "showPassword": "পিন দেখাও",
+      "selectLibrary": "একটি হোম লাইব্রেরী নির্বাচন করুন:",
+      "termsAndCondition": "হ্যাঁ, আমি শর্তাবলী মেনে নিচ্ছি।"
+    },
+    "review": {
+      "title": "5 এর ধাপ 5: আপনার তথ্য নিশ্চিত করুন",
+      "description": "নিশ্চিত হয়ে নিন যে আপনি যে সব তথ্য প্রবেশ করিয়েছেন তা সঠিক। যদি প্রয়োজন হয়, আপনি আপনার আবেদন পত্র জমা করার আগে এখনও পরিবর্তন করতে পারেন।",
+      "receiveNewsletter": "Receive information about NYPL's programs and services",
+      "yes": "হ্যাঁ",
+      "no": "না"
+    },
+    "button": {
+      "start": "এবার শুরু করা যাক",
+      "edit": "সম্পাদনা করুন",
+      "submit": "জমা",
+      "next": "পরবর্তী",
+      "previous": "পূর্ববর্তী"
+    },
     "confirmation": {}
   }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,9 +5,8 @@
       "part1": "If you are 13 or older and live, work, attend school, or pay property taxes in New York State, you can get a free digital library card right now using this online form. Visitors to New York State can also use this form to apply for a temporary card.",
       "part2": "With a digital library card you get free access to the Library’s wide array of digital resources—including e-books, databases, educational resources, and more.",
       "part3": "By submitting an application, you understand and agree to our <a href='https://www.nypl.org/help/library-card/terms-conditions'>Cardholder Terms and Conditions</a> and agree to our <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>Rules and Regulations</a>. To learn more about the Library’s use of personal information, please read our <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>Privacy Policy</a>."
-    },
-    "button": "Get Started"
-  },
+    }
+   },
   "personal": {
     "title": "Step 1 of 5: Personal Information",
     "firstName": {
@@ -18,11 +17,11 @@
     },
     "birthdate": {
       "label": "Date of Birth",
-      "instructionText": "MM/DD/YYYY, including slashes"
+      "instruction": "MM/DD/YYYY, including slashes"
     },
     "email": {
       "label": "Email Address",
-      "instructionText": "An email address is required to use many of our digital resources, such as e-books. If you do not wish to provide an email address, you can apply for a physical card using our <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>alternate form</a>. Once filled out, please visit one of our <a href='https://www.nypl.org/locations'>locations</a> with proof of identity and home address to pick up your card."
+      "instruction": "An email address is required to use many of our digital resources, such as e-books. If you do not wish to provide an email address, you can apply for a physical card using our <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>alternate form</a>. Once filled out, please visit one of our <a href='https://www.nypl.org/locations'>locations</a> with proof of identity and home address to pick up your card."
     },
     "errorMessage": {
       "firstName": "",
@@ -35,37 +34,44 @@
     }
   },
   "location": {
-    "title": ""
+    "title": "Step 2 of 5: Address",
+    "description": "If you live in NYC, please fill out the home address form.",
+    "address": {
+      "line1": {"label": "Street Address"},
+      "line2": {"label":"Apartment / Suite"},
+      "city": {"label": "City"},
+      "state": {"label": "State", "instruction": "2-letter abbreviation"},
+      "postalCode": {"label": "Postal Code", "instruction": "5 or 9-digit postal code"}
+    }
   },
-  "address": {
-    "line1": "Street Address",
-    "line2": "Apartment / Suite",
-    "city": "City",
-    "state": "State",
-    "stateInstruction": "2-letter abbreviation",
-    "postalCode": "Postal Code",
-    "postalCodeInstruction": "5 or 9-digit postal code"
+  "verifyAddress": {
+    "title": "Step 3 of 5: Address Verification",
+    "description": "Please select the correct address.",
+    "homeAddress": "Home Address",
+    "workAddress": "Alternate Address"
   },
-  "alternateAddress": {},
-  "verifyAddress": {},
   "account": {
-    "username": "Username",
-    "usernameInstruction": "5-25 alphanumeric characters. No special characters.",
-    "usernameCheckButton": "Check if username is available",
-    "password": "Password",
-    "passwordInstruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>",
-    "verifyPassword": "Verify Password",
-    "verifyPasswordInstruction": "8-32 characters",
+    "title": "Step 4 of 5: Customize Your Account",
+    "username": {"label": "Username", "instruction": "5-25 alphanumeric characters. No special characters.", "checkButton": "Check if username is available"},
+    "password": {"label": "Password", "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"},
+    "verifyPassword": {"label": "Verify Password", "instruction": "8-32 characters"},
     "showPassword": "Show Password",
     "selectLibrary": "Select a home library:",
     "termsAndCondition": "Yes, I accept the terms and conditions."
   },
   "review": {
-    "editButton": "Edit",
-    "submitButton": "Submit",
+    "title": "Step 5 of 5: Confirm Your Information",
+    "description": "Make sure all the information you’ve entered is correct. If needed, you can still make changes before you submit your application.",
     "receiveNewsletter": "Receive information about NYPL's programs and services",
     "yes": "Yes",
     "no": "No"
+  },
+  "button": {
+    "start": "Get Started",
+    "edit": "Edit",
+    "submit": "Submit",
+    "next": "Next",
+    "previous": "Previous"
   },
   "confirmation": {}
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -53,18 +53,28 @@
   "account": {
     "title": "Step 4 of 5: Customize Your Account",
     "username": {"label": "Username", "instruction": "5-25 alphanumeric characters. No special characters.", "checkButton": "Check if username is available"},
-    "password": {"label": "Password", "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"},
+    "password": {"label": "Password", "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"},
     "verifyPassword": {"label": "Verify Password", "instruction": "8-32 characters"},
     "showPassword": "Show Password",
     "selectLibrary": "Select a home library:",
-    "termsAndCondition": "Yes, I accept the terms and conditions."
+    "termsAndCondition": {
+      "label": "Yes, I accept the terms and conditions.",
+      "text": " By submitting an application, you understand and agree to our <a href='https://www.nypl.org/help/library-card/terms-conditions'>Cardholder Terms and Conditions</a> and agree to our <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>Rules and Regulations</a>. To learn more about the Library’s use of personal information, please read our <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>Privacy Policy</a>."
+    }
   },
   "review": {
     "title": "Step 5 of 5: Confirm Your Information",
     "description": "Make sure all the information you’ve entered is correct. If needed, you can still make changes before you submit your application.",
+    "section": {
+      "personal": "Personal Information",
+      "address": {"label": "Address", "location": "Location", "home": "Home","work": "Work"}, 
+      "homeLibrary": "Home Library",
+      "createAccount": "Create Your Account"
+    },
     "receiveNewsletter": "Receive information about NYPL's programs and services",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "nextStep": "After you submit your application, you will see a confirmation page with your account information, and you will be able to log in and request books and materials."
   },
   "button": {
     "start": "Get Started",
@@ -73,5 +83,19 @@
     "next": "Next",
     "previous": "Previous"
   },
-  "confirmation": {}
+  "confirmation": {
+    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "description": {
+      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
+      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
+      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+    },
+    "nextSteps": {
+      "h2": "Get Started with The New York Public Library",
+      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
+      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
+      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+    }
+  }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -76,19 +76,17 @@
     "no": "No",
     "nextStep": "After you submit your application, you will see a confirmation page with your account information, and you will be able to log in and request books and materials."
   },
-  "button": {
-    "start": "Get Started",
-    "edit": "Edit",
-    "submit": "Submit",
-    "next": "Next",
-    "previous": "Previous"
-  },
   "confirmation": {
     "title": "Congratulations! You now have a digital New York Public Library card.",
     "description": {
       "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
       "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
       "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+    },
+    "graphic": {
+      "memberName": "Member Name",
+      "password": "Password",
+      "issued": "Issued"
     },
     "nextSteps": {
       "h2": "Get Started with The New York Public Library",
@@ -97,5 +95,16 @@
       "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
       "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
     }
+  },
+  "button": {
+    "start": "Get Started",
+    "edit": "Edit",
+    "submit": "Submit",
+    "next": "Next",
+    "previous": "Previous"
+  },
+  "ariaLabel": {
+    "librarySuggestions": "List of library name suggestions",
+    "barcode": "Scannable barcode"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -5,47 +5,59 @@
       "part1": "Si tiene 13 años de edad o más y vive, trabaja, va a la escuela o paga impuestos de propiedad en el estado de Nueva York, puede obtener una tarjeta digital gratuita de la Biblioteca ahora mismo utilizando este formulario en línea. Las personas que visitan el estado de Nueva York también pueden usar este formulario para solicitar una tarjeta temporal.",
       "part2": "Con una tarjeta digital de la Biblioteca, tiene acceso gratuito a una amplia gama de recursos digitales incluyendo libros electrónicos, bases de datos, recursos educativos y más.",
       "part3": "Al enviar una solicitud, comprende y acepta nuestros <a href='https://www.nypl.org/help/library-card/terms-conditions'>Términos y condiciones del titular de la tarjeta</a> (en inglés) y acepta nuestras <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>Normas y reglamentos generales</a>. Para obtener más información sobre el uso de información personal por parte de la Biblioteca, lea nuestra <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>Política de privacidad</a>."
-    },
-    "button": "Empieza"
+    }
   },
   "personal": {
-    "firstName": "Nombre",
-    "lastName": "Apellido",
-    "dob": "Fecha de nacimiento",
-    "dobInstruction": "DD / MM / AAAA, incluyendo barras",
-    "email": "Correo Electrónico",
-    "emailInstruction": "Se requiere una dirección de correo electrónico para utilizar muchos de nuestros recursos digitales, como los libros electrónicos. Si no desea proporcionar una dirección de correo electrónico, puede solicitar una tarjeta física utilizando nuestro <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>formulario alterno (en inglés)</a>. Una vez que lo haya completado, por favor visite una de nuestras bibliotecas con un comprobante de identidad y domicilio para recoger su tarjeta física.",
-    "newsletter": "Sí, me gustaría recibir información sobre los programas y servicios que ofrece la NYPL"
+    "title": "Paso 1 de 5: información personal",
+    "firstName": {"label": "Nombre"},
+    "lastName": {"label": "Apellido"},
+    "birthdate": {"label": "Fecha de nacimiento","instruction": "DD / MM / AAAA, incluyendo barras"},
+    "email": {"label": "Correo Electrónico", "instruction": "Se requiere una dirección de correo electrónico para utilizar muchos de nuestros recursos digitales, como los libros electrónicos. Si no desea proporcionar una dirección de correo electrónico, puede solicitar una tarjeta física utilizando nuestro <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>formulario alterno (en inglés)</a>. Una vez que lo haya completado, por favor visite una de nuestras bibliotecas con un comprobante de identidad y domicilio para recoger su tarjeta física."},
+    "eCommunications": {"labelText": "Sí, me gustaría recibir información sobre los programas y servicios que ofrece la NYPL"}
   },
-  "address": {
-    "line1": "Dirreción de domicilio",
-    "line2": "Apartamento / Unidad",
-    "city": "Ciudad",
-    "state": "Estado",
-    "stateInstruction": "Abreviatura de 2 letras",
-    "postalCode": "Código postal",
-    "postalCodeInstruction": "Código postal de 5 ó 9 dígitos"
+  "location": {
+    "title": "Paso 2 de 5: dirección",
+    "description": "Si vive en la ciudad de Nueva York, por favor complete el formulario de domicilio.",
+    "address": {
+      "line1": {"label": "Dirreción de domicilio"},
+      "line2": {"label": "Apartamento / Unidad"},
+      "city": {"label": "Ciudad"},
+      "state": {"label": "Estado", "instruction": "Abreviatura de 2 letras"},
+      "postalCode": {"label": "Código postal", "instruction": "Código postal de 5 ó 9 dígitos"}
+    }
   },
-  "alternateAddress": {},
-  "verifyAddress": {},
+  "verifyAddress": {
+    "title": "Paso 3 de 5: verificación de la dirección",
+    "description": "Seleccione la dirección correcta.",
+    "homeAddress": "Dirección de domicilio",
+    "workAddress": "Alternate Address"
+  },
   "account": {
-    "username": "Nombre de usuario",
-    "usernameInstruction": "5-25 caracteres alfanuméricos. Sin caracteres especiales.",
-    "usernameCheckButton": "Compruebe si el nombre del usuario está disponible",
-    "password": "...",
-    "passwordInstruction": "...",
-    "verifyPassword": "...",
-    "verifyPasswordInstruction": "...",
+    "title": "Paso 4 de 5: personalice su cuenta",
+    "username": {
+      "label": "Nombre de usuario",
+      "instruction": "5-25 caracteres alfanuméricos. Sin caracteres especiales.",
+      "checkButton": "Compruebe si el nombre del usuario está disponible"
+    },
+    "password": {"label": "...", "instruction": "..."},
+    "verifyPassword": {"label": "...", "instruction": "..."},
     "showPassword": "...",
     "selectLibrary": "Seleccione una biblioteca local:",
     "termsAndCondition": "Sí, acepto los términos y condiciones."
   },
   "review": {
-    "editButton": "Editar",
-    "submitButton": "Enviar",
+    "title": "Paso 5 de 5 : confirme su información",
+    "description": "Asegúrese de que toda la información que ingresó sea correcta. Si es necesario, aún puede realizar cambios al formulario antes de enviar su solicitud.",
     "receiveNewsletter": "...",
     "yes": "Si",
     "no": "No"
+  },
+  "button": {
+    "start": "Empieza",
+    "edit": "Editar",
+    "submit": "Enviar",
+    "next": "Próximo",
+    "previous": "Previo"
   },
   "confirmation": {}
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -5,13 +5,81 @@
         "part1": "Si vous avez plus de 13 ans et que vous habitez, travaillez, étudiez ou payez des impôts fonciers dans l’État de New York, vous pouvez obtenir immédiatement une carte de bibliothèque numérique gratuite en remplissant ce formulaire.",
         "part2": "Cette carte dématérialisée vous permet d’accéder gratuitement au vaste catalogue numérique de la Bibliothèque—y compris aux livres électroniques, aux bases de données, aux ressources pédagogiques, et bien plus encore.",
         "part3": "En soumettant cette demande, vous certifiez que vous avez lu et accepté les <a href='https://www.nypl.org/help/library-card/terms-conditions'>conditions générales des titulaires de la carte</a> ainsi que notre <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>règlement intérieur</a>. Pour en savoir plus sur l’utilisation de vos données personnelles par la Bibliothèque, veuillez lire notre <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>politique de confidentialité</a>."
-      },
-      "button": "Commencer"
+      }
     },
-    "address": {},
-    "alternateAddress": {},
-    "verifyAddress": {},
-    "account": {},
-    "confirm": {},
+    "personal": {
+      "title": "Étape 1/5 : Informations personnelles",
+      "firstName": {
+        "label": "Prénom"
+      },
+      "lastName": {
+        "label": "Nom de famille"
+      },
+      "birthdate": {
+        "label": "Date de naissance",
+        "instruction": "MM/JJ/AAAA, séparés par des barres"
+      },
+      "email": {
+        "label": "Email Address",
+        "instruction": "Une adresse e-mail vous sera demandée pour l’utilisation de nombreuses ressources numériques comme les livres électroniques. Si vous ne souhaitez pas renseigner votre adresse email, vous pouvez demander une carte physique en remplissant notre <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>autre formulaire</a>. Une fois que vous l’aurez rempli, rendez-vous dans l’une de nos <a href='https://www.nypl.org/locations'>bibliothèques</a> avec une pièce d’identité et un justificatif de domicile pour récupérer votre carte."
+      },
+      "errorMessage": {
+        "firstName": "",
+        "lastName": "",
+        "birthdate": "",
+        "email": ""
+      },
+      "eCommunications": {
+        "labelText": "Oui, je souhaite recevoir les informations sur les activités et les services de la NYPL."
+      }
+    },
+    "location": {
+      "title": "Étape 2/5 : Adresse",
+      "description": "Si vous habitez dans la ville de New York, merci d’indiquer l’adresse de votre domicile.",
+      "address": {
+        "line1": {"label": "Nom de la rue"},
+        "line2": {"label":"Apartment / Suite"},
+        "city": {"label": "Ville"},
+        "state": {"label": "État", "instruction": "Abréviation (2 lettres)"},
+        "postalCode": {"label": "Code postal", "instruction": "Code postal à 5 ou 9 chiffres"}
+      }
+    },
+    "verifyAddress": {
+      "title": "Étape 3/5 : Vérification de l’adresse",
+      "homeAddress": "Adresse de votre domicile",
+      "workAddress": "Alternate Address"
+    },
+    "account": {
+      "title": "Étape 4/5 : Personnalisation de votre compte",
+      "username": {
+        "label": "Nom d’utilisateur",
+        "instruction": "5 à 25 caractères alphanumériques, pas de caractères spéciaux",
+        "checkButton": "Vérification de la disponibilité du nom d’utilisateur."
+      },
+      "password": {
+        "label": "Code secret",
+        "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"},
+      "verifyPassword": {
+        "label": "Vérification du code secret",
+        "instruction": "8-32 chiffres"
+      },
+      "showPassword": "Montrer le code secret",
+      "selectLibrary": "Sélectionnez une bibliothèque de rattachement:",
+      "termsAndCondition": "Oui, j’accepte les conditions générales."
+    },
+    "review": {
+      "title": "Étape 5/5 : Confirmation de vos informations",
+      "description":  "Assurez-vous que toutes les informations que vous avez fournies sont correctes. Si besoin, vous pouvez les modifier avant d’envoyer votre demande.",
+      "receiveNewsletter": "Receive information about NYPL's programs and services",
+      "yes": "Oui",
+      "no": "Non"
+    },
+    "button": {
+      "start": "Commencer",
+      "edit": "Modifier",
+      "submit": "Envoyer",
+      "next": "Suivant",
+      "previous": "Retour"
+    },
     "confirmation": {}
   }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -5,13 +5,83 @@
         "part1": "Если вы старше 13 лет, работаете , посещаете учебные заведения, или уплачиваете налоги в штате Нью Йорк, вы имеете право подать электронное заявление о получении библиотечной карточки. Лица временно находящиеся в штате Нью Йорк также имеют право  подать заявление на временное пользование библиотекой.",
         "part2": "При наличии цифровой карточки библиотеки вы сможете получить доступ к многочисленным электронным ресурсам, в том числе, к электронным книгам, базам данных, образовательным ресурсам, и многим другим источникам.",
         "part3": "Подача данного заявления является вашим согласием с установленными <a href='https://www.nypl.org/help/library-card/terms-conditions'>правилами и положениями пользователя Нью Йоркской Публичной Библиотекиs</a> and agree to our <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>Rules and Regulations</a>. Дополнительная информация о правилах пользования личными данными находится в <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>Правилах Конфиденциальности.</a>"
-      },
-      "button": "Начать"
+      }
     },
-    "address": {},
-    "alternateAddress": {},
-    "verifyAddress": {},
-    "account": {},
-    "confirm": {},
+    "personal": {
+      "title": "Первый этап : Личные данные",
+      "firstName": {
+        "label": "Имя"
+      },
+      "lastName": {
+        "label": "Фамилия"
+      },
+      "birthdate": {
+        "label": "Дата рождения",
+        "instruction": "MM/DD/YYYY, including slashes"
+      },
+      "email": {
+        "label": "Email Address",
+        "instruction": "An email address is required to use many of our digital resources, such as e-books. If you do not wish to provide an email address, you can apply for a physical card using our <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>alternate form</a>. Once filled out, please visit one of our <a href='https://www.nypl.org/locations'>locations</a> with proof of identity and home address to pick up your card."
+      },
+      "errorMessage": {
+        "firstName": "",
+        "lastName": "",
+        "birthdate": "",
+        "email": ""
+      },
+      "eCommunications": {
+        "labelText": " Да, я желаю получать информацию по электронной почте от Нью-Йоркской Публичной Библиотеки о новых услугах и программах"
+      }
+    },
+    "location": {
+      "title": "Второй этап: адрес",
+      "description": "Если вы проживаете в пределах города Нью Йорка, пожалуйста заполните нижеуказанные пункты",
+      "address": {
+        "line1": {"label": "Улица"},
+        "line2": {"label":"Квартира"},
+        "city": {"label": "Район"},
+        "state": {"label": "Штат", "instruction": "2-letter abbreviation"},
+        "postalCode": {"label": "Почтовый индекс", "instruction": "5 or 9-digit postal code"}
+      }
+    },
+    "verifyAddress": {
+      "title": "Третий этап: подтверждение места проживания",
+      "description": "Укажите правильный адрес",
+      "homeAddress": "Домашний адрес",
+      "workAddress": "Alternate Address"
+    },
+    "account": {
+      "title": "Шаг четвертый: Настройки учетной записи",
+      "username": {
+        "label": "Имя пользователя",
+        "instruction": "5-25 буквенно-цифровых знаков No special characters.",
+        "checkButton": "Проверьте, не используется ли данное имя пользователя."
+      },
+      "password": {
+        "label": "Пин код",
+        "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"
+      },
+      "verifyPassword": {
+        "label": "Подтвердите пин код",
+        "instruction": "8-32 цифры"
+      },
+      "showPassword": "Показать пин код",
+      "selectLibrary": "Выбор близлежащего или удобно расположенного филиала",
+      "termsAndCondition": "Да , я подтверждаю согласие  с условиями и положениями пользования библиотекой."
+    },
+    "review": {
+      "title": "Шаг пятый. Подтверждение личных данных",
+      "description": "Проверьте правильность всех указанных вами данных. При необходимости вы можете внести исправления до отправки заявления.",
+      "receiveNewsletter": "Receive information about NYPL's programs and services",
+      "yes": "Да",
+      "no": "Нет"
+    },
+    "button": {
+      "start": "Начать",
+      "edit": "Корректировка",
+      "submit": "Отправить",
+      "next": "Следующее",
+      "previous": "Назад"
+    },
     "confirmation": {}
   }

--- a/public/locales/zhcn/common.json
+++ b/public/locales/zhcn/common.json
@@ -5,13 +5,83 @@
         "part1": "如果您是13岁以上，并且在纽约州生活，工作，上学或缴纳财产税，则可以立即使用此在线表格获得免费的电子图书卡。 纽约州的访客也可以使用此表格申请临时卡。",
         "part2": "有了电子图书卡，您就可以免费访问图书馆的各种数字资源，包括电子书，数据库，教育资源等。",
         "part3": "提交申请，即表示您理解并同意我们的<a href='https://www.nypl.org/help/library-card/terms-conditions'>持卡人条款和条件</a>，并同意我们的<a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>规范与法则</a>。要了解有关图书馆使用个人资料的更多信息，请阅读我们的<a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>隐私政策</a>。"
-      },
-      "button": "开始使用"
+      }
     },
-    "address": {},
-    "alternateAddress": {},
-    "verifyAddress": {},
-    "account": {},
-    "confirm": {},
+    "personal": {
+      "title": "第1步：个人资料",
+      "firstName": {
+        "label": "名字"
+      },
+      "lastName": {
+        "label": "姓氏"
+      },
+      "birthdate": {
+        "label": "出生日期",
+        "instruction": "月 / 日 / 年 (MM / DD / YYYY)，包括斜线"
+      },
+      "email": {
+        "label": "Email Address",
+        "instruction": "使用我们的许多数字资源（例如，电子书）都需要一个电子邮件地址。 如果您不希望提供电 子邮件地址，则可以使用我们 <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>另一个表格</a>来申请实体图书卡。 填写完毕后，请造访我们其中一个 <a href='https://www.nypl.org/locations'>分馆</a>，提供身份和家庭住址证明以领取您的卡。 "
+      },
+      "errorMessage": {
+        "firstName": "",
+        "lastName": "",
+        "birthdate": "",
+        "email": ""
+      },
+      "eCommunications": {
+        "labelText": "是的，我想收到有关NYPL活动和服务的信息"
+      }
+    },
+    "location": {
+      "title": "第2步：地址",
+      "description": "如果您住在纽约市，请填写居住地址部分。",
+      "address": {
+        "line1": {"label": "街道地址"},
+        "line2": {"label":"公寓號碼"},
+        "city": {"label": "城市"},
+        "state": {"label": "州", "instruction": "2个字母的缩写"},
+        "postalCode": {"label": "邮政编码", "instruction": "5位或9位邮政编码"}
+      }
+    },
+    "verifyAddress": {
+      "title": "第3步：地址验证",
+      "description": "请选择正确的地址",
+      "homeAddress": "居住地址",
+      "workAddress": "Alternate Address"
+    },
+    "account": {
+      "title": "第4步：自定制您的帐户",
+      "username": {
+        "label": "用户名",
+        "instruction": "5-25个字母数字。没有特殊符号。",
+        "checkButton": "检查用户名是否可用"
+      },
+      "password": {
+        "label": "密码 (PIN)",
+        "instruction": "<p>We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab</p>"
+      },
+      "verifyPassword": {
+        "label": "验证密码 (PIN)",
+        "instruction": "8-32 characters"
+      },
+      "showPassword": "显示密码 (PIN)",
+      "selectLibrary": "選一個您經常使用的圖書館：",
+      "termsAndCondition": "是的，我接受这些条款和条件。"
+    },
+    "review": {
+      "title": "第5步：确认您的资料",
+      "description": "确保您输入的所有资料都是正确的。 如果需要，您仍然可以在提交申请之前进行更改。",
+      "receiveNewsletter": "Receive information about NYPL's programs and services",
+      "yes": "是的",
+      "no": "不"
+    },
+    "button": {
+      "start": "开始使用",
+      "edit": "更改",
+      "submit": "提交",
+      "next": "下一步",
+      "previous": "上一步"
+    },
     "confirmation": {}
   }

--- a/src/components/AcceptTermsFormFields/index.tsx
+++ b/src/components/AcceptTermsFormFields/index.tsx
@@ -43,7 +43,7 @@ const AcceptTermsForm = () => {
         isChecked={formValues.acceptTerms}
         isInvalid={errors?.acceptTerms?.message}
         name="acceptTerms"
-        labelText={t("account.termsAndCondition")}
+        labelText={t("account.termsAndCondition.label")}
         // Users must click the checkbox in order to submit.
         ref={register({
           required: "The Terms and Conditions must be checked.",

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -86,9 +86,9 @@ function AccountFormFields({ id, showPasswordOnLoad }: AccountFormFieldsProps) {
           <FormField
             id="password"
             type={passwordType}
-            label={t("account.password")}
+            label={t("account.password.label")}
             name="password"
-            instructionText={t("account.passwordInstruction")}
+            instructionText={t("account.password.instruction")}
             isRequired
             errorState={errors}
             minLength={minPasswordLength}
@@ -107,9 +107,9 @@ function AccountFormFields({ id, showPasswordOnLoad }: AccountFormFieldsProps) {
           <FormField
             id="verifyPassword"
             type={passwordType}
-            label={t("account.verifyPassword")}
+            label={t("account.verifyPassword.label")}
             name="verifyPassword"
-            instructionText={t("account.verifyPasswordInstruction")}
+            instructionText={t("account.verifyPassword.instruction")}
             isRequired
             errorState={errors}
             minLength={minPasswordLength}

--- a/src/components/AddressFormFields/index.tsx
+++ b/src/components/AddressFormFields/index.tsx
@@ -71,7 +71,7 @@ const AddressForm = ({ id, type, errorMessages }: AddressFormProps) => {
         <DSFormField>
           <FormField
             id={`line1-${type}`}
-            label={t("address.line1")}
+            label={t("location.address.line1")}
             name={`${type}-line1`}
             isRequired={isRequired}
             errorState={errors}
@@ -90,7 +90,7 @@ const AddressForm = ({ id, type, errorMessages }: AddressFormProps) => {
         <DSFormField>
           <FormField
             id={`line2-${type}`}
-            label={t("address.line2")}
+            label={t("location.address.line2")}
             name={`${type}-line2`}
             ref={register()}
             defaultValue={formValues[`${type}-line2`]}
@@ -102,7 +102,7 @@ const AddressForm = ({ id, type, errorMessages }: AddressFormProps) => {
         <DSFormField>
           <FormField
             id={`city-${type}`}
-            label={t("address.city")}
+            label={t("location.address.city")}
             name={`${type}-city`}
             isRequired={isRequired}
             errorState={errors}
@@ -118,8 +118,8 @@ const AddressForm = ({ id, type, errorMessages }: AddressFormProps) => {
         <DSFormField>
           <FormField
             id={`state-${type}`}
-            instructionText={t("address.stateInstruction")}
-            label={t("address.state")}
+            instructionText={t("location.address.state.instruction")}
+            label={t("location.address.state.label")}
             name={`${type}-state`}
             isRequired={isRequired}
             errorState={errors}
@@ -136,13 +136,13 @@ const AddressForm = ({ id, type, errorMessages }: AddressFormProps) => {
         <DSFormField>
           <FormField
             id={`zip-${type}`}
-            label={t("address.postalCode")}
+            label={t("location.address.postalCode.label")}
             name={`${type}-zip`}
             isRequired={isRequired}
             errorState={errors}
             minLength={MINLENGTHZIP}
             maxLength={MAXLENGTHZIP}
-            instructionText={t("address.postalCodeInstruction")}
+            instructionText={t("location.address.postalCode.instruction")}
             ref={register({
               validate: validateZip(),
             })}

--- a/src/components/PersonalFormFields/index.tsx
+++ b/src/components/PersonalFormFields/index.tsx
@@ -88,7 +88,7 @@ function PersonalFormFields({ agencyType = "", id = "" }) {
                 val === "" || isEmail(val) || errorMessages.email,
             })}
             defaultValue={formValues.email}
-            instructionText={t("personal.email.instructionText")}
+            instructionText={t("personal.email.instruction")}
           />
         </DSFormField>
       </FormRow>

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -87,7 +87,7 @@ function ReviewFormContainer() {
           editSectionFlag(true);
         }}
       >
-        {t("review.editButton")}
+        {t("button.edit")}
       </Button>
     ) : (
       <a
@@ -95,7 +95,7 @@ function ReviewFormContainer() {
           `newCard=true${queryValues}`
         )}`}
       >
-        {t("review.editButton")}
+        {t("button.edit")}
       </a>
     );
   /**
@@ -113,7 +113,7 @@ function ReviewFormContainer() {
           router.push("/location?newCard=true");
         }}
       >
-        {t("review.editButton")}
+        {t("button.edit")}
       </Button>
     ) : (
       <a
@@ -121,7 +121,7 @@ function ReviewFormContainer() {
           `newCard=true${queryValues}`
         )}`}
       >
-        {t("review.editButton")}
+        {t("button.edit")}
       </a>
     );
   const submitSectionButton = (
@@ -132,7 +132,7 @@ function ReviewFormContainer() {
         onClick={() => {}}
         type="submit"
       >
-        {t("review.submitButton")}
+        {t("button.submit")}
       </Button>
     </ButtonGroup>
   );
@@ -246,11 +246,11 @@ function ReviewFormContainer() {
   const renderAccountValues = () => (
     <div className={styles.container}>
       <div className={styles.field}>
-        <div className={styles.title}>{t("account.username")}</div>
+        <div className={styles.title}>{t("account.usernamel.label")}</div>
         <div>{formValues.username}</div>
       </div>
       <div className={styles.field}>
-        <div className={styles.title}>{t("account.password")}</div>
+        <div className={styles.title}>{t("account.password.label")}</div>
         {/* Only render the toggleable password with javascript enabled. */}
         {clientSide ? (
           <>
@@ -442,9 +442,7 @@ function ReviewFormContainer() {
 
         <FormRow margin-top="20px">
           <DSFormField>
-            <RoutingLinks
-              next={{ submit: true, text: t("review.submitButton") }}
-            />
+            <RoutingLinks next={{ submit: true, text: t("button.submit") }} />
           </DSFormField>
         </FormRow>
       </Form>

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -246,7 +246,7 @@ function ReviewFormContainer() {
   const renderAccountValues = () => (
     <div className={styles.container}>
       <div className={styles.field}>
-        <div className={styles.title}>{t("account.usernamel.label")}</div>
+        <div className={styles.title}>{t("account.username.label")}</div>
         <div>{formValues.username}</div>
       </div>
       <div className={styles.field}>

--- a/src/components/UsernameValidationFormFields/index.tsx
+++ b/src/components/UsernameValidationFormFields/index.tsx
@@ -108,7 +108,7 @@ const UsernameValidationForm = ({
           onClick={validateUsername}
           type="button"
         >
-          {t("account.usernameCheckButton")}
+          {t("account.username.checkButton")}
         </Button>
       </ButtonGroup>
     );
@@ -120,7 +120,7 @@ const UsernameValidationForm = ({
         <DSFormField>
           <FormField
             id="username"
-            label={t("account.username")}
+            label={t("account.username.label")}
             name="username"
             instructionText="5-25 alphanumeric characters. No special characters."
             isRequired


### PR DESCRIPTION
## Description

- Adds "title" to each page section in the 6 provided languages
- Updates json structure to have a 'button section" containing all button texts
- Updates the Form Files using button translation to use the new structure
- Adds the translation in the 6 provided languages for Location and Account pages as available
- Adds "congrats" page text in en language file
- Adds "aria-label" text in en language file

**Note** 
I will inform Smriti again of missing pieces in the translation files.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
