### PR TITLE
"hot fix" transform pin is trivial message

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -419,6 +419,9 @@ export async function callPatronAPI(
         error: err.message,
       };
     }
+    if (err.response?.data.detail.includes("PIN is trivial"))
+      err.response.data.detail =
+        "Password cannot contain consecutively repeating characters three or more times, e.g. aaaatf54 or repeating a pattern, e.g. abcabcab";
     if (status === 401 || status === 403) {
       serverError = { type: "internal" };
     }


### PR DESCRIPTION
## Description

Separating this work from the ongoing cookie investigation. This PR rather bluntly masks the Sierra error message returned when a password contains repeating characters. It does not add any input validation.