### PR TITLE
use react hook data in submission

### DIFF
--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -127,17 +127,6 @@ function ReviewFormContainer() {
         {t("button.edit")}
       </a>
     );
-  const submitSectionButton = (
-    <ButtonGroup>
-      <Button
-        buttonType="primary"
-        id="submitSectionButton"
-        type="submit"
-      >
-        {t("button.submit")}
-      </Button>
-    </ButtonGroup>
-  );
 
   /**
    * editSectionInfo
@@ -408,7 +397,6 @@ function ReviewFormContainer() {
             )}
           >
             <PersonalFormFields />
-            {submitSectionButton}
           </Form>
         )}
       </div>
@@ -434,7 +422,6 @@ function ReviewFormContainer() {
               showPasswordOnLoad
             />
             <AcceptTermsFormFields />
-            {submitSectionButton}
           </Form>
         )}
       </div>

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -40,7 +40,7 @@ import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 function ReviewFormContainer() {
   const { t } = useTranslation("common");
   const [isLoading, setIsLoading] = useState(false);
-  const { handleSubmit } = useFormContext();
+  const { handleSubmit, getValues } = useFormContext();
   const { state, dispatch } = useFormDataContext();
   const { formValues, errorObj, csrfToken } = state;
   const router = useRouter();
@@ -176,11 +176,11 @@ function ReviewFormContainer() {
     // Update the global state.
     dispatch({
       type: "SET_FORM_DATA",
-      value: formValues,
+      value: {...formValues, ...getValues()},
     });
 
     axios
-      .post("/library-card/api/create-patron", { ...formValues, csrfToken })
+      .post("/library-card/api/create-patron", { ...formValues, ...getValues(), csrfToken })
       .then((response) => {
         // Update the global state with a successful form submission data.
         dispatch({ type: "SET_FORM_RESULTS", value: response.data });


### PR DESCRIPTION
## Description

- remove individual submit button on review page after errors returned from sierra
- updates submit handler to use react-hook-form state, not the useFormDataContext state. this way, we don't have to rely on submit-button dispatches to useFormDataContext. I am wondering if there is way to pass in an onChange or onBlur to the react-hook-form registered inputs that can automatically dispatch instead of needing to use submit buttons.

## Motivation and Context

Users do not understand the individual submit buttons in the review form page after an error response is returned from Sierra. This results in a confusing experience when you update the password, click the big submit button at the bottom, and get slapped with the same error you apparently fixed. 

## How Has This Been Tested?

manually: 
1. create an account with a bad password, eg abcabcabc
2. upon reaching the review page with the error message, update the password and any other fields you want
3. submit
4. account creation should be successful (compare to prod where you just get stuck on the review page)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
