### PR TITLE
Scc 4620/set token per page

### DIFF
--- a/pages/account/index.tsx
+++ b/pages/account/index.tsx
@@ -18,9 +18,13 @@ import * as cookie from "../../src/utils/CookieUtils";
 
 interface AccountPageProps {
   hasUserAlreadyRegistered?: boolean;
+  csrfToken: string;
 }
 
-function AccountPage({ hasUserAlreadyRegistered }: AccountPageProps) {
+function AccountPage({
+  hasUserAlreadyRegistered,
+  csrfToken,
+}: AccountPageProps) {
   const { t } = useTranslation("common");
   const router = useRouter();
   useEffect(() => {
@@ -31,7 +35,7 @@ function AccountPage({ hasUserAlreadyRegistered }: AccountPageProps) {
       <Heading level="two">{t("account.title")}</Heading>
       <p>{t("account.description")}</p>
       <p>{t("internationalInstructions")}</p>
-      <AccountFormContainer csrfToken={csrfToken}/>
+      <AccountFormContainer csrfToken={csrfToken} />
     </>
   );
 }

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -3,17 +3,8 @@
  * Do NOT point the browser to http://localhost:3000 with no route.
  * If you do, you will throw an error related to i18next.
  * */
-
-import { useEffect } from "react";
 import { Heading } from "@nypl/design-system-react-components";
 import RoutingLinks from "../../src/components/RoutingLinks.tsx";
-import useFormDataContext from "../../src/context/FormDataContext";
-import {
-  generateNewCookieTokenAndHash,
-  generateNewToken,
-  parseTokenFromPostRequestCookies,
-} from "../../src/utils/csrfUtils";
-import * as cookie from "../../src/utils/CookieUtils";
 
 import { GetServerSideProps } from "next";
 import { useTranslation } from "next-i18next";
@@ -23,7 +14,6 @@ import { cookieDomain } from "../../appConfig.js";
 
 interface HomePageProps {
   policyType: any;
-  csrfToken: any;
   lang: string;
 }
 

--- a/pages/new/index.tsx
+++ b/pages/new/index.tsx
@@ -27,17 +27,8 @@ interface HomePageProps {
   lang: string;
 }
 
-function HomePage({ policyType, csrfToken, lang }: HomePageProps) {
+function HomePage({ policyType, lang }: HomePageProps) {
   const { t } = useTranslation("common");
-  const { dispatch } = useFormDataContext();
-  // When the app loads, get the CSRF token from the server and set it in
-  // the app's state.
-  useEffect(() => {
-    dispatch({
-      type: "SET_CSRF_TOKEN",
-      value: csrfToken,
-    });
-  }, []);
 
   // If we get a new policy type from the home page, make sure it gets to the
   // form on the next page. Used for the no-js scenario.
@@ -67,22 +58,16 @@ function HomePage({ policyType, csrfToken, lang }: HomePageProps) {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { query } = context;
-  // always update csrf token on /new
-  const csrfToken = generateNewToken();
-  const newTokenCookieString = generateNewCookieTokenAndHash(csrfToken);
-  const tokenCookie = cookie.buildCookieHeader(newTokenCookieString);
 
   const headers = [
     // reset cookie that would otherwise bump users out of the flow
     // to succcess page
     `nyplUserRegistered=false; Max-Age=-1; path=/; domain=${cookieDomain};`,
-    tokenCookie,
   ];
   context.res.setHeader("Set-Cookie", headers);
 
   return {
     props: {
-      csrfToken,
       lang: query?.lang || "en",
       // This allows this page to get the proper translations based
       // on the `lang=...` URL query param. Default to "en".

--- a/pages/workAddress/index.tsx
+++ b/pages/workAddress/index.tsx
@@ -14,7 +14,7 @@ import {
   generateNewCookieTokenAndHash,
   generateNewToken,
 } from "../../src/utils/csrfUtils";
-import * as cookie from "../../src/utils/CookieUtils"
+import * as cookie from "../../src/utils/CookieUtils";
 interface WorkAddressPageProps {
   hasUserAlreadyRegistered?: boolean;
   csrfToken: string;

--- a/pages/workAddress/index.tsx
+++ b/pages/workAddress/index.tsx
@@ -10,12 +10,20 @@ import {
   redirectIfUserHasRegistered,
 } from "../../src/utils/utils";
 import { useRouter } from "next/router";
-
+import {
+  generateNewCookieTokenAndHash,
+  generateNewToken,
+} from "../../src/utils/csrfUtils";
+import * as cookie from "../../src/utils/CookieUtils"
 interface WorkAddressPageProps {
   hasUserAlreadyRegistered?: boolean;
+  csrfToken: string;
 }
 
-function WorkAddressPage({ hasUserAlreadyRegistered }: WorkAddressPageProps) {
+function WorkAddressPage({
+  hasUserAlreadyRegistered,
+  csrfToken,
+}: WorkAddressPageProps) {
   const { t } = useTranslation("common");
   const router = useRouter();
   useEffect(() => {
@@ -26,7 +34,7 @@ function WorkAddressPage({ hasUserAlreadyRegistered }: WorkAddressPageProps) {
       <Heading level="two">{t("location.workAddress.title")}</Heading>
       <p>{t("location.workAddress.description.part1")}</p>
       <p>{t("internationalInstructions")}</p>
-      <WorkAddressContainer />
+      <WorkAddressContainer csrfToken={csrfToken} />
     </>
   );
 }
@@ -34,7 +42,12 @@ function WorkAddressPage({ hasUserAlreadyRegistered }: WorkAddressPageProps) {
 export const getServerSideProps: GetServerSideProps = async ({
   query,
   req,
+  res,
 }) => {
+  const csrfToken = generateNewToken();
+  const newTokenCookieString = generateNewCookieTokenAndHash(csrfToken);
+  const tokenCookie = cookie.buildCookieHeader(newTokenCookieString);
+  res.setHeader("Set-Cookie", [tokenCookie]);
   // We only want to get to this page from a form submission flow. If the page
   // is hit directly, then redirect to the home page.
   if (!query.newCard) {

--- a/src/components/AccountFormContainer/index.tsx
+++ b/src/components/AccountFormContainer/index.tsx
@@ -16,7 +16,7 @@ import { findLibraryCode } from "../../utils/formDataUtils";
 import FormField from "../FormField";
 import { createQueryParams } from "../../utils/utils";
 
-const AccountFormContainer = () => {
+const AccountFormContainer = ({ csrfToken }) => {
   const { state, dispatch } = useFormDataContext();
   const { formValues } = state;
   const router = useRouter();
@@ -49,7 +49,7 @@ const AccountFormContainer = () => {
       method="post"
       onSubmit={handleSubmit(submitForm)}
     >
-      <AccountFormFields id="account-form-container" />
+      <AccountFormFields csrfToken={csrfToken} id="account-form-container" />
       <AcceptTermsFormFields />
 
       <FormRow display="none">

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -16,9 +16,14 @@ import LibraryListFormFields from "../LibraryListFormFields";
 interface AccountFormFieldsProps {
   id?: string;
   showPasswordOnLoad?: boolean;
+  csrfToken: string;
 }
 
-function AccountFormFields({ id, showPasswordOnLoad }: AccountFormFieldsProps) {
+function AccountFormFields({
+  id,
+  showPasswordOnLoad,
+  csrfToken,
+}: AccountFormFieldsProps) {
   const { t } = useTranslation("common");
   const { register, errors, getValues } = useFormContext();
   const { state } = useFormDataContext();
@@ -64,6 +69,7 @@ function AccountFormFields({ id, showPasswordOnLoad }: AccountFormFieldsProps) {
       <UsernameValidationFormFields
         id={`${id}-accountForm-1`}
         errorMessage={t("account.errorMessage.username")}
+        csrfToken={csrfToken}
       />
 
       <FormRow id={`${id}-accountForm-2`}>

--- a/src/components/AddressContainer/index.tsx
+++ b/src/components/AddressContainer/index.tsx
@@ -26,10 +26,10 @@ import { nyCounties, nyCities, createQueryParams } from "../../utils/utils";
 import useFormDataContext from "../../context/FormDataContext";
 import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 
-const AddressContainer: React.FC = () => {
+const AddressContainer = ({ csrfToken }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { state, dispatch } = useFormDataContext();
-  const { formValues, csrfToken } = state;
+  const { formValues } = state;
   const router = useRouter();
   const { t } = useTranslation("common");
   // Specific functions and object from react-hook-form.

--- a/src/components/AddressContainer/index.tsx
+++ b/src/components/AddressContainer/index.tsx
@@ -29,7 +29,7 @@ import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 const AddressContainer: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { state, dispatch } = useFormDataContext();
-  const { formValues } = state;
+  const { formValues, csrfToken } = state;
   const router = useRouter();
   const { t } = useTranslation("common");
   // Specific functions and object from react-hook-form.
@@ -60,6 +60,7 @@ const AddressContainer: React.FC = () => {
       .post("/library-card/api/address", {
         address: homeAddress,
         isWorkAddress: false,
+        csrfToken,
       })
       .then((response) => {
         // We got a response back so use the updated address response.

--- a/src/components/AddressContainer/index.tsx
+++ b/src/components/AddressContainer/index.tsx
@@ -29,7 +29,7 @@ import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 const AddressContainer: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { state, dispatch } = useFormDataContext();
-  const { formValues, csrfToken } = state;
+  const { formValues } = state;
   const router = useRouter();
   const { t } = useTranslation("common");
   // Specific functions and object from react-hook-form.
@@ -60,7 +60,6 @@ const AddressContainer: React.FC = () => {
       .post("/library-card/api/address", {
         address: homeAddress,
         isWorkAddress: false,
-        csrfToken,
       })
       .then((response) => {
         // We got a response back so use the updated address response.

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -427,6 +427,7 @@ function ReviewFormContainer({ csrfToken }) {
             <AccountFormFields
               id="review-form-account-fields"
               showPasswordOnLoad
+              csrfToken={csrfToken}
             />
             <AcceptTermsFormFields />
             {submitSectionButton}

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -37,12 +37,12 @@ import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
  * ReviewFormContainer
  * Main page component for the "form submission review" page.
  */
-function ReviewFormContainer() {
+function ReviewFormContainer({ csrfToken }) {
   const { t } = useTranslation("common");
   const [isLoading, setIsLoading] = useState(false);
   const { handleSubmit } = useFormContext();
   const { state, dispatch } = useFormDataContext();
-  const { formValues, errorObj, csrfToken } = state;
+  const { formValues, errorObj } = state;
   const router = useRouter();
   const {
     query: { lang = "en" },
@@ -129,11 +129,7 @@ function ReviewFormContainer() {
     );
   const submitSectionButton = (
     <ButtonGroup>
-      <Button
-        buttonType="primary"
-        id="submitSectionButton"
-        type="submit"
-      >
+      <Button buttonType="primary" id="submitSectionButton" type="submit">
         {t("button.submit")}
       </Button>
     </ButtonGroup>
@@ -184,7 +180,6 @@ function ReviewFormContainer() {
       .then((response) => {
         // Update the global state with a successful form submission data.
         dispatch({ type: "SET_FORM_RESULTS", value: response.data });
-        
 
         // Adobe Analytics
         aaUtils.trackApplicationSubmitEvent({

--- a/src/components/UsernameValidationFormFields/UsernameValidationFormFields.test.tsx
+++ b/src/components/UsernameValidationFormFields/UsernameValidationFormFields.test.tsx
@@ -174,7 +174,7 @@ describe("UsernameValidationFormFields", () => {
 
     expect(axios.post).toBeCalledWith("/library-card/api/username", {
       username: "notAvailableUsername",
-      csrfToken: null,
+      csrfToken: undefined,
     });
     // Once we know that the error message _is_ in the document,
     // use `getByText`.
@@ -207,7 +207,7 @@ describe("UsernameValidationFormFields", () => {
 
     expect(axios.post).toBeCalledWith("/library-card/api/username", {
       username: "availableUsername",
-      csrfToken: null,
+      csrfToken: undefined,
     });
 
     messageDisplay = screen.getByText(message);

--- a/src/components/UsernameValidationFormFields/index.tsx
+++ b/src/components/UsernameValidationFormFields/index.tsx
@@ -24,6 +24,7 @@ import { apiTranslations } from "../../data/apiMessageTranslations";
 interface UsernameValidationFormProps {
   id?: string;
   errorMessage?: string;
+  csrfToken: string
 }
 
 /**
@@ -34,6 +35,7 @@ interface UsernameValidationFormProps {
 const UsernameValidationForm = ({
   id = "",
   errorMessage = "",
+  csrfToken
 }: UsernameValidationFormProps) => {
   const { t } = useTranslation("common");
   const {
@@ -47,7 +49,7 @@ const UsernameValidationForm = ({
   const { watch, getValues, register, errors } = useFormContext();
   const usernameWatch = watch("username");
   const { state } = useFormDataContext();
-  const { formValues, csrfToken } = state;
+  const { formValues } = state;
 
   // Whenever the username input changes, revert back to the default state.
   // This is to re-render the button after a patron tries a new username.

--- a/src/components/UsernameValidationFormFields/index.tsx
+++ b/src/components/UsernameValidationFormFields/index.tsx
@@ -24,7 +24,7 @@ import { apiTranslations } from "../../data/apiMessageTranslations";
 interface UsernameValidationFormProps {
   id?: string;
   errorMessage?: string;
-  csrfToken: string
+  csrfToken: string;
 }
 
 /**
@@ -35,7 +35,7 @@ interface UsernameValidationFormProps {
 const UsernameValidationForm = ({
   id = "",
   errorMessage = "",
-  csrfToken
+  csrfToken,
 }: UsernameValidationFormProps) => {
   const { t } = useTranslation("common");
   const {

--- a/src/components/WorkAddressContainer/index.tsx
+++ b/src/components/WorkAddressContainer/index.tsx
@@ -29,7 +29,7 @@ import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 const AddressContainer: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { state, dispatch } = useFormDataContext();
-  const { formValues, addressesResponse } = state;
+  const { formValues, addressesResponse, csrfToken } = state;
   const router = useRouter();
   const { t } = useTranslation("common");
   // Specific functions and object from react-hook-form.
@@ -64,6 +64,7 @@ const AddressContainer: React.FC = () => {
         .post("/library-card/api/address", {
           address: workAddress,
           isWorkAddress: true,
+          csrfToken,
         })
         .then((response) => {
           const work: AddressResponse = response.data;

--- a/src/components/WorkAddressContainer/index.tsx
+++ b/src/components/WorkAddressContainer/index.tsx
@@ -29,7 +29,7 @@ import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 const AddressContainer: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const { state, dispatch } = useFormDataContext();
-  const { formValues, addressesResponse, csrfToken } = state;
+  const { formValues, addressesResponse } = state;
   const router = useRouter();
   const { t } = useTranslation("common");
   // Specific functions and object from react-hook-form.
@@ -64,7 +64,6 @@ const AddressContainer: React.FC = () => {
         .post("/library-card/api/address", {
           address: workAddress,
           isWorkAddress: true,
-          csrfToken,
         })
         .then((response) => {
           const work: AddressResponse = response.data;

--- a/src/components/WorkAddressContainer/index.tsx
+++ b/src/components/WorkAddressContainer/index.tsx
@@ -26,17 +26,16 @@ import { createQueryParams } from "../../utils/utils";
 import { useTranslation } from "next-i18next";
 import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 
-const AddressContainer: React.FC = () => {
+const AddressContainer = ({ csrfToken }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { state, dispatch } = useFormDataContext();
-  const { formValues, addressesResponse, csrfToken } = state;
+  const { formValues, addressesResponse } = state;
   const router = useRouter();
   const { t } = useTranslation("common");
   // Specific functions and object from react-hook-form.
   const { handleSubmit } = useFormContext();
   // Get the URL query params for `newCard` and `lang`.
   const queryStr = createQueryParams(router?.query);
-
   /**
    * submitForm
    * @param formData - data object returned from react-hook-form

--- a/src/context/FormDataContext.tsx
+++ b/src/context/FormDataContext.tsx
@@ -12,7 +12,6 @@ import {
 export const formInitialState: FormData = {
   results: undefined,
   errorObj: undefined,
-  csrfToken: null,
   formValues: {
     ecommunicationsPref: true,
     policyType: "webApplicant",

--- a/src/context/__tests__/FormDataContext.test.tsx
+++ b/src/context/__tests__/FormDataContext.test.tsx
@@ -8,7 +8,6 @@ import { FormData, FormInputData, AddressesResponse } from "../../interfaces";
 const initState: FormData = {
   results: undefined,
   errorObj: null,
-  csrfToken: null,
   formValues: {
     ecommunicationsPref: true,
     policyType: "webApplicant",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -142,7 +142,6 @@ export interface FormResults {
 export interface FormData {
   results: FormResults | undefined;
   errorObj: ProblemDetail | undefined;
-  csrfToken: string;
   formValues: FormInputData;
   addressesResponse: AddressesResponse;
 }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -12,12 +12,6 @@ export function formReducer(state, action) {
         errorObj: action.value,
       };
     }
-    case "SET_CSRF_TOKEN": {
-      return {
-        ...state,
-        csrfToken: action.value,
-      };
-    }
     case "SET_FORM_RESULTS": {
       return {
         ...state,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -238,6 +238,10 @@ function invalidCsrfResponse(res) {
  */
 export async function validateAddress(req, res, appObj = app) {
   const tokenObject = appObj["tokenObject"];
+  const csrfTokenValid = validateCsrfToken(req);
+  if (!csrfTokenValid) {
+    return invalidCsrfResponse(res);
+  }
   if (tokenObject && tokenObject?.access_token) {
     const token = tokenObject.access_token;
     const addressRequest: AddressAPIRequestData = {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -238,10 +238,6 @@ function invalidCsrfResponse(res) {
  */
 export async function validateAddress(req, res, appObj = app) {
   const tokenObject = appObj["tokenObject"];
-  const csrfTokenValid = validateCsrfToken(req);
-  if (!csrfTokenValid) {
-    return invalidCsrfResponse(res);
-  }
   if (tokenObject && tokenObject?.access_token) {
     const token = tokenObject.access_token;
     const addressRequest: AddressAPIRequestData = {


### PR DESCRIPTION
## Description

Remove token setting from redux state, instead passing it in per-page when needed, for username and address validation validation and form submission.

## Motivation and Context

There is a mysterious issue where the csrf token is not persisting in the redux state. Instead of hunting it down, I am going to remove it from that state management. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
