### PR TITLE
SWIS-420: Patron name cutoff at 400 percent zoom level

### DIFF
--- a/src/components/ConfirmationGraphic/index.tsx
+++ b/src/components/ConfirmationGraphic/index.tsx
@@ -48,7 +48,9 @@ const styles = {
   },
   memberName: {
     color: "white",
-    fontSize: "clamp(0.8rem, 0.8rem + 0.4vw, 1.2rem)",
+    fontSize: "clamp(0.8rem, 0.8rem + 0.4vw, 1rem)",
+    lineHeight: 1.1,
+    gridColumn: "span 2",
   },
   logoItem: {
     color: "white",
@@ -118,7 +120,7 @@ const ConfirmationContainer = () => {
   }, [canvas]);
 
   return (
-    <Box sx={styles.outerBox}>
+    <Box className="card-container" sx={styles.outerBox}>
       <Box className="image-lion" sx={styles.imageLion}>
         <Image
           alt="NYPL Library Barcode Background"
@@ -127,10 +129,13 @@ const ConfirmationContainer = () => {
           width="939"
         />
         <Grid className="background-lion" sx={styles.backgroundLion}>
-          <GridItem id="member-name" sx={styles.memberName}>
-            {t("confirmation.graphic.memberName")}
-            <Box className="content" fontSize="1.6em">
-              {name}
+          <GridItem id="issued" sx={styles.issuedText}>
+            {t("confirmation.graphic.issued")}
+            <Box
+              className="content"
+              fontSize={"clamp(1rem, 1rem + 0.2vw, 1.6rem)"}
+            >
+              {new Date().toLocaleDateString()}
             </Box>
           </GridItem>
           <GridItem sx={styles.logoItem}>
@@ -149,13 +154,10 @@ const ConfirmationContainer = () => {
               {barcode}
             </Box>
           </Box>
-          <GridItem id="issued" sx={styles.issuedText}>
-            {t("confirmation.graphic.issued")}
-            <Box
-              className="content"
-              fontSize={"clamp(1rem, 1rem + 0.2vw, 1.6rem)"}
-            >
-              {new Date().toLocaleDateString()}
+          <GridItem id="member-name" sx={styles.memberName}>
+            {t("confirmation.graphic.memberName")}
+            <Box className="content" fontSize="1.6em">
+              {name}
             </Box>
           </GridItem>
         </Grid>

--- a/src/components/ConfirmationGraphic/index.tsx
+++ b/src/components/ConfirmationGraphic/index.tsx
@@ -42,7 +42,7 @@ const styles = {
     p: "0 2em 0 1.25em",
     gap: "0.5em 0.25em",
     gridTemplateColumns: "58% 30%",
-    gridTemplateRows: "20% 40% 20%",
+    gridTemplateRows: "20% 40% 14%",
     justifyContent: "center",
     alignItems: "center",
   },
@@ -50,7 +50,7 @@ const styles = {
     color: "white",
     fontSize: "clamp(0.8rem, 0.8rem + 0.4vw, 1rem)",
     lineHeight: 1.1,
-    gridColumn: "span 2",
+    gridColumn: "span 3",
   },
   logoItem: {
     color: "white",


### PR DESCRIPTION
## Description

This PR swaps the member name issued date so that there are more rooms for long names on small screens.

Tickets:

- [SWIS-420](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-420)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Approved by Clare and Lucia/Nicole

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[SWIS-420]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ