### PR TITLE
prevent default submit behavior

### DIFF
--- a/pages/workAddress/index.tsx
+++ b/pages/workAddress/index.tsx
@@ -56,6 +56,7 @@ export const getServerSideProps: GetServerSideProps = async ({
   const hasUserAlreadyRegistered = !!req.cookies["nyplUserRegistered"];
   return {
     props: {
+      csrfToken,
       hasUserAlreadyRegistered,
       ...(await serverSideTranslations(query?.lang?.toString() || "en", [
         "common",

--- a/src/components/AccountFormContainer/index.tsx
+++ b/src/components/AccountFormContainer/index.tsx
@@ -29,7 +29,8 @@ const AccountFormContainer = ({ csrfToken }) => {
    * submitForm
    * @param formData - data object returned from react-hook-form
    */
-  const submitForm = (formData) => {
+  const submitForm = (formData, e) => {
+    e.preventDefault();
     // Convert the home library name to its code value.
     formData.homeLibraryCode = findLibraryCode(formData.homeLibraryCode);
     // Set the global form state...
@@ -44,7 +45,7 @@ const AccountFormContainer = ({ csrfToken }) => {
 
   return (
     <Form
-      action="/library-card/api/submit"
+      // action="/library-card/api/submit"
       id="account-form-container"
       method="post"
       onSubmit={handleSubmit(submitForm)}

--- a/src/components/AddressContainer/index.tsx
+++ b/src/components/AddressContainer/index.tsx
@@ -41,7 +41,8 @@ const AddressContainer = ({ csrfToken }) => {
    * submitForm
    * @param formData - data object returned from react-hook-form
    */
-  const submitForm = (formData) => {
+  const submitForm = (formData, e) => {
+    e.preventDefault();
     setIsLoading(true);
 
     // Set the global form state...
@@ -140,7 +141,7 @@ const AddressContainer = ({ csrfToken }) => {
       <Loader isLoading={isLoading} />
 
       <Form
-        action="/library-card/api/submit"
+        // action="/library-card/api/submit"
         id="address-container"
         method="post"
         onSubmit={handleSubmit(submitForm)}

--- a/src/components/AddressVerificationContainer/index.tsx
+++ b/src/components/AddressVerificationContainer/index.tsx
@@ -82,7 +82,8 @@ function AddressVerificationContainer() {
     return updatedValues;
   };
 
-  const submitForm = (formData) => {
+  const submitForm = (formData, e) => {
+    e.preventDefault();
     // These are the values from the radio button inputs if they were rendered.
     const home = formData["home-address-select"];
     const work = formData["work-address-select"];
@@ -191,7 +192,7 @@ function AddressVerificationContainer() {
 
   return (
     <Form
-      action="/library-card/api/submit"
+      // action="/library-card/api/submit"
       id="address-verification-container"
       method="post"
       onSubmit={handleSubmit(submitForm)}

--- a/src/components/PersonalFormContainer/index.tsx
+++ b/src/components/PersonalFormContainer/index.tsx
@@ -31,7 +31,8 @@ const PersonalFormContainer = () => {
    * submitForm
    * @param formData - data object returned from react-hook-form
    */
-  const submitForm = (formData) => {
+  const submitForm = (formData, e) => {
+    e.preventDefault();
     // Set the global form state...
     dispatch({
       type: "SET_FORM_DATA",
@@ -47,7 +48,7 @@ const PersonalFormContainer = () => {
       id="perform-form-container"
       onSubmit={handleSubmit(submitForm)}
       method="post"
-      action="/library-card/api/submit"
+      // action="/library-card/api/submit"
     >
       <PersonalFormFields
         agencyType={formValues.policyType}

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -438,7 +438,7 @@ function ReviewFormContainer({ csrfToken }) {
       <div className={styles.formSection}>{t("review.nextStep")}</div>
 
       <Form
-        action="/library-card/api/submit"
+        // action="/library-card/api/submit"
         id="review-submit"
         method="post"
         onSubmit={handleSubmit(submitForm)}

--- a/src/components/WorkAddressContainer/index.tsx
+++ b/src/components/WorkAddressContainer/index.tsx
@@ -40,7 +40,8 @@ const AddressContainer = ({ csrfToken }) => {
    * submitForm
    * @param formData - data object returned from react-hook-form
    */
-  const submitForm = (formData) => {
+  const submitForm = (formData, e) => {
+    e.preventDefault();
     setIsLoading(true);
     const workAddress = constructAddressType(formData, "work");
     // If the work address wasn't filled out, that's okay, proceed.
@@ -129,7 +130,7 @@ const AddressContainer = ({ csrfToken }) => {
       <Loader isLoading={isLoading} />
 
       <Form
-        action="/library-card/api/submit"
+        // action="/library-card/api/submit"
         id="work-address-container"
         method="post"
         onSubmit={handleSubmit(submitForm)}


### PR DESCRIPTION
## Description

Remove action and add prevent default to submit buttons.

## Motivation and Context

QA and Production environments are sending a post request first to /api/submit, then calling router.push. Perhaps this is causing the hard reload, as the initial post is returning a 307 temporary redirect response. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
