### PR TITLE
RENO-3571: Add Adobe Analytics

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,8 @@ OAUTH_PROVIDER_URL=https://isso.nypl.org/oauth/token
 OAUTH_CLIENT_ID=askTeammate
 OAUTH_CLIENT_SECRET=askTeammate
 IPSTACK_KEY=askTeammate
+#PRODUCTION
+ADOBE_ANALYTICS_TAG=askTeammate
+#DEV
+#ADOBE_ANALYTICS_TAG=askTeammate
+

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import Footer from "@nypl/dgx-react-footer";
+const ADOBE_ANALYTICS_TAG = process.env.ADOBE_ANALYTICS_TAG;
 
 /**
  * MyDocument
@@ -12,7 +13,21 @@ class MyDocument extends Document {
   render(): React.ReactElement {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          {/* <!-- Initial Data Layer Definition --> */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.adobeDataLayer = [];
+                window.adobeDataLayer.push({
+                  page_name: "Library Card App | " + window.location.pathname.split("/").pop(),
+                  site_section: "Library Card Application Form"
+                });`,
+            }}
+          />
+          {/* <!-- Tag Manager Library Script --> */}
+          <script src={ADOBE_ANALYTICS_TAG} async></script>
+        </Head>
         <body>
           <div id="Header-Placeholder" style={{ minHeight: "230px" }}>
             <div id="nypl-header"></div>

--- a/src/components/AccountFormContainer/index.tsx
+++ b/src/components/AccountFormContainer/index.tsx
@@ -11,12 +11,12 @@ import useFormDataContext from "../../context/FormDataContext";
 import RoutingLinks from "../RoutingLinks.tsx";
 import AccountFormFields from "../AccountFormFields";
 import AcceptTermsFormFields from "../AcceptTermsFormFields";
-import { findLibraryCode } from "../../utils/formDataUtils";
+import { findLibraryCode, findLibraryName } from "../../utils/formDataUtils";
 import { lcaEvents } from "../../externals/gaUtils";
 import FormField from "../FormField";
 import { createQueryParams } from "../../utils/utils";
 
-const AccountFormContainer = () => {
+const AccountFormContainer = (): React.ReactElement => {
   const { state, dispatch } = useFormDataContext();
   const { formValues } = state;
   const router = useRouter();
@@ -32,6 +32,7 @@ const AccountFormContainer = () => {
   const submitForm = (formData) => {
     // Convert the home library name to its code value.
     formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
+    formData.location = findLibraryName(formData.homeLibraryCode);
     // Set the global form state...
     dispatch({
       type: "SET_FORM_DATA",

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -18,7 +18,10 @@ interface AccountFormFieldsProps {
   showPasswordOnLoad?: boolean;
 }
 
-function AccountFormFields({ id, showPasswordOnLoad }: AccountFormFieldsProps) {
+function AccountFormFields({
+  id,
+  showPasswordOnLoad,
+}: AccountFormFieldsProps): React.ReactElement {
   const { t } = useTranslation("common");
   const { register, errors, getValues } = useFormContext();
   const { state } = useFormDataContext();

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -23,6 +23,7 @@ import AcceptTermsFormFields from "../AcceptTermsFormFields";
 import Loader from "../Loader";
 import FormField from "../FormField";
 import { lcaEvents } from "../../externals/gaUtils";
+import aaUtils from "../../externals/aaUtils";
 import { createQueryParams } from "../../utils/utils";
 import useFormDataContext from "../../../src/context/FormDataContext";
 import {
@@ -150,6 +151,10 @@ function ReviewFormContainer() {
   const editSectionInfo = (formData, editSectionFlag) => {
     if (formData.homeLibraryCode) {
       formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
+      formData.location = findLibraryName(formData.homeLibraryCode);
+    }
+    if (formData.location) {
+      formData.homeLibraryCode = findLibraryCode(formData.location);
     }
     dispatch({
       type: "SET_FORM_DATA",
@@ -184,6 +189,14 @@ function ReviewFormContainer() {
         // Update the global state with a successful form submission data.
         dispatch({ type: "SET_FORM_RESULTS", value: response.data });
         lcaEvents("Submit", "Submit");
+
+        // Adobe Analytics
+        aaUtils.trackApplicationSubmitEvent({
+          id: formValues.username,
+          lang: formValues.preferredLanguage,
+          locationId: formValues.homeLibraryCode,
+          locationName: formValues.location,
+        });
         router.push(`/congrats?${queryStr}`);
       })
       .catch((error) => {

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -192,7 +192,7 @@ function ReviewFormContainer() {
 
         // Adobe Analytics
         aaUtils.trackApplicationSubmitEvent({
-          id: formValues.username,
+          id: null,
           lang: formValues.preferredLanguage,
           locationId: formValues.homeLibraryCode,
           locationName: formValues.location,

--- a/src/components/RoutingLinks.tsx/index.tsx
+++ b/src/components/RoutingLinks.tsx/index.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useTranslation } from "next-i18next";
 
 import { lcaEvents } from "../../externals/gaUtils";
+import aaUtils from "../../externals/aaUtils";
 import styles from "./RoutingLinks.module.css";
 
 export interface LinkType {
@@ -51,7 +52,10 @@ function RoutingLinks({ previous, next }: RoutingLinksType): JSX.Element {
             className={`button ${styles.button}`}
             // Just track the "Get Started" or "Submit" clicks. Routing events
             // are tracked at the component level in each "onSubmit".
-            onClick={() => lcaEvents("Navigation", next.text)}
+            onClick={() => {
+              lcaEvents("Navigation", next.text);
+              aaUtils.trackCtaEvent("Start Application", next.text, next.url);
+            }}
           >
             {nextText}
           </a>

--- a/src/externals/aaUtils.ts
+++ b/src/externals/aaUtils.ts
@@ -1,5 +1,5 @@
 interface ApplicationSubmitProps {
-  id: string;
+  id: string | null;
   lang: string;
   locationId: string;
   locationName: string;

--- a/src/externals/aaUtils.ts
+++ b/src/externals/aaUtils.ts
@@ -1,0 +1,79 @@
+interface ApplicationSubmitProps {
+  id: string;
+  lang: string;
+  locationId: string;
+  locationName: string;
+}
+/**
+ * AaUtils
+ * Adobe Analytics utility class that hold trackEvent methods.
+ */
+class AaUtils {
+  /**
+   * trackEvent
+   * Create a function to track a, Adobe Analytics event type. A convenience
+   * function values which don't change, don't have to be
+   * added every time.
+   */
+  pageViewEvent = (url: string) => {
+    window.adobeDataLayer.push({ page_name: null, site_section: null });
+    const pageName = url.split("/").pop();
+
+    window.adobeDataLayer.push({
+      event: "virtual_page_view",
+      page_name: `Library Card App | ${pageName}`,
+      site_section: "Library Card Application Form",
+    });
+  };
+
+  // Call To Action event
+  trackCtaEvent = (
+    subsection: string,
+    ctaText: string,
+    destination: string
+  ) => {
+    window.adobeDataLayer.push({
+      event_data: null,
+    });
+    window.adobeDataLayer.push({
+      event: "send_event",
+      event_data: {
+        name: "cta_click",
+        cta_section: "Library Card App",
+        cta_subsection: subsection,
+        cta_text: ctaText,
+        cta_position: "",
+        destination_url: destination,
+      },
+    });
+  };
+
+  // Application Sumbit event
+  trackApplicationSubmitEvent = ({
+    id,
+    lang,
+    locationId,
+    locationName,
+  }: ApplicationSubmitProps) => {
+    window.adobeDataLayer.push({
+      event_data: null,
+    });
+
+    window.adobeDataLayer.push({
+      event: "send_event",
+      event_data: {
+        name: "application_submit",
+        serialization_id: id,
+        description: "Library Card",
+        language: lang,
+        preferred_location_id: locationId,
+        preferred_location_name: locationName,
+      },
+    });
+  };
+}
+
+const aaUtils = new AaUtils();
+
+// Export the main instance.
+export default aaUtils;

--- a/src/externals/gaUtils.ts
+++ b/src/externals/gaUtils.ts
@@ -10,7 +10,7 @@ interface GaDimension {
  * Return the Google Analytics code for the production property if isProd is
  * true, or the dev property if isProd is false
  */
-export const getGoogleGACode = (isProd: boolean) => {
+export const getGoogleGACode = (isProd: boolean): string => {
   const codes = {
     production: "UA-1420324-3",
     dev: "UA-1420324-122",

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    adobeDataLayer: Record<string, any>[];
+    gtag: (...args: any[]) => void;
+  }
+}


### PR DESCRIPTION
## Description

- [ ] Adds Adobe Analytics initiation scripts in _document file
- [ ] Adds aaUtills containing all Adobe Analytics methods
- [ ] Fixes Preferred location bug

## Motivation and Context

Migrating fron GA to AA

## To Do
I would recommend testing it on NYPL Entities Prod since the reporting of it is connected to the NYPL Entities Dev Dashboard. However it can be also test first be tested on NYPL Entities Dev tag

 - [ ] Confirm with BlastX that missing properties are either added or not intended to be added. 
  >> missing preferred_location_id , description and serialization_id on `application_submit`
- [ ] Investigate with BlastX the `event6` "form-submit" that is getting triggered on each page change upon clicking the "Next" button (this is not an implementation in code!?)
 - [ ] Confirm Adobe Report Real Time Dashboards are set up to track "page views" and "cta_click"/"application_submit" events
 - [ ] Confirm that LCA is using NYPL Entities Prod/NYPL Entities Dev tag before testing

## How Has This Been Tested?

Looking at the Network tab while navigating through the app
(filter for "/ee" to see all AA related calls)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
