### PR TITLE
HOTFIX Remove Setting of location field

### DIFF
--- a/src/components/AccountFormContainer/index.tsx
+++ b/src/components/AccountFormContainer/index.tsx
@@ -32,7 +32,6 @@ const AccountFormContainer = (): React.ReactElement => {
   const submitForm = (formData) => {
     // Convert the home library name to its code value.
     formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
-    formData.location = findLibraryName(formData.homeLibraryCode);
     // Set the global form state...
     dispatch({
       type: "SET_FORM_DATA",

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -151,7 +151,6 @@ function ReviewFormContainer() {
   const editSectionInfo = (formData, editSectionFlag) => {
     if (formData.homeLibraryCode) {
       formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
-      formData.location = findLibraryName(formData.homeLibraryCode);
     }
     if (formData.location) {
       formData.homeLibraryCode = findLibraryCode(formData.location);

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -194,7 +194,7 @@ function ReviewFormContainer() {
           id: null,
           lang: formValues.preferredLanguage,
           locationId: formValues.homeLibraryCode,
-          locationName: formValues.location,
+          locationName: findLibraryName(formValues.homeLibraryCode),
         });
         router.push(`/congrats?${queryStr}`);
       })


### PR DESCRIPTION
## Description

Recent updates set the `formData.location` variable equal to the name of the selected branch. This field is used to determine the patron's eligibility for certain library card types and this change has broken that functionality

## Motivation and Context

Received bug reports that library cards were not being created as desired

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
