### PR TITLE
Use older aws action

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: "package-lock.json"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::946183545209:role/GithubActionsDeployerRole
           aws-region: us-east-1

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: "package-lock.json"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::946183545209:role/GithubActionsDeployerRole
           aws-region: us-east-1


### PR DESCRIPTION
`aws-actions/configure-aws-credentials@v4` requires a different setup than `v2`. The old deploy job used `v2`, so we'll replicate that for now and see what v4 requirements we need later. 