### PR TITLE
RENO-3687: Update NYPL Header min-height

### DIFF
--- a/src/styles/components/globals.scss
+++ b/src/styles/components/globals.scss
@@ -15,12 +15,18 @@
 }
 
 #nypl-header {
-  min-height: 70px;
+  min-height: 62px;
+}
+
+@media screen and (min-width: 832px) {
+  #nypl-header {
+    min-height: 112px;
+  }
 }
 
 @media screen and (min-width: 1024px) {
   #nypl-header {
-    min-height: 207px;
+    min-height: 130px;
   }
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
- Updates the `min-height` values for the nypl-header placeholder

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change was required after the NYPL Header height was updated and deployed by the Design System.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
