### PR TITLE
RENO-3225: Add Congrats Page Translations And Aria-labels

### DIFF
--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -10,7 +10,7 @@
     }
   },
   "personal": {
-    "title": "الخطوة 1 من 5: المعلومات الشخصية",
+    "title": "الخطوة ١ من ٥: المعلومات الشخصية",
     "firstName": {
       "label": "الاسم الأول"
     },
@@ -19,7 +19,7 @@
     },
     "birthdate": {
       "label": "تاريخ الميلاد",
-      "instruction": "شهر/يوم/سنة, including slashes"
+      "instruction": "شهر/يوم/سنة، تتوسط التاريخ خطوط مائلة"
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
@@ -38,7 +38,7 @@
     }
   },
   "location": {
-    "title": "الخطوة 2 من 5: العنوان ",
+    "title": "الخطوة ٢ من ٥: العنوان",
     "address": {
       "title": "عنوان المنزل",
       "description": "إذا كنت تعيش في مدينة نيويورك ، فيرجى إكمال نموذج عنوان المنزل.",
@@ -72,22 +72,22 @@
     "workAddress": "Alternate Address"
   },
   "account": {
-    "title": "الخطوة 4 من 5: تخصيص حسابك",
-    "description": "Create a username and password so you can log in and manage your account or access an array of our digital resources. Your username should be unique.",
+    "title": "الخطوة ٤ من ٥: تخصيص حسابك",
+    "description": "أنشئ اسم مستخدم وكلمة مرور حتى تتمكن من تسجيل الدخول وإدارة حسابك أو الوصول إلى مجموعة من مواردنا الرقمية. يجب أن يكون اسم المستخدم الخاص بك فريدًا.",
     "username": {
       "label": "اسم المستخدم",
       "instruction": "٥-٢٥ حرفًا أبجديًا رقميًا. لا توجد حروفًا  خاصة.",
       "checkButton": "تحقق مما إذا كان اسم المستخدم متاحًا"
     },
     "password": {
-      "label": "رقم التعريف الشخصي",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "كلمة المرور",
+      "instruction": "شجعك على اختيار كلمة مرور قوية تتضمن: ۸ أحرف إنجليزية على الأقل، ومزيجًا من الحروف الكبيرة والحروف الصغيرة، ومزيجًا من الحروف والأرقام، ورمزًا خاصًا واحدًا على الأقل غير النقطة (.) <br />على سبيل المثال: @MyLib1731<br />لا يمكن لكلمة المرور أن تحتوي على أنماط شائعة مثل تكرار حرف ثلاث مرات على التوالي أو أكثر، على سبيل المثال aaaatf54 أو تكرار نمط، على سبيل المثال abcabcab"
     },
     "verifyPassword": {
-      "label": "التحقق من رقم التعريف الشخصي",
-      "instruction": "8-32 characters"
+      "label": "التحقق من كلمة المرور",
+      "instruction": "من ۸ إلى ۳۲ حرفًا إنجليزيًا"
     },
-    "showPassword": "إظهار رقم التعريف الشخصي",
+    "showPassword": "إظهار كلمة المرور",
     "library": {
       "selectLibrary": "حدد مكتبة مفضلة:",
       "placeholder": "اكتب اسم المكتبة ، مثل 'مكتبة باركشستر' (Parkchester)",
@@ -109,15 +109,15 @@
     }
   },
   "review": {
-    "title": "الخطوة 5 من 5: تأكيد معلوماتك",
+    "title": "الخطوة ٥ من ٥: تأكيد معلوماتك",
     "description": "تأكد من صحة جميع المعلومات التي أدخلتها. إذا لزم الأمر ، لا يزال بإمكانك إجراء التغييرات قبل إرسال طلبك.",
     "section": {
       "personal": "معلومات شخصية",
       "address": {
-        "label": "Address",
-        "location": "Location",
-        "home": "Home",
-        "work": "Work"
+        "label": "العنوان",
+        "location": "موقع",
+        "home": "مسكن",
+        "work": "عمل"
       },
       "homeLibrary": "المكتبة المفضلة"
     },
@@ -128,23 +128,23 @@
     "nextStep": "بعد تقديم طلبك ، سترى صفحة تأكيد تحتوي على معلومات حسابك , و ستتمكن من تسجيل الدخول وطلب الكتب والمواد."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "تهانينا! لديك الآن بطاقة رقمية لمكتبة نيويورك العامة.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "اطبع هذه المعلومات أو احفظها لسجلاتك. ستتلقى بريدًا إلكترونيًا في غضون ۲٤ ساعة بتفاصيل حسابك",
+      "part2": "لاستعارة مواد مادية، يرجى زيارة أحد <a href='http://nypl.org/locations'>مواقعنا</a> مع <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'> بطاقة هوية صالحة تحمل صورة وإثبات للعنوان</a>لإكمال طلب الحصول على بطاقة مادية.",
+      "part3": "هذه بطاقة مؤقتة وستنتهي صلاحيتها خلال ۱٤ يومًا. إذا كنت طالبًا في كلية معتمدة في نيويورك أو موظفًا في إحدى شركات مدينة نيويورك، لكنك لست موجودًا في المدينة أو الولاية فعليًا، أو كنت باحثًا سيزور أحد مراكز البحوث الخاصة بنا، يرجى الاتصال <a href='mailto:gethelp@nypl.org'>لتحديث بطاقتك.</a>"
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "كلمة المرور",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "ابدأ مع مكتبة نيويورك العامة",
+      "explore": "<b>استكشف الكتب الإلكترونية الخاصة بالمكتبة</b><br />قم بتنزيل تطبيق SimplyE لأجهزة <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> أو أجهزة <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>استعر الكتب والمزيد</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>سجِّل الدخول إلى حسابك</a> وتصفح الفهرس.",
+      "updates": "<b>احصل على التحديثات</b><br /><a href='https://www.nypl.org/enews'>تعرَّف على كل ما تقدمه المكتبة.</a>",
+      "more": "<b>تعرَّف على المزيد</b><br /><a href='https://www.nypl.org/discover-library-card'>اكتشف كل ما يمكنك فعله ببطاقة المكتبة الخاصة بك.</a>"
     }
   },
   "button": {
@@ -162,7 +162,7 @@
     "defaultError": "حدثت مشكلات تتعلق بعملية الإرسال"
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "قائمة باقتراحات اسم المكتبة",
+    "barcode": "رمز شريطي قابل للمسح الضوئي"
   }
 }

--- a/public/locales/bn/common.json
+++ b/public/locales/bn/common.json
@@ -23,7 +23,7 @@
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
-      "label": "ইমেইল ঠিকানা",
+      "label": "ইমেইল অ্যাড্রেস",
       "instruction": "আমাদের অনেক ডিজিটাল সম্পদ, যেমন ই-বুক ব্যবহার করার জন্য একটি ইমেইল ঠিকানা প্রয়োজন। আপনি যদি একটি ইমেইল ঠিকানা প্রদান করতে না চান, আপনি আমাদের <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>বিকল্প ফর্ম</a>. ব্যবহার করে একটি ফিজিক্যাল কার্ডের জন্য আবেদন করতে পারেন। একবার পূরণ হয়ে গেলে, আপনার কার্ড তোলার জন্য পরিচয় এবং বাড়ির ঠিকানার প্রমাণ সহ অনুগ্রহ করে আমাদের যে কোন একটি <a href='https://www.nypl.org/locations'>স্থানে</a> যান।."
     },
     "eCommunications": {
@@ -45,10 +45,10 @@
       "line1": { "label": "রাস্তার ঠিকানা" },
       "line2": { "label": "এপার্টমেন্ট / সুইট" },
       "city": { "label": "শহর" },
-      "state": { "label": "স্টেট", "instruction": "২ অক্ষরের সংক্ষিপ্ত" },
+      "state": { "label": "রাজ্য", "instruction": "2-টি অক্ষরের অ্যাব্রিভিয়েশন" },
       "postalCode": {
         "label": "পোস্টাল কোড",
-        "instruction": "৫ অথবা ৯ ডিজিটের পোস্টাল কোড"
+        "instruction": "5 বা 9 সংখ্যার পোস্টাল কোড"
       }
     },
     "workAddress": {
@@ -73,21 +73,21 @@
   },
   "account": {
     "title": "ধাপ 5-এর মধ্যে 4: আপনার অ্যাকাউন্ট কাস্টমাইজ করুন",
-    "description": "Create a username and password so you can log in and manage your account or access an array of our digital resources. Your username should be unique.",
+    "description": "ব্যবহারকারীর নাম এবং পাসওয়ার্ড তৈরি করুন, যাতে আপনি লগ ইন করতে পারেন এবং আপনার অ্যাকাউন্ট পরিচালনা করতে পারেন ও আমাদের বিভিন্ন ধরনের ডিজিটাল পরিষেবা অ্যাক্সেস করতে পারেন। আপনার ব্যবহারকারীর নাম অনন্য হতে হবে।",
     "username": {
       "label": "ব্যবহারকারীর নাম",
       "instruction": "৫-২৫ আলফানিউমেরিক অক্ষর। কোন বিশেষ অক্ষর নেই.",
       "checkButton": "ব্যবহারকারীর নাম সুপ্রাপ্য কিনা পরীক্ষা করুন"
     },
     "password": {
-      "label": "পিন",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "পাসওয়ার্ড",
+      "instruction": "এমন শক্তিশালী পাসওয়ার্ড বেছে নিন যার মধ্যে এগুলো যেন থাকে: কমপক্ষে 8টি অক্ষর, বড় হাতের এবং ছোট হাতের অক্ষর নিয়ে, অক্ষর এবং সংখ্যা নিয়ে এবং কমপক্ষে একটি স্পেশাল অক্ষর থাকতে হবে, পিরিয়ড (.)<br />যেমন: MyLib1731@<br />পাসওয়ার্ডের মধ্যে কোনো কমন প্যাটার্ন থাকা যাবে না, যেমন তিনবার বা তার বেশি কোনো অক্ষর ব্যবহার করা, যেমন aaaatf54 অথবা রিপিটিং প্যাটার্ন, যেমন abcabcab"
     },
     "verifyPassword": {
-      "label": "প্রয়োজনীয় পিন",
-      "instruction": "8-32 টি সংখ্যা"
+      "label": "পাসওয়ার্ড যাচাই করুন",
+      "instruction": "8-32টি অক্ষর"
     },
-    "showPassword": "পিন দেখাও",
+    "showPassword": "পাসওয়ার্ড দেখান",
     "library": {
       "selectLibrary": "একটি হোম লাইব্রেরী নির্বাচন করুন:",
       "placeholder": "একটি লাইব্রেরীর নাম টাইপ করুন, যেমন পার্কচেস্টার লাইব্রেরী",
@@ -115,9 +115,9 @@
       "personal": "ব্যক্তিগত তথ্য",
       "address": {
         "label": "ঠিকানা",
-        "location": "Location",
-        "home": "Home",
-        "work": "Work"
+        "location": "অবস্থান",
+        "home": "বাড়ি",
+        "work": "কাজ"
       },
       "homeLibrary": "হোম লাইব্রেরি"
     },
@@ -128,27 +128,27 @@
     "nextStep": "আপনি আপনার আবেদন পত্র জমা দেওয়ার পর, আপনি আপনার অ্যাকাউন্ট তথ্য সহ একটি নিশ্চিতকরণ পৃষ্ঠা দেখতে পাবেন, এবং আপনি লগ ইন করতে পারবেন এবং বই এবং উপকরণ অনুরোধ করতে পারবেন"
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "অভিনন্দন! এবার আপনার কাছে নিউ ইয়র্ক পাবলিক লাইব্রেরির একটি ডিজিটাল কার্ড আছে।",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "আপনার রেকর্ডের জন্য এই তথ্য প্রিন্ট করুন বা সেভ করে রাখুন। 24 ঘণ্টার মধ্যে আপনার অ্যাকাউন্টের বিশদ সহ আপনি একটি ইমেইল পাবেন।",
+      "part2": "ফিজিক্যাল মেটেরিয়াল নিতে হলে আমাদের <a href='http://nypl.org/locations'>লোকেশনে</a> যান, সাথে একটি বৈধ ফটো আইডি <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>এবং ঠিকানার প্রমাণ</a> নিয়ে যাবেন, যাতে ফিজিক্যাল কার্ডের জন্য আবেদন সম্পূর্ণ করা যায়।",
+      "part3": "এই কার্ডটা অস্থায়ী এবং 14 দিন পরে এর মেয়াদ শেষ হবে। আপনি যদি নিউ ইয়র্কের কোনো অনুমোদিত কলেজের শিক্ষার্থী, NYC-তে কর্মরত হলেও শহর বা রাজ্যের বাইরে থাকেন বা একজন গবেষক যিনি আমাদের রিসার্চ সেন্টার ভিজিট করবেন, তাহলে <a href='mailto:gethelp@nypl.org'>আপনার কার্ড আপডেট করার জন্য যোগাযোগ করুন।</a>"
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "পাসওয়ার্ড",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "নিউ ইয়র্ক পাবলিক লাইব্রেরির সাথে শুরু করুন",
+      "explore": "<b>লাইব্রেরির ই-বুক খুঁজে দেখুন</b><br />ডাউনলোড করুন SimplyE, যা <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> বা <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android-এর জন্য পাবেন।</a>.",
+      "borrow": "<b>বই এবং আরও অনেক কিছু পাবেন</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>আপনার অ্যাকাউন্টে লগ ইন করুন</a> এবং ক্যাটালগ ব্রাউজ করুন।",
+      "updates": "<b>আপডেট পান</b><br /><a href='https://www.nypl.org/enews'>লাইব্রেরি থেকে কী কী পাওয়া যায় তা দেখুন।</a>",
+      "more": "<b>আরও জানুন</b><br /><a href='https://www.nypl.org/discover-library-card'>লাইব্রেরি কার্ড দিয়ে আপনি কী কী করতে পারেন তা জানুন।</a>"
     }
   },
   "button": {
-    "start": "এবার শুরু করা যাক",
+    "start": "শুরু করুন",
     "edit": "সম্পাদনা করুন",
     "submit": "জমা",
     "next": "পরবর্তী",
@@ -162,7 +162,7 @@
     "defaultError": "এই জমার সময় একটা ত্রুটি হয়েছে"
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "লাইব্রেরির নামের প্রস্তাবের তালিকা।",
+    "barcode": "স্ক্যান করা যায় এমন বারকোড"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -19,7 +19,7 @@
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
-      "label": "Correo Electrónico",
+      "label": "Dirección de correo electrónico",
       "instruction": "Se requiere una dirección de correo electrónico para utilizar muchos de nuestros recursos digitales, como los libros electrónicos. Si no desea proporcionar una dirección de correo electrónico, puede solicitar una tarjeta física utilizando nuestro <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>formulario alterno (en inglés)</a>. Una vez que lo haya completado, por favor visite una de nuestras bibliotecas con un comprobante de identidad y domicilio para recoger su tarjeta física."
     },
     "eCommunications": {
@@ -37,10 +37,10 @@
     "address": {
       "title": "Dirección de domicilio",
       "description": "Si vive en la ciudad de Nueva York, por favor complete el formulario de domicilio.",
-      "line1": { "label": "Dirreción de domicilio" },
-      "line2": { "label": "Apartamento / Unidad" },
+      "line1": { "label": "Calle" },
+      "line2": { "label": "Departamento/Suite" },
       "city": { "label": "Ciudad" },
-      "state": { "label": "Estado", "instruction": "Abreviatura de 2 letras" },
+      "state": { "label": "Estado", "instruction": "Abreviación de 2 letras" },
       "postalCode": {
         "label": "Código postal",
         "instruction": "Código postal de 5 ó 9 dígitos"
@@ -68,15 +68,15 @@
   },
   "account": {
     "title": "Paso 4 de 5: Personalice su cuenta",
-    "description": "Create a username and password so you can log in and manage your account or access an array of our digital resources. Your username should be unique.",
+    "description": "Cree un nombre de usuario y una contraseña para iniciar sesión y gestionar su cuenta, o para acceder a una amplia variedad de recursos digitales. Su nombre de usuario debe ser único",
     "username": {
       "label": "Nombre de usuario",
-      "instruction": "5-25 caracteres alfanuméricos. Sin caracteres especiales.",
-      "checkButton": "Compruebe si el nombre del usuario está disponible"
+      "instruction": "Entre 5 y 25 caracteres alfanuméricos. No use caracteres especiales.",
+      "checkButton": "Consultar si el nombre de usuario está disponible"
     },
-    "password": { "label": "...", "instruction": "..." },
-    "verifyPassword": { "label": "...", "instruction": "..." },
-    "showPassword": "...",
+    "password": { "label": "Contraseña", "instruction": "Le recomendamos elegir una contraseña segura que incluya al menos 8 caracteres, una combinación de letras mayúsculas y minúsculas, una combinación de letras y números, y al menos un carácter especial, excepto el punto (.).<br />Ejemplo: MyLib1731@<br />La contraseña no puede tener patrones comunes, como repetir consecutivamente un carácter tres o más veces (por ejemplo, aaaatf54) o repetir un patrón (por ejemplo, abcabcab)." },
+    "verifyPassword": { "label": "Verificar contraseña", "instruction": "Entre 8 y 32 caracteres" },
+    "showPassword": "Mostrar contraseña",
     "library": {
       "selectLibrary": "Seleccione una biblioteca local:",
       "placeholder": "Escriba un nombre de biblioteca, como Biblioteca de Parkchester",
@@ -104,9 +104,9 @@
       "personal": "Información personal",
       "address": {
         "label": "Dirreción",
-        "location": "Location",
-        "home": "Home",
-        "work": "Work"
+        "location": "Ubicación",
+        "home": "Hogar",
+        "work": "Trabajar"
       },
       "homeLibrary": "Biblioteca local"
     },
@@ -117,27 +117,27 @@
     "nextStep": "Después de enviar su solicitud, verá una página de confirmación con la información de su cuenta, y podrá iniciar sesión y solicitar libros y materiales."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "¡Felicitaciones! Ahora tiene una tarjeta digital de la Biblioteca Pública de Nueva York.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "Imprima o guarde esta información para su registro. En las próximas 24 horas, recibirá un correo electrónico con los detalles de su cuenta.",
+      "part2": "Para pedir prestados materiales físicos, visite una de nuestras <a href='http://nypl.org/locations'>localidades</a> con una <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>identificación válida con foto y prueba de domicilio particular</a> para completar la solicitud de una tarjeta física.",
+      "part3": "Esta tarjeta es temporal y caducará en 14 días. Si estudia en una universidad acreditada en Nueva York, trabaja en una empresa de la ciudad de Nueva York pero no está físicamente en la ciudad o el estado, o se dedica a investigar y va a visitar uno de nuestros centros de investigación, comuníquese con nosotros <a href='mailto:gethelp@nypl.org'>para actualizar su tarjeta.</a>"
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "Contraseña",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "Comenzar con la Biblioteca Pública de Nueva York",
+      "explore": "<b>Explore los libros electrónicos de la biblioteca</b><br />Descargue SimplyE para <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> o <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>Pedir prestados libros y más</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Inicie sesión en su cuenta </a> y explore el catálogo.",
+      "updates": "<b>Reciba actualizaciones</b><br /><a href='https://www.nypl.org/enews'>Descubra todo lo que la biblioteca tiene para ofrecer.</a>",
+      "more": "<b>Obtener más información</b><br /><a href='https://www.nypl.org/discover-library-card'>Descubra todo lo que puede hacer con su tarjeta de la biblioteca.a>"
     }
   },
   "button": {
-    "start": "Empieza",
+    "start": "Comenzar",
     "edit": "Editar",
     "submit": "Enviar",
     "next": "Próximo",
@@ -151,7 +151,7 @@
     "defaultError": "Hubo un problema con el envío."
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "Lista de sugerencias de nombre de la biblioteca",
+    "barcode": "Código de barras escaneable"
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -23,7 +23,7 @@
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
-      "label": "Email Address",
+      "label": "Adresse e-mail",
       "instruction": "Une adresse e-mail vous sera demandée pour l’utilisation de nombreuses ressources numériques comme les livres électroniques. Si vous ne souhaitez pas renseigner votre adresse email, vous pouvez demander une carte physique en remplissant notre <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>autre formulaire</a>. Une fois que vous l’aurez rempli, rendez-vous dans l’une de nos <a href='https://www.nypl.org/locations'>bibliothèques</a> avec une pièce d’identité et un justificatif de domicile pour récupérer votre carte."
     },
     "eCommunications": {
@@ -67,13 +67,13 @@
   },
   "verifyAddress": {
     "title": "Étape 3/5 : Vérification de l’adresse",
-    "description": "Veuillez sélectionner la bonne adresse..",
+    "description": "Veuillez sélectionner la bonne adresse.",
     "homeAddress": "Adresse de votre domicile",
     "workAddress": "Alternate Address"
   },
   "account": {
     "title": "Étape 4/5 : Personnalisation de votre compte",
-    "description": "Create a username and password so you can log in and manage your account or access an array of our digital resources. Your username should be unique.",
+    "description": "Créez un nom d’utilisateur et un mot de passe pour pouvoir vous connecter, gérer votre compte et accéder à un vaste éventail de nos ressources numériques. Votre nom d’utilisateur doit être unique.",
     "username": {
       "label": "Nom d’utilisateur",
       "instruction": "5 à 25 caractères alphanumériques, pas de caractères spéciaux",
@@ -81,13 +81,13 @@
     },
     "password": {
       "label": "Mot de passe",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "instruction": "Nous vous recommandons de choisir un mot de passe sécurisé qui serait constitué d'au moins 8 caractères, un mélange de minuscules et majuscules, de lettres et de chiffres, et d'au moins un caractère spécial à l'exception du point (.).<br />Exemple: MyLib1731@<br />Le mot de passe ne doit pas suivre une structure commune, comme la répétition d'un même caractère trois fois de suite ou plus, comme par exemple aaaatf54, ou un modèle répétitif, comme par exemple abcabcab."
     },
     "verifyPassword": {
       "label": "Vérification du mot de passe",
-      "instruction": "8-32 chiffres"
+      "instruction": "8 à 32 caractères"
     },
-    "showPassword": "Montrer le mot de passe",
+    "showPassword": "Affichage du mot de passe",
     "library": {
       "selectLibrary": "Sélectionnez une bibliothèque de rattachement:",
       "placeholder": "Tapez le nom d’une bibliothèque, par exemple Parkchester Library",
@@ -115,7 +115,7 @@
       "personal": "Informations personnelles",
       "address": {
         "label": "Adresse",
-        "location": "Location",
+        "location": "Emplacement",
         "home": "Domicile",
         "work": "Travaille"
       },
@@ -128,27 +128,27 @@
     "nextStep": "Après l’envoi de votre demande, vous accéderez à une page de confirmation avec les informations de votre compte, et vous pourrez vous connecter pour réserver des livres et d’autres articles."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "Félicitations ! Vous êtes désormais en possession d'une carte numérique de la Bibliothèque publique de New York.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "Imprimez ou sauvegardez ces informations pour vos dossiers. Dans les 24 heures qui suivent, vous recevrez un e-mail contenant les informations relatives à votre compte.",
+      "part2": "Pour emprunter des ouvrages physiques, veuillez vous rendre dans l'une de nos <a href='http://nypl.org/locations'>bibliothèques</a> avec une <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>pièce d'identité avec photo valide et un justificatif de domicile</a> pour remplir la demande de carte physique.",
+      "part3": "Il s'agit d'une carte temporaire qui expirera après 14 jours. Si vous êtes un(e) étudiant(e) dans une université accréditée de New York, un(e) employé(e) d'une entreprise new-yorkaise, mais que vous ne vous trouvez pas physiquement dans la ville ou l'État, ou un chercheur qui se rendra dans un de nos centres de recherche, contactez <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> pour mettre votre carte à jour."
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "Mot de passe",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "Lancez-vous à la découverte de la Bibliothèque publique de New York",
+      "explore": "<b>Explorer les livres électroniques de la Bibliothèque</b><br />Téléchargez SimplyE pour <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> ou <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>Emprunter des livres et bien plus encore</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Connectez-vous à votre compte</a> et consultez le catalogue.",
+      "updates": "<b>Recevoir des mises à jour</b><br /><a href='https://www.nypl.org/enews'>Découvrez tout ce que la Bibliothèque a à offrir.</a>",
+      "more": "<b>En savoir plus</b><br /><a href='https://www.nypl.org/discover-library-card'>Découvrez tout ce que vous pouvez faire avec votre carte de bibliothèque.</a>"
     }
   },
   "button": {
-    "start": "Commencer",
+    "start": "Commencer le processus",
     "edit": "Modifier",
     "submit": "Envoyer",
     "next": "Suivant",
@@ -162,7 +162,7 @@
     "defaultError": "Un problème est survenu lors de la soumission."
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "Liste de suggestions de nom de bibliothèque",
+    "barcode": "Code barre lisible"
   }
 }

--- a/public/locales/ht/common.json
+++ b/public/locales/ht/common.json
@@ -12,18 +12,18 @@
   "personal": {
     "title": "Etap 1 sou 5: Enfomasyon Pèsonèl",
     "firstName": {
-      "label": "Premye non"
+      "label": "Non"
     },
     "lastName": {
       "label": "Siyati"
     },
     "birthdate": {
-      "label": "Date of Birth",
+      "label": "Dat Nesans",
       "instruction": "MM/DD/AAAA, ki gen ladann karaktè oblik yo "
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
-      "label": "Adrès imèl",
+      "label": "Imèl",
       "instruction": "Yon adrès imèl nesesè pou itilize plizyè nan resous nimerik nou yo, tankou liv elektwonik. Si w pa vle bay yon adrès imèl, ou ka aplike pou yon kat fizik lè w sèvi ak <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>lòt fòm</a> nou an. Yon fwa w ranpli l, tanpri vizite youn nan <a href='https://www.nypl.org/locations'>lokal</a> nou yo avèk prèv idantite ak adrès lakay ou pou w ka pran kat ou a."
     },
     "eCommunications": {
@@ -42,10 +42,10 @@
     "address": {
       "title": "Adrès Lakay Ou",
       "description": "Si ou abite NYC, tanpri ranpli fòm pou adrès lakay ou a.",
-      "line1": { "label": "Non Ri" },
+      "line1": { "label": "Non Ri a" },
       "line2": { "label": "Apatman / Swit" },
       "city": { "label": "Vil" },
-      "state": { "label": "Eta", "instruction": "Abrevyasyon 2 lèt" },
+      "state": { "label": "Eta", "instruction": "Abrevyasyon ak 2 lèt" },
       "postalCode": {
         "label": "Kòd Postal",
         "instruction": "Kòd postal ki genyen 5 oswa 9 chif."
@@ -76,18 +76,18 @@
     "description": "Kreye yon non itilizatè ak yon nimewo idantifikasyon pèsonèl (Personal Identification Number, PIN) pou w ka konekte w ak jere kont ou oswa pou jwenn aksè ak plizyè nan resous nimerik nou yo. Non itilizatè w la dwe inik.",
     "username": {
       "label": "Non Itilizatè",
-      "instruction": "5-25 karaktè alfanimerik. Okenn karaktè espesyal.",
+      "instruction": "5 a 25 karaktè alfanimerik. Karaktè espesyal pa otorize.",
       "checkButton": "Tcheke si non itilizatè a disponib"
     },
     "password": {
-      "label": "Password",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "Modpas",
+      "instruction": "Nou ankouraje w pou chwazi yon modpas ki solid ki gen ladann: omwen 8 karaktè, yon melanj lèt majiskil ak miniskil, yon melanj lèt ak chif, epi omwen yon karaktè espesyal, sòf pwen (.)<br />Egzanp: MyLib1731@<br /> Modpas la pa ka gen ladann karaktè komen tankou repete 3 fwa oswa plis menm karaktè a youn dèyè lòt; egzanp: aaaatf54 oswa repete yon karaktè, egzanp: abcabcab"
     },
     "verifyPassword": {
-      "label": "Verify Password",
-      "instruction": "8-32 characters"
+      "label": "Verifye Modpas ",
+      "instruction": "8 a 32 karaktè"
     },
-    "showPassword": "Show Password",
+    "showPassword": "Montre modpas la",
     "library": {
       "selectLibrary": "Chwazi yon bibliyotèk adomisil:",
       "placeholder": "Tape non yon bibliyotèk, tankou Parkchester Library",
@@ -128,27 +128,27 @@
     "nextStep": "Apre ou fin soumèt aplikasyon w lan, w ap wè yon paj konfimasyon ki genyen enfòmasyon sou kont ou an ladan, epi w ap kapab konekte w ak mande liv ak materyèl."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "Felisitasyon! Kounye a, ou gen yon kat Bibliyotèk Piblik New York.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "Enprime oswa sovgade enfòmasyon sa yo pou dosye w. Nan 24 èdtan, ou pral resevwa yon imèl ak tout detay kont ou an.",
+      "part2": "Pou prete materyèl fizik, tanpri ale nan youn nan l <a href='http://nypl.org/locations'>lokal nou yo</a> ak yon <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>pyès idantite ki gen foto epi ki valab ak prèv adrès kote ou rete a</a> pou ranpli aplikasyon an pou jwenn yon kat fizik",
+      "part3": "Sa a se yon kat tanporè li ye epi li pral ekspire nan 14 jou. Si ou se yon elèv nan yon kolèj ki akredi New York, oubyen yon anplwaye nan yon konpayi nan Vil NY men ou pa fizikman nan vil oswa Eta New York, oubyen yon chèchè ki pral vizite youn nan sant rechèch nou yo, kontakte <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> pou mete kat ou ajou."
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "Modpas",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "Demare ak Bibliyotèk Piblik New York la",
+      "explore": "<b>Eksplore Liv Elektwonik Bibliyotèk la</b><br />Telechaje SimplyE pou <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> oswa <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>Prete Liv ak Plis Bagay Toujou</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Konekte sou kont ou</a> epi konsilte katalòg la.",
+      "updates": "<b>Jwenn Mizajou yo</b><br /><a href='https://www.nypl.org/enews'>Dekouvri tout sa Bibliyotèk la kapab ofri w.</a>",
+      "more": "<b>Jwenn plis enfòmasyon.</b><br /><a href='https://www.nypl.org/discover-library-card'>Dekouvri tout bagay ou kapab fè ak kat Bibliyotèk ou an.</a>"
     }
   },
   "button": {
-    "start": "Get Started",
+    "start": "Demare",
     "edit": "Chanjman",
     "submit": "Soumèt",
     "next": "Suivan",
@@ -162,7 +162,7 @@
     "defaultError": "Te gen yon pwoblèm ak soumisyon an"
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "Etabli lis tout sigjesyon pou non bibliyotèk yo",
+    "barcode": "Kòdbar eskann la kapab rekonèt9"
   }
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -15,7 +15,7 @@
       "label": "이름"
     },
     "lastName": {
-      "label": "성씨"
+      "label": "성"
     },
     "birthdate": {
       "label": "생년월일",
@@ -73,21 +73,21 @@
   },
   "account": {
     "title": "4/5단계: 계정을 만드십시오.",
-    "description": "Create a username and password so you can log in and manage your account or access an array of our digital resources. Your username should be unique.",
+    "description": "사용자명과 비밀번호를 만들면 로그인하여 계정을 관리하거나 디지털 자료에 액세스할 수 있습니다. 사용자명은 고유한 것이어야 합니다.",
     "username": {
       "label": "사용자명 필수",
       "instruction": "5-25자의 영숫자 특수문자 없음",
       "checkButton": "사용자명이 사용 가능한지 확인하십시오."
     },
     "password": {
-      "label": "Password",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "비밀번호",
+      "instruction": "다음과 같이 강력한 비밀번호를 생성하시기를 권합니다. 즉, 비밀번호는 8자 이상이어야 하며, 대문자, 소문자, 숫자, 특수문자(마침표(.) 제외)를 혼합하여 만들어야 합니다.<br />예:  MyLib1731@<br />비밀번호는 같은 문자를 3번 이상 연속적으로 반복하는 것이나(예: aaaatf54) 반복되는 패턴(예: abcabcab)이 포함돼서는 안 됩니다."
     },
     "verifyPassword": {
-      "label": "Verify Password",
-      "instruction": "8-32 characters"
+      "label": "비밀번호 확인",
+      "instruction": "8-32자"
     },
-    "showPassword": "Show Password",
+    "showPassword": "비밀번호 표시",
     "library": {
       "selectLibrary": "홈 라이브러리를 선택해주십시오:",
       "placeholder": "도서관명을 입력해주십시오. 예: Parkchester Library",
@@ -128,27 +128,27 @@
     "nextStep": "신청서를 제출하고 나면 계정 정보가 담긴 확인 페이지를 보실 수 있고, 로그인하여 도서와 자료를 요청할 수 있습니다."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "축하드립니다! 이제 디지털 뉴욕 공공도서관 카드를 갖게 되셨습니다.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "기록용으로 이 정보를 인쇄해두거나 보관해 두십시오. 24시간 이내로 귀하의 계정에 대한 자세한 정보와 함께 이메일을 받으시게 됩니다.",
+      "part2": "실제 자료를 대여하시려면 저희 <a href='http://nypl.org/locations'>지점</a> 중 한 곳에 유효한 <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>사진 부착 신분증과 주소지 증명</a> 을 지참하고 방문해 주십시오. 그리고 실제 카드를 받기 위한 신청을 마쳐 주십시오.",
+      "part3": "본 카드는 임시 카드이며 14일 후에 만료됩니다. 뉴욕주 인정 칼리지의 학생이거나 뉴욕시 소재 회사의 직원이지만 여기 시 또는 주에 실거주를 하지 않고 있거나 여기 연구소를 방문할 연구원인 경우 귀하의 카드를 <a href='mailto:gethelp@nypl.org'>업데이트하기 위해</a> 연락해 주십시오."
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "비밀번호",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "뉴욕 공공도서관 이용 시작하기",
+      "explore": "<b>도서관 전자책 탐색</b><br /><a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> 또는 <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>용 SimplyE 앱을 다운로드하십시오",
+      "borrow": "<b>책과 자료 대여</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>계정에 로그인하여</a> 카탈로그를 탐색하십시오.",
+      "updates": "<b>업데이트 확인</b><br /><a href='https://www.nypl.org/enews'>도서관에서 이용할 수 있는 정보를 확인해 보십시오.</a>",
+      "more": "<b>자세히 알아보기</b><br /><a href='https://www.nypl.org/discover-library-card'>도서관 카드로 어떤 일을 할 수 있는지 알아 보십시오.</a>"
     }
   },
   "button": {
-    "start": "Get Started",
+    "start": "시작하기",
     "edit": "수정하기",
     "submit": "제출",
     "next": "다음",
@@ -162,7 +162,7 @@
     "defaultError": "제출한 정보에 문제가 있었습니다."
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "도서관 이름 제안 목록",
+    "barcode": "스캔할 바코드"
   }
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -73,21 +73,21 @@
   },
   "account": {
     "title": "Krok 4 z 5: dostosowanie konta",
-    "description": "Utwórz nazwę użytkownika i kod PIN, aby móc się logować i zarządzać kontem oraz korzystać z szerokiej gamy zasobów cyfrowych. Nazwa użytkownika powinna być unikatowa.",
+    "description": "Utwórz nazwę użytkownika i hasło, aby móc się logować i zarządzać kontem oraz korzystać z szerokiej gamy zasobów cyfrowych. Nazwa użytkownika powinna być unikatowa.",
     "username": {
       "label": "Nazwa użytkownika",
       "instruction": "5–25 liter i cyfr. Bez znaków specjalnych.",
       "checkButton": "Sprawdź dostępność nazwy użytkownika"
     },
     "password": {
-      "label": "Password",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "Hasło",
+      "instruction": "Zachęcamy do wybrania silnego hasła, które składa się z co najmniej 8 znaków, w tym wielkich i małych liter, cyfr oraz co najmniej jednego znaku specjalnego — z wyjątkiem kropki (.).<br />Przykład: MyLib1731@<br />Hasło nie może zawierać typowych wzorców, takich jak ten sam znak powtórzony trzy lub więcej razy, np. aaaatf54, czy powtarzający się ciąg, np. abcabcab."
     },
     "verifyPassword": {
-      "label": "Verify Password",
-      "instruction": "8-32 characters"
+      "label": "Zweryfikuj hasło",
+      "instruction": "Od 8 do 32 znaków"
     },
-    "showPassword": "Show Password",
+    "showPassword": "Pokaż hasło",
     "library": {
       "selectLibrary": "Wybierz lokalną bibliotekę:",
       "placeholder": "Wpisz nazwę biblioteki, na przykład Parkchester Library",
@@ -115,7 +115,7 @@
       "personal": "Dane osobowe",
       "address": {
         "label": "Adres",
-        "location": "Location",
+        "location": "Lokalizacja",
         "home": "Zamieszkania",
         "work": "Adres pracy"
       },
@@ -128,27 +128,27 @@
     "nextStep": "Kiedy wyślesz wniosek, wyświetli się strona z potwierdzeniem i danymi konta. Możesz wówczas się zalogować i zamówić książki oraz inne materiały."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "Gratulujemy! Masz już cyfrową kartę Nowojorskiej Biblioteki Publicznej.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "Wydrukuj lub zapisz te informacje na przyszłość. W ciągu 24 godzin otrzymasz e-mail z danymi konta.",
+      "part2": "Aby wypożyczyć materiały fizyczne, odwiedź jeden z naszych <a href='http://nypl.org/locations'>oddziałów</a> i okaż ważny <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>dokument tożsamości ze zdjęciem oraz dowód adresu zamieszkania</a> w celu wypełnienia wniosku o kartę fizyczną.",
+      "part3": "Ta karta jest tymczasowa i wygaśnie po 14 dniach. Jeżeli jesteś studentem uczelni akredytowanej w Nowym Jorku, pracownikiem firmy z NYC, który nie przebywa w mieście ani stanie Nowy Jork, albo badaczem, który będzie odwiedzać jeden z naszych ośrodków badawczych, skontaktuj się z nami, <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> aby zaktualizować kartę"
     },
     "graphic": {
       "memberName": "MEMBER NAME",
-      "password": "PASSWORD",
+      "password": "Hasło",
       "issued": "ISSUED"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "Zacznij korzystać z Nowojorskiej Biblioteki Publicznej",
+      "explore": "<b>Poznaj kolekcję e-booków Biblioteki</b><br />Pobierz SimplyE dla systemu <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> lub <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>Wypożycz książki i inne materiałye</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Zaloguj się na konto</a> i przejrzyj katalog.",
+      "updates": "<b>Otrzymuj aktualności</b><br /><a href='https://www.nypl.org/enews'>Dowiedz się wszystkiego o ofercie Biblioteki.</a>",
+      "more": "<b>Więcej informacji</b><br /><a href='https://www.nypl.org/discover-library-card'>Dowiedz się, co możesz robić przy użyciu karty bibliotecznej.</a>"
     }
   },
   "button": {
-    "start": "Get Started",
+    "start": "Rozpocznij",
     "edit": "Edytuj",
     "submit": "Prześlij",
     "next": "Dalej",
@@ -162,7 +162,7 @@
     "defaultError": "Wystąpił problem z przesłaniem wniosku."
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "Lista propozycji nazw bibliotek",
+    "barcode": "Kod kreskowy do skanowania"
   }
 }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -42,9 +42,9 @@
     "address": {
       "title": "Домашний адрес",
       "description": "Если вы проживаете в пределах города Нью Йорка, пожалуйста заполните нижеуказанные пункты",
-      "line1": { "label": "Улица" },
-      "line2": { "label": "Квартира" },
-      "city": { "label": "Район" },
+      "line1": { "label": "Улица и номер дома" },
+      "line2": { "label": "Квартира / апартаменты" },
+      "city": { "label": "Город" },
       "state": { "label": "Штат", "instruction": "Аббревиатура из 2 букв" },
       "postalCode": {
         "label": "Почтовый индекс",
@@ -75,18 +75,18 @@
     "title": "Шаг 4 из 5: настройка учетной записи",
     "username": {
       "label": "Имя пользователя",
-      "instruction": "5-25 буквенно-цифровых знаков No special characters.",
+      "instruction": "5-25 буквенно-цифровых символов. Не используйте специальные символы.",
       "checkButton": "Проверьте, не используется ли данное имя пользователя."
     },
     "password": {
-      "label": "Пин код",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "Пароль",
+      "instruction": "Рекомендуем создать надежный пароль, содержащий как минимум 8 символов, включая сочетание букв верхнего и нижнего регистров, сочетание букв и цифр, а также как минимум один специальный символ, кроме точки (.)Рекомендуем создать надежный пароль, содержащий как минимум 8 символов, включая сочетание букв верхнего и нижнего регистров, сочетание букв и цифр, а также как минимум один специальный символ, кроме точки (.)Рекомендуем создать надежный пароль, содержащий как минимум 8 символов, включая сочетание букв верхнего и нижнего регистров, сочетание букв и цифр, а также как минимум один специальный символ, кроме точки (.)Рекомендуем создать надежный пароль, содержащий как минимум 8 символов, включая сочетание букв верхнего и нижнего регистров, сочетание букв и цифр, а также как минимум один специальный символ, кроме точки (.). <br />Пример: MyLib1731@br />Пароль не должен содержать распространенные комбинации, такие как повторяющийся три и более раз подряд символ (например, aaaatf54), или повторяющуюся комбинацию (например, abcabcab)."
     },
     "verifyPassword": {
-      "label": "Подтвердите пин код",
-      "instruction": "8-32 цифры"
+      "label": "Подтвердить пароль",
+      "instruction": "От 8 до 32 символов"
     },
-    "showPassword": "Показать пин код",
+    "showPassword": "Показать пароль",
     "library": {
       "selectLibrary": "Выбор близлежащего или удобно расположенного филиала",
       "placeholder": "Укажите название выбранного вами филиала,например 'Parkchester LIbrary'",
@@ -114,9 +114,9 @@
       "personal": "Личные данные",
       "address": {
         "label": "Адрес",
-        "location": "Location",
-        "home": "Home",
-        "work": "Work"
+        "location": "Расположение",
+        "home": "Дом",
+        "work": "Работа"
       },
       "homeLibrary": "Близлежащий или удобно расположенный филиал библиотеки"
     },
@@ -127,27 +127,27 @@
     "nextStep": "После успешной подачи заявления, вы будете переведены на страницу с подтверждением данных вашей учетной записи. Теперь вы сможете входить в систему и заказывать книги и материалы."
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "Поздравляем! Теперь у вас есть цифровой читательский билет Нью-Йоркской публичной библиотеки.",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "Распечатайте или сохраните эти данные. В течение 24 часов вы получите по электронной почте письмо с подробной информацией о вашей учетной записи.",
+      "part2": "Для заказа физических материалов посетите один из наших <a href='http://nypl.org/locations'>филиалов</a> и предъявите действительное <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>удостоверение личности с фотографией и документ, подтверждающий домашний адрес</a>, чтобы заполнить заявление на получение физического читательского билета.",
+      "part3": "Это временный читательский билет. Срок его действия истечет через 14 дней. Если вы являетесь студентом аккредитованного в Нью-Йорке колледжа, сотрудником нью-йоркской компании с фактическим местоположением за пределами города или штата или исследователем, посещающим один из наших исследовательских центров, обратитесь к нам, чтобы <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a>продлить действие вашего читательского билета."
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "Пароль",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "Начните пользоваться Нью-Йоркской публичной библиотекой",
+      "explore": "<b>Исследуйте коллекцию электронных книг библиотеки</b><br />Загрузите приложение SimplyE для <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> или <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
+      "borrow": "<b>Берите книги и многое другое</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Зайдите в свою учетную запись</a> и просмотрите каталог.",
+      "updates": "<b>Получайте новости</b><br /><a href='https://www.nypl.org/enews'>Узнайте обо всем, что предлагает библиотека.</a>",
+      "more": "<b>Подробнее</b><br /><a href='https://www.nypl.org/discover-library-card'>Узнайте обо всем, что можно получить с помощью читательского билета.</a>"
     }
   },
   "button": {
-    "start": "Начать",
+    "start": "Начинайте пользоваться",
     "edit": "Корректировка",
     "submit": "Отправить",
     "next": "Следующее",
@@ -161,7 +161,7 @@
     "defaultError": "С отправкой данных возникла проблема"
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "Список предлагаемых названий библиотек",
+    "barcode": "Сканируемый штрихкодs"
   }
 }

--- a/public/locales/ur/common.json
+++ b/public/locales/ur/common.json
@@ -23,7 +23,7 @@
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
-      "label": "ای میل اڈریس",
+      "label": "ای میل ایڈریس",
       "instruction": "ہمارے بہت سے ڈیجیٹل وسائل، جیسے ای-بُکس استعمال کرنے کے لیے ایک ای میل ایڈریس درکار ہے۔ اگر آپ ای میل ایڈریس فراہم نہیں کرنا چاہتے، تو آپ ہمارا <a href='https://legacycatalog.nypl.org/selfreg/patonsite'>متبادل فارم</a> استعمال کرتے ہوئے مادی کارڈ کے لیے درخواستدے سکتے ہیں۔ ایک بار پُر کرنے کے بعد، براہِ کرم اپنا کارڈ لینے کے لیے شناخت کے ثبوت اور گھر کے پتے کے ساتھ ہمارے<a href='https://www.nypl.org/locations'>مقامات</a> پر جائیں۔"
     },
     "eCommunications": {
@@ -80,14 +80,14 @@
       "checkButton": "دیکھیں کہ کیا یہ صارف کا نام دستیاب ہے"
     },
     "password": {
-      "label": "Password",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "پاسورڈ",
+      "instruction": "ہم آپ کو ایک مضبوط پاس ورڈ منتخب کرنے کی ترغیب دیتے ہیں جس میں شامل ہوں: کم از کم 8 حروف، بڑے اور چھوٹے حروف کا مرکب، حروف اور اعداد کا مرکب، اور کم از کم ایک خاص حرف ماسوائے وقف (.)<br />مثال: MyLib1731@<br />پاس ورڈ میں عام ترتیبیں شامل نہیں ہو سکتیں جیسے کہ ایک حرف کو لگاتار تین یا زیادہ بار دوہرانا، جیسے کہ aaaatf54 یا ایک ترتیب کو دوہرانا، جیسے کہ abcabcab"
     },
     "verifyPassword": {
-      "label": "Verify Password",
-      "instruction": "8-32 characters"
+      "label": "پاس ورڈ کی تصدیق کریں",
+      "instruction": "8-32 حروف"
     },
-    "showPassword": "Show Password",
+    "showPassword": "پاسورڈ ظاہر کریں",
     "library": {
       "selectLibrary": "ایک ہوم لائبریری منتخب کریں:",
       "placeholder": "لائبریری کا نام ٹائپ کریں، جیسے پارک چیسٹر لائبریری",
@@ -128,27 +128,27 @@
     "nextStep": "اپنی درخواست جمع کروانے کے بعد، آپ کو اپنے اکاؤنٹ کی معلومات کے ساتھ ایک تصدیقی صفحہ نظر آئے گا، اور آپ لاگ ان کرنے اور کتب اور مواد کی درخواست کرنے کے قابل ہوں گے۔"
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "مبارکباد! آپ کو اب ایک ڈیجیٹل نیویارک پبلک لائبریری کا کارڈ مل گیا ہے۔",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "اس معلومات کو اپنے ریکارڈ کے لیے پرنٹ کر لیں یا محفوظ کر لیں۔ 24 گھنٹے کے اندر اندر، آپ کو اپنے اکاؤنٹ کی تفصیلات پر مشتمل ایک ای میل موصول ہو گی۔",
+      "part2": "مادی مواد مستعار لینے کے لیے، براہِ کرم مادی کارڈ کے لیے درخواست مکمل کرنے کے لیے ایک <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>معتبر تصویری شناخت اور پتے کے ثبوت</a> کے ساتھ ہمارے <a href='http://nypl.org/locations'>مقامات</a> میں سے کسی ایک پر تشریف لائیں۔",
+      "part3": "یہ ایک عارضی کارڈ ہے اور اس کی معیاد 14 دن میں ختم ہو جائے گی۔ اگر آپ نیویارک سے منظور شدہ کالج کے طالب علم ہیں، NYC کمپنی میں ملازم ہیں مگر جسمانی طور پر شہر یا ریاست میں موجود نہیں ہیں، یا کوئی محقق ہیں جو ہمارے کسی تحقیقی مرکز کا دورہ کرے گا، تو <a href='mailto:gethelp@nypl.org'اپنے کارڈ کی تجدید کرنے کے لیے</a> رابطہ کریں۔"
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "پاسورڈ",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "نیویارک پبلک لائبریری کے ساتھ آغاز کریں",
+      "explore": "<b>لائبریری کی ای-بُکس دریافت کریں</b><br />SimplyE برائے <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> یا <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a> ڈاؤن لوڈ کریں۔",
+      "borrow": "<b>کتابیں اور بہت کچھ مستعار لیں</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>اپنے اکاؤنٹ میں لاگ ان کریں</a> اور فہرستِ باتصویر دیکھیں۔",
+      "updates": "<b>تازہ ترین معلومات حاصل کریں</b><br /><a href='https://www.nypl.org/enews'>لائبریری میں آپ کو پیش کرنے کے لیے جو کچھ بھی ہے وہ معلوم کریں۔</a>",
+      "more": "<b>مزید جانیں</b><br /><a href='https://www.nypl.org/discover-library-card'>ہر وہ چیز دریافت کریں جو آپ اپنے لائبریری کارڈ کے ساتھ کر سکتے ہیں۔</a>"
     }
   },
   "button": {
-    "start": "Get Started",
+    "start": "آغاز کریں",
     "edit": "ترمیم کریں",
     "submit": "جمع کروائیں",
     "next": "اگلا",
@@ -162,7 +162,7 @@
     "defaultError": "جمع کرانے میں ایک مسئلہ تھا۔"
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "لائبریری کے نام کی تجاویز کی فہرست۔",
+    "barcode": "قابلِ سکین بارکوڈ"
   }
 }

--- a/public/locales/zhcn/common.json
+++ b/public/locales/zhcn/common.json
@@ -19,7 +19,7 @@
     },
     "birthdate": {
       "label": "出生日期",
-      "instruction": "月 / 日 / 年 (MM / DD / YYYY)，包括斜线"
+      "instruction": "月/日/年，包括斜杠"
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
@@ -70,21 +70,21 @@
   },
   "account": {
     "title": "第 4 步：自定义您的账户。",
-    "description": "Create a username and password so you can log in and manage your account or access an array of our digital resources. Your username should be unique.",
+    "description": "创建用户名和密码，以便您登录和管理您的帐户或访问我们的众多数字资源。您的用户名应该是唯一的。",
     "username": {
       "label": "用户名",
       "instruction": "5-25个字母数字。没有特殊符号。",
       "checkButton": "检查用户名是否可用"
     },
     "password": {
-      "label": "Password",
-      "instruction": "We encourage you to select a strong password that includes: at least 8 characters, a mixture of uppercase and lowercase letters, a mixture of letters and numbers, and at least one special character <i>except</i> period (.) <br />Example: MyLib1731@<br />Password cannot contain common patterns such as consecutively repeating a character three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab"
+      "label": "密码",
+      "instruction": "我们建议您选择包含以下内容的强密码：至少 8 个字符、大小写字母混合、字母和数字混合以及至少包含 1 个除句点 (.) 之外的特殊字符<br />例子：MyLib1731@<br />密码不能包含常见模式，如连续重复某一字符 3 次或以上（如 aaaatf54）或重复某一模式（如 abcabcab）。"
     },
     "verifyPassword": {
-      "label": "Verify Password",
-      "instruction": "8-32 characters"
+      "label": "验证密码",
+      "instruction": "8-32 个字符"
     },
-    "showPassword": "Show Password",
+    "showPassword": "显示密码",
     "library": {
       "selectLibrary": "選一個您經常使用的圖書館：",
       "placeholder": "输入图书馆名称，例如 Parkchester Library",
@@ -112,9 +112,9 @@
       "personal": "个人资料",
       "address": {
         "label": "地址",
-        "location": "Location",
-        "home": "Home",
-        "work": "Work"
+        "location": "地点",
+        "home": "家",
+        "work": "工作"
       },
       "homeLibrary": "您經常使用的圖書館"
     },
@@ -125,23 +125,23 @@
     "nextStep": "提交申请后，您将看到一个确认页面，其中包含您的帐户资料，您将能够登录并索取书籍和物料。"
   },
   "confirmation": {
-    "title": "Congratulations! You now have a digital New York Public Library card.",
+    "title": "恭喜！您现在已获取一张纽约公共图书馆电子图书卡。",
     "description": {
-      "part1": "Print or save this information for your records. Within 24 hours, you will receive an email with the details of your account.",
-      "part2": "To borrow physical materials, please visit one of our <a href='http://nypl.org/locations'>locations</a> with a valid <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>photo ID and proof of address</a> to complete the application for a physical card.",
-      "part3": " This is a temporary card and will expire in 14 days. If you are a student in a New York–accredited college, an employee at a NYC company but not physically in the city or state, or a researcher who will be visiting one of our research centers, contact <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> to update your card."
+      "part1": "请打印或保存此信息以作为记录。您将在 24 小时内收到一封包含您账户详细信息的电子邮件。",
+      "part2": "如要借阅实体材料，请携带有效的<a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>带照片身份证件和地址证明</a>前往我们的其中一个<a href='http://nypl.org/locations'>分馆地点</a>完成实体图书卡的申请。",
+      "part3": "这是一张临时图书卡，将在 14 天后到期失效。如您是在纽约认可的学院就读的学生、纽约市企业的员工（现在不在纽约市或纽约州）或即将访问我们研究中心的研究人员，请联系我们<a href='mailto:gethelp@nypl.org'>更新您的图书卡。</a>"
     },
     "graphic": {
       "memberName": "Member Name",
-      "password": "Password",
+      "password": "密码",
       "issued": "Issued"
     },
     "nextSteps": {
-      "title": "Get Started with The New York Public Library",
-      "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
-      "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
-      "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
+      "title": "开始使用纽约公共图书馆",
+      "explore": "<b>探索图书馆电子书</b><br />下载适用于 <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> 或 <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a> 的 SimplyE。",
+      "borrow": "<b>借阅书籍和其他物品</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>登录您的帐户</a>并浏览目录。",
+      "updates": "<b>获取更新</b><br /><a href='https://www.nypl.org/enews'>发现图书馆提供的所有服务。</a>",
+      "more": "<b>了解更多</b><br /><a href='https://www.nypl.org/discover-library-card'>发现您可以用图书卡做些什么。</a>"
     }
   },
   "button": {
@@ -159,7 +159,7 @@
     "defaultError": "提交时出现问题"
   },
   "ariaLabel": {
-    "librarySuggestions": "List of library name suggestions",
-    "barcode": "Scannable barcode"
+    "librarySuggestions": "图书馆名称建议列表",
+    "barcode": "可扫描条形码"
   }
 }


### PR DESCRIPTION
## Description

- Updates all 10 translation .json files with the confirmation page text
- Adds the aria-label translations
- Updates existing translations according to the updates on the google sheets

## How Has This Been Tested?

- run tests locally
- build site locally

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
