### PR TITLE
SWIS-42: Playwright tests to confirm address form displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 ## CHANGE LOG
 
 ### Unreleased
+
+- Playwright test for Step 1:Personal Information [SWIS-40](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-40)
+- Add Playwright tests to confirm elements on landing page [SWIS-39](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-39)
+- Add Playwright tests to confirm elements on location page [SWIS-42](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-42)
+
+### 1.2.5
+
 - Updates to confirmation barcode layout [SWIS-12](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-12)
 - Add New Relic setup [SWIS-13](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-13)
 - Install Playwright [SWIS-38](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-38)
-- Add Playwright tests to confirm elements on landing page [SWIS-39](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-39)
-- Playwright test for Step 1:Personal Information [SWIS-40](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-40)
 - Set up GitHub Actions workflow with Playwright tests [SWIS-41](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-41)
-
 
 ### 1.2.4
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,7 +74,6 @@ export default defineConfig({
     // },
   ],
 
-
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "npm run dev",

--- a/playwright/pageobjects/location.page.ts
+++ b/playwright/pageobjects/location.page.ts
@@ -5,6 +5,11 @@ export class LocationPage {
   readonly mainHeading: Locator; // displays on each page
   readonly stepHeading: Locator;
   readonly addressHeading: Locator;
+  readonly streetAddressInput: Locator;
+  readonly apartmentSuiteInput: Locator;
+  readonly cityInput: Locator;
+  readonly stateInput: Locator;
+  readonly postalCodeInput: Locator;
   readonly nextButton: Locator;
   readonly previousButton: Locator;
 
@@ -22,6 +27,11 @@ export class LocationPage {
       name: "Home Address",
       level: 3,
     });
+    this.streetAddressInput = page.getByLabel(/Street Address/i);
+    this.apartmentSuiteInput = page.getByLabel(/Apartment \/ Suite/i);
+    this.cityInput = page.getByLabel(/City/i);
+    this.stateInput = page.getByLabel(/State/i);
+    this.postalCodeInput = page.getByLabel(/Postal Code/i);
     this.nextButton = page.getByRole("button", { name: "Next" });
     this.previousButton = page.getByRole("link", { name: "Previous" });
   }

--- a/playwright/pageobjects/location.page.ts
+++ b/playwright/pageobjects/location.page.ts
@@ -1,0 +1,28 @@
+import { Page, Locator } from "@playwright/test";
+
+export class LocationPage {
+  readonly page: Page;
+  readonly mainHeading: Locator; // displays on each page
+  readonly stepHeading: Locator;
+  readonly addressHeading: Locator;
+  readonly nextButton: Locator;
+  readonly previousButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.mainHeading = page.getByRole("heading", {
+      name: "Apply for a Library Card Online",
+      level: 1,
+    });
+    this.stepHeading = page.getByRole("heading", {
+      name: /^Step \d of 5: .+$/,
+      level: 2,
+    });
+    this.addressHeading = page.getByRole("heading", {
+      name: "Home Address",
+      level: 3,
+    });
+    this.nextButton = page.getByRole("button", { name: "Next" });
+    this.previousButton = page.getByRole("link", { name: "Previous" });
+  }
+}

--- a/playwright/pageobjects/location.page.ts
+++ b/playwright/pageobjects/location.page.ts
@@ -20,7 +20,7 @@ export class LocationPage {
       level: 1,
     });
     this.stepHeading = page.getByRole("heading", {
-      name: /^Step \d of 5: .+$/,
+      name: "Step 2 of 5: Address",
       level: 2,
     });
     this.addressHeading = page.getByRole("heading", {

--- a/playwright/tests/location.spec.ts
+++ b/playwright/tests/location.spec.ts
@@ -12,6 +12,15 @@ test("displays all headings", async ({ page }) => {
   await expect(locationPage.addressHeading).toBeVisible();
 });
 
+test("displays address form", async ({ page }) => {
+  const locationPage = new LocationPage(page);
+  await expect(locationPage.streetAddressInput).toBeVisible();
+  await expect(locationPage.apartmentSuiteInput).toBeVisible();
+  await expect(locationPage.cityInput).toBeVisible();
+  await expect(locationPage.stateInput).toBeVisible();
+  await expect(locationPage.postalCodeInput).toBeVisible();
+});
+
 test("displays next and previous buttons", async ({ page }) => {
   const locationPage = new LocationPage(page);
   await expect(locationPage.nextButton).toBeVisible();

--- a/playwright/tests/location.spec.ts
+++ b/playwright/tests/location.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { LocationPage } from "../pageobjects/location.page";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/library-card/location?newCard=true");
+});
+
+test("displays the main heading", async ({ page }) => {
+  const locationPage = new LocationPage(page);
+  await expect(locationPage.mainHeading).toBeVisible();
+});
+
+test("displays the step heading", async ({ page }) => {
+  const locationPage = new LocationPage(page);
+  await expect(locationPage.stepHeading).toBeVisible();
+});
+
+test("displays the address heading", async ({ page }) => {
+  const locationPage = new LocationPage(page);
+  await expect(locationPage.addressHeading).toBeVisible();
+});
+
+test("displays next and previous buttons", async ({ page }) => {
+  const locationPage = new LocationPage(page);
+  await expect(locationPage.nextButton).toBeVisible();
+  await expect(locationPage.previousButton).toBeVisible();
+});

--- a/playwright/tests/location.spec.ts
+++ b/playwright/tests/location.spec.ts
@@ -5,18 +5,10 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/library-card/location?newCard=true");
 });
 
-test("displays the main heading", async ({ page }) => {
+test("displays all headings", async ({ page }) => {
   const locationPage = new LocationPage(page);
   await expect(locationPage.mainHeading).toBeVisible();
-});
-
-test("displays the step heading", async ({ page }) => {
-  const locationPage = new LocationPage(page);
   await expect(locationPage.stepHeading).toBeVisible();
-});
-
-test("displays the address heading", async ({ page }) => {
-  const locationPage = new LocationPage(page);
   await expect(locationPage.addressHeading).toBeVisible();
 });
 


### PR DESCRIPTION
## Description
- Verifies page headings are visible
- Verifies input fields in address form are visible
- Corrects Prettier extra line error in `playwright.config.ts`

## Motivation and Context
A user must enter their address on this page before they can proceed in the application.

Tests to write for the LCA address page (/library-card/location) as described in [SWIS-42](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-42):
- [x] Verify Step 2 heading and its corresponding sub-text displays
- [x] Verify Home Address heading and its corresponding sub-text displays
- [x] Verify Street Address (required) displays
- [x] Verify Apartment/Suite displays
- [x] Verify City (required) displays
- [x] Verify State (required) displays and its corresponding sub-text displays
- [x] Verify Postal Code (required) displays and its corresponding sub-text displays 
- [x] Verify Previous button displays
- [x] Verify Next button displays 


## How Has This Been Tested?
Run `npm run playwright -- location.spec.ts`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.


[SWIS-42]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ