### PR TITLE
transform pin is trivial message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## CHANGE LOG
 
-### 1.1.2 Hot fix 3/20
+### 1.1.3 Mask PIN error message
+- Transform Sierra error message "PIN is trivial" to something more legible to users
 
+### 1.1.2 Hot fix 3/20
 - Updating the legacy catalog library card form link to `https://on.nypl.org/internationalresearch`.
 
 ### v1.1.1 Fix CSRF regression

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -419,6 +419,9 @@ export async function callPatronAPI(
         error: err.message,
       };
     }
+    if (err.response?.data.detail.includes("PIN is trivial"))
+      err.response.data.detail =
+        "Password cannot contain consecutively repeating characters three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab";
     if (status === 401 || status === 403) {
       serverError = { type: "internal" };
     }


### PR DESCRIPTION
## Description

Override PIN is trivial error message

## Motivation and Context

Patrons are confused by PIN is trivial message. Also indicates that the password instructions are not legible

## How Has This Been Tested?

Filling out form with password abcabcabc

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
