### PR TITLE
RENO-3227: Adding IP-based user location Google translations

### DIFF
--- a/__tests__/library-card_review.test.tsx
+++ b/__tests__/library-card_review.test.tsx
@@ -108,6 +108,16 @@ jest.mock("react-i18next", () => {
     }),
   };
 });
+jest.mock("next/router", () => ({
+  useRouter() {
+    return {
+      route: "/",
+      pathname: "",
+      query: { lang: "en" },
+      asPath: "",
+    };
+  },
+}));
 
 describe("ReviewPage", () => {
   let container;

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -43,6 +43,9 @@ function ReviewFormContainer() {
   const { state, dispatch } = useFormDataContext();
   const { formValues, errorObj, csrfToken } = state;
   const router = useRouter();
+  const {
+    query: { lang = "en" },
+  } = router;
   // For routing when javascript is not enabled, we want to track the form
   // values through the URL query params.
   const queryValues = createQueryParams(formValues);
@@ -301,7 +304,7 @@ function ReviewFormContainer() {
             className="radio-input"
             id="review-location-id"
             isChecked={true}
-            labelText={getLocationValue(formValues.location)}
+            labelText={getLocationValue(formValues.location, lang)}
             name={"location"}
             value={formValues.location}
           />

--- a/src/data/ipLocationMessageTranslations.ts
+++ b/src/data/ipLocationMessageTranslations.ts
@@ -1,0 +1,57 @@
+export const ipLocationMessageTranslations = {
+  ar: {
+    nyc: "مدينة نيويورك (جميع الأحياء الخمسة)",
+    nys: "ولاية نيويورك (خارج مدينة نيويورك)",
+    us: "الولايات المتحدة (زيارة مدينة نيويورك)",
+  },
+  bn: {
+    nyc: "নিউ ইয়র্ক সিটি (সমস্ত পাঁচটি বরো)",
+    nys: "নিউ ইয়র্ক স্টেট (NYC এর বাইরে)",
+    us: "মার্কিন যুক্তরাষ্ট্র (এনওয়াইসি পরিদর্শন)",
+  },
+  en: {
+    nyc: "New York City (All five boroughs)",
+    nys: "New York State (Outside NYC)",
+    us: "United States (Visiting NYC)",
+  },
+  es: {
+    nyc: "Ciudad de Nueva York (los cinco distritos)",
+    nys: "Estado de Nueva York (fuera de la ciudad de Nueva York)",
+    us: "Estados Unidos (visitando NYC)",
+  },
+  fr: {
+    nyc: "New York (les cinq arrondissements)",
+    nys: "État de New York (en dehors de NYC)",
+    us: "États-Unis (en visite à NYC)",
+  },
+  ht: {
+    nyc: "Vil Nouyòk (tout senk minisipalite)",
+    nys: "Eta New York (deyò vil Nouyòk)",
+    us: "Etazini (Visite NYC)",
+  },
+  ko: {
+    nyc: "뉴욕시(5개 자치구 모두)",
+    nys: "뉴욕주(NYC 외부)",
+    us: "미국(NYC 방문)",
+  },
+  pl: {
+    nyc: "Nowy Jork (wszystkie pięć dzielnic)",
+    nys: "Stan Nowy Jork (poza Nowym Jorkiem)",
+    us: "Stany Zjednoczone (zwiedzanie Nowego Jorku)",
+  },
+  ru: {
+    nyc: "Нью-Йорк (все пять районов)",
+    nys: "Штат Нью-Йорк (за пределами Нью-Йорка)",
+    us: "США (посещение Нью-Йорка)",
+  },
+  ur: {
+    nyc: "نیو یارک سٹی (تمام پانچ بورو)",
+    nys: "نیویارک اسٹیٹ (NYC سے باہر)",
+    us: "ریاستہائے متحدہ (NYC کا دورہ کرتے ہوئے)",
+  },
+  zhcn: {
+    nyc: "纽约市（所有五个行政区）",
+    nys: "纽约州（纽约市以外）",
+    us: "美国（访问纽约市）",
+  },
+};

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -9,6 +9,7 @@ import {
   FormAPISubmission,
   FormInputData,
 } from "../interfaces";
+import { ipLocationMessageTranslations } from "../data/ipLocationMessageTranslations";
 
 const errorMessages = {
   firstName: "Please enter a valid first name.",
@@ -110,13 +111,10 @@ const getPatronAgencyType = (agencyTypeParam?) => {
  * getLocationValue
  * Map the location value from the form field into the string value.
  */
-const getLocationValue = (location: string): string => {
-  const locationMap = {
-    nyc: "New York City (All five boroughs)",
-    nys: "New York State (Outside NYC)",
-    us: "United States (Visiting NYC)",
-  };
-  return locationMap[location] || "United States (Visiting NYC)";
+const getLocationValue = (location = "en", lang = "en"): string => {
+  const defaultLocation = ipLocationMessageTranslations[lang]["us"];
+  const userLocation = ipLocationMessageTranslations[lang][location];
+  return userLocation || defaultLocation;
 };
 
 /**

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -111,7 +111,7 @@ const getPatronAgencyType = (agencyTypeParam?) => {
  * getLocationValue
  * Map the location value from the form field into the string value.
  */
-const getLocationValue = (location = "en", lang = "en"): string => {
+const getLocationValue = (location = "us", lang = "en"): string => {
   const defaultLocation = ipLocationMessageTranslations[lang]["us"];
   const userLocation = ipLocationMessageTranslations[lang][location];
   return userLocation || defaultLocation;

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -112,9 +112,7 @@ const getPatronAgencyType = (agencyTypeParam?) => {
  * Map the location value from the form field into the string value.
  */
 const getLocationValue = (location = "us", lang = "en"): string => {
-  const defaultLocation = ipLocationMessageTranslations[lang]["us"];
-  const userLocation = ipLocationMessageTranslations[lang][location];
-  return userLocation || defaultLocation;
+  return ipLocationMessageTranslations[lang][location];
 };
 
 /**


### PR DESCRIPTION
## Description

Resolves [RENO-3227](https://jira.nypl.org/browse/RENO-3227).
This adds missing translations through Google Translate for the user's location based on their IP. This appears in the "Review" page.

## Motivation and Context

Forgot about this.

## How Has This Been Tested?

Unit tests. It is difficult to check for user location locally so we must test on QA.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
