### PR TITLE
moving the language menu up on the page

### DIFF
--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -36,7 +36,10 @@ function HomePage({
   const queryParam = policyType ? `&policyType=${policyType}` : "";
   return (
     <>
+      <LanguageMenu />
+
       <Heading level="two">{t("home.title")}</Heading>
+
       <p>{t("home.description.part1")}</p>
       <p>{t("home.description.part2")}</p>
       <div dangerouslySetInnerHTML={{ __html: t("home.description.part3") }} />
@@ -49,8 +52,6 @@ function HomePage({
           text: t("button.start"),
         }}
       />
-
-      <LanguageMenu />
     </>
   );
 }

--- a/src/components/RoutingLinks.tsx/RoutingLinks.module.css
+++ b/src/components/RoutingLinks.tsx/RoutingLinks.module.css
@@ -31,7 +31,6 @@
   display: inline-block;
   background-color: var(--nypl-colors-ui-link-primary) !important;
   color: var(--nypl-colors-ui-white);
-  border: 1px solid var(--nypl-colors-ui-gray-medium);
   margin-right: 10px;
   border-radius: 2px;
   padding: 8px 30px;
@@ -43,7 +42,6 @@
   display: inline-block;
   background-color: var(--nypl-colors-ui-link-primary) !important;
   color: var(--nypl-colors-ui-white);
-  border: 1px solid var(--nypl-colors-ui-gray-medium);
   margin-right: 10px;
   text-decoration: none !important;
   border-radius: 2px;

--- a/src/styles/components/globals.scss
+++ b/src/styles/components/globals.scss
@@ -12,8 +12,8 @@
   a {
     text-decoration: underline !important;
   }
+}
 
-  #footer a {
-    text-decoration: none !important;
-  }
+#footer {
+  box-sizing: initial;
 }


### PR DESCRIPTION
## Description

This moves the language menu with language links to the top of the home page. Also minor style changes to the routing links.

## Motivation and Context

To be consistent with other pages on NYPL.org.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
