### PR TITLE
Address verification retest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add Playwright tests to confirm elements on account page [SWIS-69](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-69)
 - Add Playwright tests to confirm invalid value errors on address page [SWIS-63](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-63)
+- Add Playwright test to confirm address verification page [SWIS-54] (https://newyorkpubliclibrary.atlassian.net/browse/SWIS-54)
 
 ### 1.2.6
 

--- a/playwright/pageobjects/address-verification.page.ts
+++ b/playwright/pageobjects/address-verification.page.ts
@@ -1,0 +1,33 @@
+import { Page, Locator } from "@playwright/test";
+
+export class AddressVerificationPage {
+  readonly page: Page;
+  readonly mainHeader: Locator;
+  readonly subHeader: Locator;
+  readonly homeAddressHeader: Locator;
+  readonly verifyRadioButton: Locator;
+  readonly nextButton: Locator;
+  readonly previousButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.mainHeader = this.page.getByRole("heading", {
+      name: "Apply for a Library Card Online",
+    });
+    this.subHeader = this.page.getByRole("heading", {
+      name: "Step 3 of 5: Address Verification",
+    });
+    this.homeAddressHeader = this.page.getByRole("heading", {
+      name: "Home Address",
+    });
+
+    this.verifyRadioButton = page.locator(
+      'span.radio-input[aria-hidden="true"]'
+    );
+    this.previousButton = this.page.getByRole("link", { name: "Previous" });
+    this.nextButton = this.page.getByRole("button", {
+      name: "Next",
+      exact: true,
+    });
+  }
+}

--- a/playwright/tests/address-verification.spec.ts
+++ b/playwright/tests/address-verification.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { AddressVerificationPage } from "../pageobjects/address-verification.page";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/library-card/address-verification?&newCard=true");
+});
+
+test("should display the correct headers", async ({ page }) => {
+  const addressVerificationPage = new AddressVerificationPage(page);
+  await expect(addressVerificationPage.mainHeader).toBeVisible();
+  await expect(addressVerificationPage.subHeader).toBeVisible();
+  await expect(addressVerificationPage.homeAddressHeader).toBeVisible();
+});
+
+test("should allow user to verify address", async ({ page }) => {
+  const addressVerificationPage = new AddressVerificationPage(page);
+  await expect(addressVerificationPage.previousButton).toBeVisible();
+  await expect(addressVerificationPage.nextButton).toBeVisible();
+});


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add tests for the Address Verification. Only verifying the headings, buttons for now.

This is a new branch for already approved work. There were a couple of issues with prettier and some reversions that made me close the other branch https://github.com/NYPL/nypl-library-card-app/tree/address-verification-test

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
npm run playwright address-verification.spec.ts  
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
