### PR TITLE
SCC-4660 Override free text input on review form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGE LOG
 
+### 1.2.4 
+- revert verify password match to original state
+- update auth url [SCC-4657](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4657)
+- replace SimplyE label with EBrowse [SCC-4659](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4659)
+
 ### 1.2.3 Fix PIN translation errors
 - use password instructions for "PIN is trivial" error translation
 - add id's to facilitate QA testing in other languages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### 1.2.4 
 - revert verify password match to original state
 - update auth url [SCC-4657](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4657)
-- replace SimplyE label with EBrowse [SCC-4659](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4659)
+- replace SimplyE label with EBranch [SCC-4659](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4659)
+- enforce EBranch default on form review submission
 
 ### 1.2.3 Fix PIN translation errors
 - use password instructions for "PIN is trivial" error translation

--- a/src/components/ReviewFormContainer/index.tsx
+++ b/src/components/ReviewFormContainer/index.tsx
@@ -32,6 +32,7 @@ import {
   findLibraryCode,
 } from "../../../src/utils/formDataUtils";
 import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
+import ilsLibraryList from "../../data/ilsLibraryList";
 
 /**
  * ReviewFormContainer
@@ -161,15 +162,22 @@ function ReviewFormContainer({ csrfToken }) {
     setIsLoading(true);
     // This is resetting any errors from previous submissions, if any.
     dispatch({ type: "SET_FORM_ERRORS", value: null });
-
+    // default to eb if user has managed to input something silly in the free text input
+    const homeLibraryCode = ilsLibraryList
+      .map(({ value }) => value)
+      .includes(getValues("homeLibraryCode")) ? getValues("homeLibraryCode") : "eb"
     // Update the global state.
     dispatch({
       type: "SET_FORM_DATA",
-      value: {...formValues, ...getValues()},
+      value: { ...formValues, ...getValues(), homeLibraryCode },
     });
 
     axios
-      .post("/library-card/api/create-patron", { ...formValues, ...getValues(), csrfToken })
+      .post("/library-card/api/create-patron", {
+        ...formValues,
+        ...getValues(),
+        csrfToken,
+      })
       .then((response) => {
         // Update the global state with a successful form submission data.
         dispatch({ type: "SET_FORM_RESULTS", value: response.data });

--- a/src/utils/__tests__/formDataUtils.test.ts
+++ b/src/utils/__tests__/formDataUtils.test.ts
@@ -51,7 +51,7 @@ describe("findLibraryCode", () => {
 describe("findLibraryName", () => {
   // "SimplyE" library is the default.
   test("it returns `eb` as the default value", () => {
-    expect(findLibraryName()).toEqual("SimplyE");
+    expect(findLibraryName()).toEqual("E-Branch");
   });
 
   test("it returns the value code for a library name", () => {

--- a/src/utils/formDataUtils.ts
+++ b/src/utils/formDataUtils.ts
@@ -92,7 +92,7 @@ function findLibraryName(libraryCode?: string): string {
   const library = ilsLibraryList.find(
     (library) => library.value === libraryCode
   );
-  return library?.label || "SimplyE";
+  return library?.label || "E-Branch";
 }
 
 /**


### PR DESCRIPTION
The home library selector lets you input any text. It only resets to the default when the user clicks that individual form submission. Since the user does not click that form button on the review page anymore, the default "eb" was not overriding the erroneous user input. This PR adds another override in the higher level review form submit button.

This may be a regression after removing the individual submit buttons from the review form.