### PR TITLE
verify password match works on both inputs

### DIFF
--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -56,11 +56,16 @@ function AccountFormFields({
 
   // Note: As of 1/22, the password must not contain a period to allow
   // patrons to log into Overdrive for digital reading.
-  const validatePassword = (val) => {
+  const validatePasswordLength = (val) => {
     return (
-      val.length >= minPasswordLength &&
-      val.length <= maxPasswordLength &&
-      val.indexOf(".") === -1
+      (val.length >= minPasswordLength && val.length <= maxPasswordLength) ||
+      t("account.errorMessage.password")
+    );
+  };
+  const verifyPasswordmatch = () => {
+    return (
+      getValues("password") === getValues("verifyPassword") ||
+      t("account.errorMessage.verifyPassword")
     );
   };
 
@@ -85,8 +90,10 @@ function AccountFormFields({
             minLength={minPasswordLength}
             maxLength={maxPasswordLength}
             ref={register({
-              validate: (val) =>
-                validatePassword(val) || t("account.errorMessage.password"),
+              validate: {
+                validatePasswordLength,
+                verifyPasswordmatch,
+              },
             })}
             defaultValue={formValues.password}
           />
@@ -106,9 +113,7 @@ function AccountFormFields({
             minLength={minPasswordLength}
             maxLength={maxPasswordLength}
             ref={register({
-              validate: (val) =>
-                val === originalPassword ||
-                t("account.errorMessage.verifyPassword"),
+              validate: verifyPasswordmatch,
             })}
             defaultValue={formValues.verifyPassword}
           />


### PR DESCRIPTION
## Description

addressing bug where adding wrong letters to the first password input doesn't trigger password does not match error.