### PR TITLE
[NO-REF] Add qa tag workflow

### DIFF
--- a/.github/workflows/tag-qa.yml
+++ b/.github/workflows/tag-qa.yml
@@ -13,8 +13,6 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Create QA tag
-        env:
-          TAG: qa-${{ github.sha::7 }}
         run: |
-          git tag "${TAG}"
-          git push origin "${TAG}"
+          git tag "qa-${GITHUB_SHA:0:8}"
+          git push origin "qa-${GITHUB_SHA:0:8}"

--- a/.github/workflows/tag-qa.yml
+++ b/.github/workflows/tag-qa.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Create QA tag
         env:
-          TAG: qa-${{ github.sha }}
+          TAG: qa-${{ github.sha::7 }}
         run: |
-          git tag "${TAG:0:11}"
-          git push origin "${TAG:0:11}"
+          git tag "${TAG}"
+          git push origin "${TAG}"

--- a/.github/workflows/tag-qa.yml
+++ b/.github/workflows/tag-qa.yml
@@ -1,0 +1,20 @@
+name: Create QA Tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  tag-qa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Create QA tag
+        env:
+          TAG: qa-${{ github.sha }}
+        run: |
+          git tag "${TAG:0:11}"
+          git push origin "${TAG:0:11}"

--- a/README.md
+++ b/README.md
@@ -106,24 +106,23 @@ Deployments are triggered by creating and pushing tags with specific naming conv
 
 #### Deploy to QA Environment
 
+A QA compatible tag can be created by manually triggering the `tag-qa` workflow from the project's [Github actions dashboard](https://github.com/NYPL/nypl-library-card-app/actions/workflows/tag-qa.yml).
+
+Alternatively, tags can be created manually from any branch, and must be of this format: `qa-*`
+
 ```bash
-git tag qa-v1.2.3
-git push origin qa-v1.2.3
+git tag qa-123abc456
+git push origin qa-123abc456
 ```
 
 #### Deploy to Production Environment
 
-This tag should be created from a release branch, and only after QA validation is complete.
+This tag should be created from a release branch, and only after QA validation is complete, and must be in the form of `production-*`
 
 ```bash
 git tag production-v1.2.3
 git push origin production-v1.2.3
 ```
-
-### Tag Naming Convention
-
-- **QA tags**: `qa-v1.2.3`, `qa-v1.2.3-hotfix`, `qa-v1.2.4-rc1`
-- **Production tags**: `production-v1.2.3`, `production-v1.2.3-hotfix`
 
 ## CI/CD
 
@@ -135,6 +134,7 @@ Our CI/CD pipeline uses GitHub Actions with multiple specialized workflows to en
 | ------------------------ | -------------------------------- | -------------------------------------------- |
 | **Unit Tests**           | Unit tests and linting           | PRs, pushes to `main`, called by deployments |
 | **Playwright Tests**     | End-to-end browser testing       | PRs, pushes to `main`, called by deployments |
+| **Tag QA**               | Tags a branch with `qa-*`        | Manual                                       |
 | **Deploy to QA**         | Deploy to QA environment         | `qa-*` tags                                  |
 | **Deploy to Production** | Deploy to production environment | `production-*` tags                          |
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: "./playwright",
   timeout: 30000, // default timeout for each test
   expect: {
-    timeout: 5000, // default timeout for expect statements
+    timeout: 15000, // default timeout for expect statements
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: "./playwright",
   timeout: 30000, // default timeout for each test
   expect: {
-    timeout: 15000, // default timeout for expect statements
+    timeout: 5000, // default timeout for expect statements
   },
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
## Description

Adds a workflow (triggered manually) that tags a given branch with `qa-{commit-hash}`. The creation of this tag will then trigger the qa-deploy workflow and deploy that branch to the QA environment. 

## How Has This Been Tested?

Will be tested once this is merged to `main`

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
