### PR TITLE
Scc 4628/pin message translations

### DIFF
--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "ابدأ مع مكتبة نيويورك العامة",
       "explore": "<b>استكشف الكتب الإلكترونية الخاصة بالمكتبة</b><br />قم بتنزيل تطبيق SimplyE لأجهزة <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> أو أجهزة <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>استعر الكتب والمزيد</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>سجِّل الدخول إلى حسابك</a> وتصفح الفهرس.",
+      "borrow": "<b>استعر الكتب والمزيد</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>سجِّل الدخول إلى حسابك</a> وتصفح الفهرس.",
       "updates": "<b>احصل على التحديثات</b><br /><a href='https://www.nypl.org/enews'>تعرَّف على كل ما تقدمه المكتبة.</a>",
       "more": "<b>تعرَّف على المزيد</b><br /><a href='https://www.nypl.org/discover-library-card'>اكتشف كل ما يمكنك فعله ببطاقة المكتبة الخاصة بك.</a>"
     }

--- a/public/locales/bn/common.json
+++ b/public/locales/bn/common.json
@@ -149,7 +149,7 @@
     "nextSteps": {
       "title": "নিউ ইয়র্ক পাবলিক লাইব্রেরির সাথে শুরু করুন",
       "explore": "<b>লাইব্রেরির ই-বুক খুঁজে দেখুন</b><br />ডাউনলোড করুন SimplyE, যা <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> বা <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android-এর জন্য পাবেন।</a>.",
-      "borrow": "<b>বই এবং আরও অনেক কিছু পাবেন</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>আপনার অ্যাকাউন্টে লগ ইন করুন</a> এবং ক্যাটালগ ব্রাউজ করুন।",
+      "borrow": "<b>বই এবং আরও অনেক কিছু পাবেন</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>আপনার অ্যাকাউন্টে লগ ইন করুন</a> এবং ক্যাটালগ ব্রাউজ করুন।",
       "updates": "<b>আপডেট পান</b><br /><a href='https://www.nypl.org/enews'>লাইব্রেরি থেকে কী কী পাওয়া যায় তা দেখুন।</a>",
       "more": "<b>আরও জানুন</b><br /><a href='https://www.nypl.org/discover-library-card'>লাইব্রেরি কার্ড দিয়ে আপনি কী কী করতে পারেন তা জানুন।</a>"
     }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "Get Started with The New York Public Library",
       "explore": "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
+      "borrow": "<b>Borrow Books & More</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'> Log into your account</a> and browse the catalog.",
       "updates": "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
       "more": "<b>Learn More</b><br /><a href='https://www.nypl.org/discover-library-card'>Discover everything you can do with your library card.</a>"
     }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -141,7 +141,7 @@
     "nextSteps": {
       "title": "Comenzar con la Biblioteca Pública de Nueva York",
       "explore": "<b>Explore los libros electrónicos de la biblioteca</b><br />Descargue SimplyE para <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> o <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Pedir prestados libros y más</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Inicie sesión en su cuenta </a> y explore el catálogo.",
+      "borrow": "<b>Pedir prestados libros y más</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>Inicie sesión en su cuenta </a> y explore el catálogo.",
       "updates": "<b>Reciba actualizaciones</b><br /><a href='https://www.nypl.org/enews'>Descubra todo lo que la Biblioteca tiene para ofrecer.</a>",
       "more": "<b>Obtener más información</b><br /><a href='https://www.nypl.org/discover-library-card'>Descubra todo lo que puede hacer con su tarjeta de la Biblioteca.</a>"
     }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "Lancez-vous à la découverte de la Bibliothèque publique de New York",
       "explore": "<b>Explorer les livres électroniques de la Bibliothèque</b><br />Téléchargez SimplyE pour <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> ou <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Emprunter des livres et bien plus encore</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Connectez-vous à votre compte</a> et consultez le catalogue.",
+      "borrow": "<b>Emprunter des livres et bien plus encore</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>Connectez-vous à votre compte</a> et consultez le catalogue.",
       "updates": "<b>Recevoir des mises à jour</b><br /><a href='https://www.nypl.org/enews'>Découvrez tout ce que la Bibliothèque a à offrir.</a>",
       "more": "<b>En savoir plus</b><br /><a href='https://www.nypl.org/discover-library-card'>Découvrez tout ce que vous pouvez faire avec votre carte de bibliothèque.</a>"
     }

--- a/public/locales/ht/common.json
+++ b/public/locales/ht/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "Demare ak Bibliyotèk Piblik New York la",
       "explore": "<b>Eksplore Liv Elektwonik Bibliyotèk la</b><br />Telechaje SimplyE pou <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> oswa <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Prete Liv ak Plis Bagay Toujou</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Konekte sou kont ou</a> epi konsilte katalòg la.",
+      "borrow": "<b>Prete Liv ak Plis Bagay Toujou</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'> Konekte sou kont ou</a> epi konsilte katalòg la.",
       "updates": "<b>Jwenn Mizajou yo</b><br /><a href='https://www.nypl.org/enews'>Dekouvri tout sa Bibliyotèk la kapab ofri w.</a>",
       "more": "<b>Jwenn plis enfòmasyon.</b><br /><a href='https://www.nypl.org/discover-library-card'>Dekouvri tout bagay ou kapab fè ak kat Bibliyotèk ou an.</a>"
     }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "뉴욕 공공도서관 이용 시작하기",
       "explore": "<b>도서관 전자책 탐색</b><br /><a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> 또는 <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>용 SimplyE 앱을 다운로드하십시오",
-      "borrow": "<b>책과 자료 대여</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>계정에 로그인하여</a> 카탈로그를 탐색하십시오.",
+      "borrow": "<b>책과 자료 대여</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>계정에 로그인하여</a> 카탈로그를 탐색하십시오.",
       "updates": "<b>업데이트 확인</b><br /><a href='https://www.nypl.org/enews'>도서관에서 이용할 수 있는 정보를 확인해 보십시오.</a>",
       "more": "<b>자세히 알아보기</b><br /><a href='https://www.nypl.org/discover-library-card'>도서관 카드로 어떤 일을 할 수 있는지 알아 보십시오.</a>"
     }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "Zacznij korzystać z Nowojorskiej Biblioteki Publicznej",
       "explore": "<b>Poznaj kolekcję e-booków Biblioteki</b><br />Pobierz SimplyE dla systemu <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> lub <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Wypożycz książki i inne materiały</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Zaloguj się na konto</a> i przejrzyj katalog.",
+      "borrow": "<b>Wypożycz książki i inne materiały</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>Zaloguj się na konto</a> i przejrzyj katalog.",
       "updates": "<b>Otrzymuj aktualności</b><br /><a href='https://www.nypl.org/enews'>Dowiedz się wszystkiego o ofercie Biblioteki.</a>",
       "more": "<b>Więcej informacji</b><br /><a href='https://www.nypl.org/discover-library-card'>Dowiedz się, co możesz robić przy użyciu karty bibliotecznej.</a>"
     }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "Начните пользоваться Нью-Йоркской публичной библиотекой",
       "explore": "<b>Исследуйте коллекцию электронных книг библиотеки</b><br />Загрузите приложение SimplyE для <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> или <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
-      "borrow": "<b>Берите книги и многое другое</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>Зайдите в свою учетную запись</a> и просмотрите каталог.",
+      "borrow": "<b>Берите книги и многое другое</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>Зайдите в свою учетную запись</a> и просмотрите каталог.",
       "updates": "<b>Получайте новости</b><br /><a href='https://www.nypl.org/enews'>Узнайте обо всем, что предлагает библиотека.</a>",
       "more": "<b>Подробнее</b><br /><a href='https://www.nypl.org/discover-library-card'>Узнайте обо всем, что можно получить с помощью читательского билета.</a>"
     }

--- a/public/locales/ur/common.json
+++ b/public/locales/ur/common.json
@@ -146,7 +146,7 @@
     "nextSteps": {
       "title": "نیویارک پبلک لائبریری کے ساتھ آغاز کریں",
       "explore": "<b>لائبریری کی ای-بُکس دریافت کریں</b><br />SimplyE برائے <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> یا <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a> ڈاؤن لوڈ کریں۔",
-      "borrow": "<b>کتابیں اور بہت کچھ مستعار لیں</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>اپنے اکاؤنٹ میں لاگ ان کریں</a> اور فہرستِ باتصویر دیکھیں۔",
+      "borrow": "<b>کتابیں اور بہت کچھ مستعار لیں</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>اپنے اکاؤنٹ میں لاگ ان کریں</a> اور فہرستِ باتصویر دیکھیں۔",
       "updates": "<b>تازہ ترین معلومات حاصل کریں</b><br /><a href='https://www.nypl.org/enews'>لائبریری میں آپ کو پیش کرنے کے لیے جو کچھ بھی ہے وہ معلوم کریں۔</a>",
       "more": "<b>مزید جانیں</b><br /><a href='https://www.nypl.org/discover-library-card'>ہر وہ چیز دریافت کریں جو آپ اپنے لائبریری کارڈ کے ساتھ کر سکتے ہیں۔</a>"
     }

--- a/public/locales/zhcn/common.json
+++ b/public/locales/zhcn/common.json
@@ -143,7 +143,7 @@
     "nextSteps": {
       "title": "开始使用纽约公共图书馆",
       "explore": "<b>探索图书馆电子书</b><br />下载适用于 <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> 或 <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a> 的 SimplyE。",
-      "borrow": "<b>借阅书籍和其他物品</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'>登录您的帐户</a>并浏览目录。",
+      "borrow": "<b>借阅书籍和其他物品</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'>登录您的帐户</a>并浏览目录。",
       "updates": "<b>获取更新</b><br /><a href='https://www.nypl.org/enews'>发现图书馆提供的所有服务。</a>",
       "more": "<b>了解更多</b><br /><a href='https://www.nypl.org/discover-library-card'>发现您可以用图书卡做些什么。</a>"
     }

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -89,7 +89,6 @@ function AccountFormFields({
             ref={register({
               validate: {
                 validatePasswordLength,
-                verifyPasswordmatch,
               },
             })}
             defaultValue={formValues.password}

--- a/src/components/ConfirmationGraphic/ConfirmationGraphic.test.tsx
+++ b/src/components/ConfirmationGraphic/ConfirmationGraphic.test.tsx
@@ -51,7 +51,7 @@ jest.mock("react-i18next", () => {
         explore:
           "<b>Explore Library E-Books</b><br />Download SimplyE for <a href='https://apps.apple.com/app/apple-store/id1046583900'>iOS</a> or <a href='https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&referrer=utm_source%3Dnypl.org%26utm_medium%3Dreferral%26utm_content%3Dnypl_website_simplye2%26utm_campaign%3Dnypl_website_simplye2'>Android</a>.",
         borrow:
-          "<b>Borrow Books & More</b><br /><a href='https://ilsstaff.nypl.org/iii/cas/login?service=http%3A%2F%2Fauth.nypl.org%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3Dapp_myaccount%26scope%3Dopenid%2Boffline_access%2Bpatron%253Aread%26redirect_uri%3Dhttps%253A%252F%252Flogin.nypl.org%252Fauth%252Flogin%26state%3DeyJyZWRpcmVjdF91cmkiOiJodHRwczpcL1wvYnJvd3NlLm55cGwub3JnXC9paWlcL2VuY29yZVwvbXlhY2NvdW50In0%253D'> Log into your account</a> and browse the catalog.",
+          "<b>Borrow Books & More</b><br /><a href='https://login.nypl.org/auth/login?redirect_uri=https%3A%2F%2Fborrow.nypl.org%2F%3FopenAccount%3Dprofile'> Log into your account</a> and browse the catalog.",
         updates:
           "<b>Get Updates</b><br /><a href='https://www.nypl.org/enews'>Find out about all the Library has to offer.</a>",
         more:

--- a/src/data/ilsLibraryList.ts
+++ b/src/data/ilsLibraryList.ts
@@ -1,7 +1,7 @@
 import { LibraryListObject } from "../interfaces";
 
 const ilsLibraryList: LibraryListObject[] = [
-  { label: "SimplyE", value: "eb" },
+  { label: "E-Branch", value: "eb" },
   { label: "Harry Belafonte 115th Street Library", value: "hu" },
   { label: "125th Street Library", value: "hd" },
   { label: "58th Street Library", value: "fe" },


### PR DESCRIPTION
## Description

- update auth url
- update simplyE label to e-browse
- revert password validation. This is tricky due to limitations with react hook forms. Since the error state is dependent on onChange events rather than form state, it seems impossible to have the error state of one input change based on the interactions with another input. I tried a couple approaches to no avail, including having the two inputs share a single register()-returned ref.

## Motivation and Context

Sunsetting of SimplyE and buggy auth behavior.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
