### PR TITLE
RENO-3230: Update Korean, Polish and Chinese (Simplified) Translations

### DIFF
--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -6,7 +6,7 @@
     "description": {
       "part1": "13세 이상이고, 뉴욕주에서 거주, 근무, 재학 중, 또는 재산세를 납부하시는 분은 이 온라인 양식을 사용하여 바로 디지털 도서관 카드를 무료로 발급받을 수 있습니다. 뉴욕주 방문자도 이 양식을 사용하여 임시 카드를 신청할 수 있습니다.",
       "part2": "디지털 도서관 카드를 가지고 도서관의 다양한 디지털 자료들, 즉 전자책, 데이터베이스, 교육 자료 등을 무료로 이용하실 수 있습니다.",
-      "part3": "신청서를 제출하시면, 귀하는 <a href='https://www.nypl.org/help/library-card/terms-conditions'>카드소지자 이용약관</a> 에 동의하고, <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>R규칙과 규정</a> 에 동의하는 것으로 간주됩니다. 도서관의 개인정보 사용에 관해 자세히 알아보시려면 <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>개인정보 취급방침</a>을 읽어주십시오."
+      "part3": "신청서를 제출하시면, 귀하는 <a href='https://www.nypl.org/help/library-card/terms-conditions'>카드소지자 이용약관</a>에 동의하고, <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>규칙과 규정</a> 에 동의하는 것으로 간주됩니다. 도서관의 개인정보 사용에 관해 자세히 알아보시려면<a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>개인정보 취급방침</a>을 읽어주십시오."
     }
   },
   "personal": {
@@ -24,7 +24,7 @@
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
       "label": "이메일 주소",
-      "instruction": "전자책과 같은 많은 디지털 자료를 이용하기 위해서는 이메일 주소가 필요합니다. 이메일 주소를 제공하기를 원치 않으시면 <a href='https://legacycatalog.nypl.org/selfreg/patonsite'> 대체 형식</a> 을 사용하는 실물 카드를 신청하실 수 있습니다. 신청서를 작성하셨으면, 신분증과 배송받을 집 주소를 가지고 저희 <a href='https://www.nypl.org/locations'>도서관</a> 중 한 곳을 방문해주십시오."
+      "instruction": "전자책과 같은 많은 디지털 자료를 이용하기 위해서는 이메일 주소가 필요합니다. 이메일 주소를 제공하기를 원치 않으시면 <a href='https://legacycatalog.nypl.org/selfreg/patonsite'> 대체 형식</a>을 사용하는 실물 카드를 신청하실 수 있습니다. 신청서를 작성하셨으면, 신분증과 배송받을 집 주소를 가지고 저희 <a href='https://www.nypl.org/locations'>도서관</a> 중 한 곳을 방문해주십시오."
     },
     "eCommunications": {
       "labelText": "예, NYPL의 프로그램과 서비스에 대한 정보를 받기를 원합니다."
@@ -76,7 +76,7 @@
     "description": "사용자명과 비밀번호를 만들면 로그인하여 계정을 관리하거나 디지털 자료에 액세스할 수 있습니다. 사용자명은 고유한 것이어야 합니다.",
     "username": {
       "label": "사용자명 필수",
-      "instruction": "5-25자의 영숫자 특수문자 없음",
+      "instruction": "5-25자의 영문 글자 및 숫자 사용. 특수 문자는 사용하지 마십시오.",
       "checkButton": "사용자명이 사용 가능한지 확인하십시오."
     },
     "password": {
@@ -99,7 +99,7 @@
     },
     "termsAndCondition": {
       "label": "예, 이용약관에 동의합니다.",
-      "text": "신청서를 제출하시면, 귀하는 <a href='https://www.nypl.org/help/library-card/terms-conditions'>카드소지자 이용약관</a> 에 동의하고, <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>규칙과 규정</a> 에 동의하는 것으로 간주됩니다. 도서관의 개인정보 사용에 관해 자세히 알아보시려면 <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>개인정보 취급방침</a> 을 읽어주십시오."
+      "text": "신청서를 제출하시면, 귀하는 <a href='https://www.nypl.org/help/library-card/terms-conditions'>카드소지자 이용약관</a>에 동의하고, <a href='https://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations'>규칙과 규정</a>에 동의하는 것으로 간주됩니다. 도서관의 개인정보 사용에 관해 자세히 알아보시려면 <a href='https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy'>개인정보 취급방침</a>을 읽어주십시오."
     },
     "errorMessage": {
       "username": "사용자명은 5 내지 25자의 영숫자로 해야 합니다.",
@@ -131,7 +131,7 @@
     "title": "축하드립니다! 이제 디지털 뉴욕 공공도서관 카드를 갖게 되셨습니다.",
     "description": {
       "part1": "기록용으로 이 정보를 인쇄해두거나 보관해 두십시오. 24시간 이내로 귀하의 계정에 대한 자세한 정보와 함께 이메일을 받으시게 됩니다.",
-      "part2": "실제 자료를 대여하시려면 저희 <a href='http://nypl.org/locations'>지점</a> 중 한 곳에 유효한 <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>사진 부착 신분증과 주소지 증명</a> 을 지참하고 방문해 주십시오. 그리고 실제 카드를 받기 위한 신청을 마쳐 주십시오.",
+      "part2": "실제 자료를 대여하시려면 저희 <a href='http://nypl.org/locations'>지점</a> 중 한 곳에 유효한 <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>사진 부착 신분증과 주소지 증명</a>을 지참하고 방문해 주십시오. 그리고 실제 카드를 받기 위한 신청을 마쳐 주십시오.",
       "part3": "본 카드는 임시 카드이며 14일 후에 만료됩니다. 뉴욕주 인정 칼리지의 학생이거나 뉴욕시 소재 회사의 직원이지만 여기 시 또는 주에 실거주를 하지 않고 있거나 여기 연구소를 방문할 연구원인 경우 귀하의 카드를 <a href='mailto:gethelp@nypl.org'>업데이트하기 위해</a> 연락해 주십시오."
     },
     "graphic": {

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -132,7 +132,7 @@
     "description": {
       "part1": "Wydrukuj lub zapisz te informacje na przyszłość. W ciągu 24 godzin otrzymasz e-mail z danymi konta.",
       "part2": "Aby wypożyczyć materiały fizyczne, odwiedź jeden z naszych <a href='http://nypl.org/locations'>oddziałów</a> i okaż ważny <a href='https://www.nypl.org/help/library-card/terms-conditions#Eligibility'>dokument tożsamości ze zdjęciem oraz dowód adresu zamieszkania</a> w celu wypełnienia wniosku o kartę fizyczną.",
-      "part3": "Ta karta jest tymczasowa i wygaśnie po 14 dniach. Jeżeli jesteś studentem uczelni akredytowanej w Nowym Jorku, pracownikiem firmy z NYC, który nie przebywa w mieście ani stanie Nowy Jork, albo badaczem, który będzie odwiedzać jeden z naszych ośrodków badawczych, skontaktuj się z nami, <a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a> aby zaktualizować kartę"
+      "part3": "Ta karta jest tymczasowa i wygaśnie po 14 dniach. Jeżeli jesteś studentem uczelni akredytowanej w Nowym Jorku, pracownikiem firmy z NYC, który nie przebywa w mieście ani stanie Nowy Jork, albo badaczem, który będzie odwiedzać jeden z naszych ośrodków badawczych, skontaktuj się z nami pod adresem<a href='mailto:gethelp@nypl.org'>gethelp@nypl.org</a>, aby zaktualizować kartę"
     },
     "graphic": {
       "memberName": "Nazwa członka",
@@ -142,7 +142,7 @@
     "nextSteps": {
       "title": "Zacznij korzystać z Nowojorskiej Biblioteki Publicznej",
       "explore": "<b>Poznaj kolekcję e-booków Biblioteki</b><br />Pobierz SimplyE dla systemu <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> lub <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Wypożycz książki i inne materiałye</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Zaloguj się na konto</a> i przejrzyj katalog.",
+      "borrow": "<b>Wypożycz książki i inne materiały</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Zaloguj się na konto</a> i przejrzyj katalog.",
       "updates": "<b>Otrzymuj aktualności</b><br /><a href='https://www.nypl.org/enews'>Dowiedz się wszystkiego o ofercie Biblioteki.</a>",
       "more": "<b>Więcej informacji</b><br /><a href='https://www.nypl.org/discover-library-card'>Dowiedz się, co możesz robić przy użyciu karty bibliotecznej.</a>"
     }

--- a/public/locales/zhcn/common.json
+++ b/public/locales/zhcn/common.json
@@ -19,7 +19,7 @@
     },
     "birthdate": {
       "label": "出生日期",
-      "instruction": "月/日/年，包括斜杠"
+      "instruction": "月月/日日/年年年年，包括斜杠"
     },
     "ageGate": "Yes, I am over 13 years old.",
     "email": {
@@ -32,7 +32,7 @@
     "errorMessage": {
       "firstName": "请输入有效的名字。",
       "lastName": "请输入有效的姓氏。",
-      "birthdate": "请输入有效的日期（月/日/年，包括斜杠）。",
+      "birthdate": "请输入有效的日期（月月/日日/年年年年，包括斜杠）。",
       "ageGate": "You must be 13 years or older to continue.",
       "email": "请输入有效的电子邮件地址。"
     }
@@ -73,7 +73,7 @@
     "description": "创建用户名和密码，以便您登录和管理您的帐户或访问我们的众多数字资源。您的用户名应该是唯一的。",
     "username": {
       "label": "用户名",
-      "instruction": "5-25个字母数字。没有特殊符号。",
+      "instruction": "5-25 个英文字母数字字符。没有特殊字符。",
       "checkButton": "检查用户名是否可用"
     },
     "password": {
@@ -86,12 +86,12 @@
     },
     "showPassword": "显示密码",
     "library": {
-      "selectLibrary": "選一個您經常使用的圖書館：",
-      "placeholder": "输入图书馆名称，例如 Parkchester Library",
-      "title": "您經常使用的圖書館",
+      "selectLibrary": "选择区内图书馆：",
+      "placeholder": "键入图书馆名称，例如 Parkchester Library",
+      "title": "区内图书馆",
       "description": {
-        "part1": "選一個您經常使用的圖書館将帮助我们确保您从最方便您的分馆中获取所需的一切。",
-        "part2": "您可以跳过此步骤，并随时通过您的帐户进行更新。"
+        "part1": "选择一个区内图书馆将有助于我们确保您能够从对您来说最便利的分馆获得所需的一切。",
+        "part2": "您可以跳过此步骤并通过您的帐户随时进行更新。"
       }
     },
     "termsAndCondition": {
@@ -116,7 +116,7 @@
         "home": "家",
         "work": "工作"
       },
-      "homeLibrary": "您經常使用的圖書館"
+      "homeLibrary": "区内图书馆"
     },
     "createAccount": "创建您的帐户",
     "receiveNewsletter": "接收有关 NYPL 计划和服务的信息",


### PR DESCRIPTION
## Description

- Updates the .json language files of Korean, Polish and Chinese after User testing review

## Motivation and Context

Note: One thing that I found weird is that the Korean and Chinese review mark that the username helper text was in english. As visible in this PR, there existed a translation for that field already. I am not sure why they would not come though.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
