### PR TITLE
Reverting back to the prod header URL for the embed script

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -18,7 +18,7 @@ class MyDocument extends Document {
             <div id="nypl-header"></div>
             <script
               type="text/javascript"
-              src="https://qa-header.nypl.org/dgx-header.min.js?skipNav=main-content&containerId=nypl-header"
+              src="https://header.nypl.org/dgx-header.min.js?skipNav=main-content&containerId=nypl-header"
               async
             ></script>
           </div>


### PR DESCRIPTION
Uses the production NYPL Header embed URL. To be deployed 1/17/23.