### PR TITLE
SWIS-78: location and work page Design System upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add Playwright tests to confirm elements on account page [SWIS-69](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-69)
 - `new` page Design system upgrade [SWIS-79](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-79)
+- `location` and `workAddress` page Design system upgrade [SWIS-78](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-78)
 
 ### 1.2.6
 

--- a/pages/location/index.tsx
+++ b/pages/location/index.tsx
@@ -16,6 +16,7 @@ import {
   generateNewCookieTokenAndHash,
 } from "../../src/utils/csrfUtils";
 import * as cookie from "../../src/utils/CookieUtils";
+import { Paragraph } from "../../src/components/Paragraph";
 
 interface PageProps {
   location: string;
@@ -44,8 +45,8 @@ function AddressPage({
   });
   return (
     <>
-      <Heading level="two">{t("location.title")}</Heading>
-      <p>{t("internationalInstructions")}</p>
+      <Heading level="h2">{t("location.title")}</Heading>
+      <Paragraph>{t("internationalInstructions")}</Paragraph>
       <AddressContainer csrfToken={csrfToken} />
     </>
   );

--- a/pages/workAddress/index.tsx
+++ b/pages/workAddress/index.tsx
@@ -15,6 +15,7 @@ import {
   generateNewToken,
 } from "../../src/utils/csrfUtils";
 import * as cookie from "../../src/utils/CookieUtils";
+import { Paragraph } from "../../src/components/Paragraph";
 interface WorkAddressPageProps {
   hasUserAlreadyRegistered?: boolean;
   csrfToken: string;
@@ -31,9 +32,9 @@ function WorkAddressPage({
   });
   return (
     <>
-      <Heading level="two">{t("location.workAddress.title")}</Heading>
-      <p>{t("location.workAddress.description.part1")}</p>
-      <p>{t("internationalInstructions")}</p>
+      <Heading level="h2">{t("location.workAddress.title")}</Heading>
+      <Paragraph>{t("location.workAddress.description.part1")}</Paragraph>
+      <Paragraph>{t("internationalInstructions")}</Paragraph>
       <WorkAddressContainer csrfToken={csrfToken} />
     </>
   );

--- a/src/components/AddressContainer/index.tsx
+++ b/src/components/AddressContainer/index.tsx
@@ -26,6 +26,7 @@ import { nyCounties, nyCities, createQueryParams } from "../../utils/utils";
 import useFormDataContext from "../../context/FormDataContext";
 import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
 import { NRError } from "../../logger/newrelic";
+import { Paragraph } from "../Paragraph";
 
 const AddressContainer = ({ csrfToken }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -145,8 +146,8 @@ const AddressContainer = ({ csrfToken }) => {
 
   return (
     <>
-      <Heading level="three">{t("location.address.title")}</Heading>
-      <p>{t("location.address.description")}</p>
+      <Heading level="h3">{t("location.address.title")}</Heading>
+      <Paragraph>{t("location.address.description")}</Paragraph>
 
       <Loader isLoading={isLoading} />
 

--- a/src/components/RoutingLinks.tsx/index.tsx
+++ b/src/components/RoutingLinks.tsx/index.tsx
@@ -45,7 +45,8 @@ function RoutingLinks({
           id="routing-links-previous"
           variant="buttonSecondary"
           borderColor="ui.gray.medium"
-          color="black"
+          _visited={{ color: "ui.gray.dark" }}
+          _hover={{ color: "ui.gray.dark" }}
         >
           {previousText}
         </DSLink>

--- a/src/components/WorkAddressContainer/index.tsx
+++ b/src/components/WorkAddressContainer/index.tsx
@@ -25,6 +25,7 @@ import useFormDataContext from "../../context/FormDataContext";
 import { createQueryParams } from "../../utils/utils";
 import { useTranslation } from "next-i18next";
 import { commonAPIErrors } from "../../data/apiErrorMessageTranslations";
+import { Paragraph } from "../Paragraph";
 
 const AddressContainer = ({ csrfToken }) => {
   const [isLoading, setIsLoading] = useState(false);
@@ -124,8 +125,10 @@ const AddressContainer = ({ csrfToken }) => {
 
   return (
     <>
-      <Heading level="three">{t("location.workAddress.title")}</Heading>
-      <p>{t("location.workAddress.description.part2")}</p>
+      <Heading mb="s" level="h3">
+        {t("location.workAddress.title")}
+      </Heading>
+      <Paragraph>{t("location.workAddress.description.part2")}</Paragraph>
 
       <Loader isLoading={isLoading} />
 


### PR DESCRIPTION
## Description

Updates the `location` and `workdAddress` page components

Tickets:

- [SWIS-78](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-78)

## Motivation and Context

Upgrade Design System from v1 to v4

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Run `npm run dev` locally and visit `http://localhost:3000/library-card/location?&newCard=true` and `http://localhost:3000/library-card/workAddress?&newCard=true`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
