### PR TITLE
Add nr browser script to Vercel

### DIFF
--- a/.github/workflows/accessibility-tests.yml
+++ b/.github/workflows/accessibility-tests.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
+      - name: Output process.platform for debugging
+        run: node -e "console.log('process.platform=', process.platform)"
 
       - name: Run Accessibility tests
         run: npx playwright test playwright/tests/accessibility-tests/

--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
+      - name: Output process.platform for debugging
+        run: node -e "console.log('process.platform=', process.platform)"
+
       - name: Run Playwright tests
         run: npx playwright test
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -13,6 +13,7 @@ import Script from "next/script";
 
 type DocumentProps = {
   browserTimingHeader: string;
+  isVercel: boolean;
 };
 /**
  * MyDocument
@@ -25,6 +26,7 @@ class MyDocument extends Document<DocumentProps> {
     ctx: DocumentContext
   ): Promise<DocumentInitialProps & DocumentProps> {
     const initialProps = await Document.getInitialProps(ctx);
+    const isVercel = process.env.NEXT_PUBLIC_VERCEL_BUILD === "1";
 
     const browserTimingHeader = newrelic.getBrowserTimingHeader({
       hasToRemoveScriptWrapper: true,
@@ -34,11 +36,12 @@ class MyDocument extends Document<DocumentProps> {
     return {
       ...initialProps,
       browserTimingHeader,
+      isVercel,
     };
   }
 
   render() {
-    const { browserTimingHeader } = this.props;
+    const { browserTimingHeader, isVercel } = this.props;
     return (
       <Html lang="en">
         <Head />
@@ -64,6 +67,16 @@ class MyDocument extends Document<DocumentProps> {
           <script src="https://cdn.optimizely.com/js/284748925.js"></script>
           {/* <!-- OptinMonster --> */}
           <script src="https://assets.nypl.org/js/advocacy.js"></script>
+          {/* 
+              Vercel serverless environment prevents us from generating the 
+              browser header from the agent, so we are injecting the QA instance manually 
+          */}
+          {isVercel && (
+            <script
+              type="text/javascript"
+              src="/library-card/js/new-relic-browser.js"
+            />
+          )}
           {/* New Relic Browser Metric */}
           <Script
             dangerouslySetInnerHTML={{ __html: browserTimingHeader }}

--- a/playwright/tests/accessibility-tests/account-a11y.spec.ts
+++ b/playwright/tests/accessibility-tests/account-a11y.spec.ts
@@ -5,8 +5,9 @@ import { PAGE_ROUTES } from "../../utils/constants";
 import { A11Y_GUIDELINES, validateA11yCoverage } from "../../utils/a11y-utils";
 
 test.describe("Account Page Accessibility Tests", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     await page.goto(PAGE_ROUTES.ACCOUNT);
+    console.log({ browserName, platform: process.platform });
   });
 
   test("should have no accessibility violations on load", async ({ page }) => {

--- a/public/js/new-relic-browser.js
+++ b/public/js/new-relic-browser.js
@@ -1,0 +1,4149 @@
+window.NREUM || (NREUM = {});
+NREUM.init = {
+  distributed_tracing: { enabled: true },
+  performance: { capture_measures: true },
+  browser_consent_mode: { enabled: false },
+  privacy: { cookies_enabled: true },
+  ajax: { capture_payloads: "none" },
+};
+
+NREUM.loader_config = {
+  accountID: "121334",
+  trustKey: "121334",
+  agentID: "1589118632",
+  licenseKey: "NRBR-652886ebb1f9416c1bb",
+  applicationID: "1519420078",
+};
+NREUM.info = {
+  beacon: "gov-bam.nr-data.net",
+  errorBeacon: "gov-bam.nr-data.net",
+  licenseKey: "NRBR-652886ebb1f9416c1bb",
+  applicationID: "1519420078",
+  sa: 1,
+}; /*! For license information please see nr-loader-spa-1.312.1.min.js.LICENSE.txt */
+(() => {
+  var e,
+    t,
+    r = {
+      384: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          NT: () => a,
+          Zm: () => c,
+          bQ: () => u,
+          dV: () => d,
+          pV: () => l,
+        });
+        var n = r(6154),
+          i = r(1863),
+          s = r(944),
+          o = r(1910);
+        const a = { beacon: "bam.nr-data.net", errorBeacon: "bam.nr-data.net" };
+        function c() {
+          return (
+            n.gm.NREUM || (n.gm.NREUM = {}),
+            void 0 === n.gm.newrelic && (n.gm.newrelic = n.gm.NREUM),
+            n.gm.NREUM
+          );
+        }
+        function d() {
+          let e = c();
+          return (
+            e.o ||
+              ((e.o = {
+                ST: n.gm.setTimeout,
+                SI: n.gm.setImmediate || n.gm.setInterval,
+                CT: n.gm.clearTimeout,
+                XHR: n.gm.XMLHttpRequest,
+                REQ: n.gm.Request,
+                EV: n.gm.Event,
+                PR: n.gm.Promise,
+                MO: n.gm.MutationObserver,
+                FETCH: n.gm.fetch,
+                WS: n.gm.WebSocket,
+              }),
+              (0, o.i)(...Object.values(e.o))),
+            e
+          );
+        }
+        function u(e, t) {
+          let r = c();
+          ((r.initializedAgents ??= {}),
+            (t.initializedAt = { ms: (0, i.t)(), date: new Date() }),
+            (r.initializedAgents[e] = t),
+            2 === Object.keys(r.initializedAgents).length && (0, s.R)(69));
+        }
+        function l() {
+          return (
+            (function () {
+              let e = c();
+              const t = e.info || {};
+              e.info = { beacon: a.beacon, errorBeacon: a.errorBeacon, ...t };
+            })(),
+            (function () {
+              let e = c();
+              const t = e.init || {};
+              e.init = { ...t };
+            })(),
+            d(),
+            (function () {
+              let e = c();
+              const t = e.loader_config || {};
+              e.loader_config = { ...t };
+            })(),
+            c()
+          );
+        }
+      },
+      782: (e, t, r) => {
+        "use strict";
+        r.d(t, { T: () => n });
+        const n = r(860).K7.pageViewTiming;
+      },
+      860: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          $J: () => u,
+          K7: () => c,
+          P3: () => d,
+          XX: () => i,
+          Yy: () => a,
+          df: () => s,
+          qY: () => n,
+          v4: () => o,
+        });
+        const n = "events",
+          i = "jserrors",
+          s = "browser/blobs",
+          o = "rum",
+          a = "browser/logs",
+          c = {
+            ajax: "ajax",
+            genericEvents: "generic_events",
+            jserrors: i,
+            logging: "logging",
+            metrics: "metrics",
+            pageAction: "page_action",
+            pageViewEvent: "page_view_event",
+            pageViewTiming: "page_view_timing",
+            sessionReplay: "session_replay",
+            sessionTrace: "session_trace",
+            softNav: "soft_navigations",
+          },
+          d = {
+            [c.pageViewEvent]: 1,
+            [c.pageViewTiming]: 2,
+            [c.metrics]: 3,
+            [c.jserrors]: 4,
+            [c.softNav]: 5,
+            [c.ajax]: 6,
+            [c.sessionTrace]: 7,
+            [c.sessionReplay]: 8,
+            [c.logging]: 9,
+            [c.genericEvents]: 10,
+          },
+          u = {
+            [c.pageViewEvent]: o,
+            [c.pageViewTiming]: n,
+            [c.ajax]: n,
+            [c.softNav]: n,
+            [c.metrics]: i,
+            [c.jserrors]: i,
+            [c.sessionTrace]: s,
+            [c.sessionReplay]: s,
+            [c.logging]: a,
+            [c.genericEvents]: "ins",
+          };
+      },
+      944: (e, t, r) => {
+        "use strict";
+        r.d(t, { R: () => i });
+        var n = r(3241);
+        function i(e, t) {
+          "function" == typeof console.debug &&
+            (console.debug(
+              "New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#".concat(
+                e
+              ),
+              t
+            ),
+            (0, n.W)({
+              drained: null,
+              type: "data",
+              name: "warn",
+              feature: "warn",
+              data: { code: e, secondary: t },
+            }));
+        }
+      },
+      993: (e, t, r) => {
+        "use strict";
+        r.d(t, { A$: () => s, ET: () => o, TZ: () => a, p_: () => i });
+        var n = r(860);
+        const i = {
+            ERROR: "ERROR",
+            WARN: "WARN",
+            INFO: "INFO",
+            DEBUG: "DEBUG",
+            TRACE: "TRACE",
+          },
+          s = { OFF: 0, ERROR: 1, WARN: 2, INFO: 3, DEBUG: 4, TRACE: 5 },
+          o = "log",
+          a = n.K7.logging;
+      },
+      1541: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          $5: () => d,
+          B5: () => c,
+          Ux: () => o,
+          YA: () => a,
+          fQ: () => i,
+        });
+        var n = r(5871);
+        const i = { MFE: "MFE", BA: "BA" };
+        function s(e, t) {
+          if (!e || !t?.init.api.allow_registered_children) return [];
+          const r = t.runtime.registeredEntities;
+          return (
+            r
+              ?.filter((t) => t.metadata.timings?.asset?.endsWith(e))
+              .map((e) => e.metadata.target) || []
+          );
+        }
+        function o(e, t) {
+          if (!u(t)) return {};
+          const r = t.agentRef.runtime.appMetadata.agents[0].entityGuid;
+          return e
+            ? e.attributes
+            : { "entity.guid": r, appId: t.agentRef.info.applicationID };
+        }
+        function a(e, t) {
+          return c(e, t)
+            ? { "child.id": e.id, "child.type": e.type, ...o(void 0, t) }
+            : {};
+        }
+        function c(e, t) {
+          return !!e && !!u(t) && t.agentRef.init.api.duplicate_registered_data;
+        }
+        function d(e) {
+          if (!e?.init.api.allow_registered_children) return [void 0];
+          const t = [];
+          try {
+            var r = (0, n.AZ)((0, n.QL)());
+            let i = r.length - 1;
+            for (; r[i]; ) t.push(...s(r[i--], e));
+          } catch (e) {}
+          return (t.length || t.push(void 0), t);
+        }
+        function u(e) {
+          return 2 === e?.harvestEndpointVersion;
+        }
+      },
+      1687: (e, t, r) => {
+        "use strict";
+        r.d(t, { Ak: () => a, Ze: () => d, x3: () => c });
+        var n = r(3241),
+          i = r(3606),
+          s = r(860),
+          o = r(2646);
+        function a(e, t) {
+          if (!e) return;
+          const r = { staged: !1, priority: s.P3[t] || 0 };
+          e.runtime.drainRegistry.get(t) || e.runtime.drainRegistry.set(t, r);
+        }
+        function c(e, t) {
+          if (!e) return;
+          const r = e.runtime.drainRegistry;
+          r && (r.get(t) && r.delete(t), l(e, t, !1), r.size && u(e));
+        }
+        function d(e, t = "feature", r = !1) {
+          if (e) {
+            if (!e.runtime.drainRegistry.get(t) || r) return l(e, t);
+            ((e.runtime.drainRegistry.get(t).staged = !0), u(e));
+          }
+        }
+        function u(e) {
+          if (!e) return;
+          const t = Array.from(e.runtime.drainRegistry);
+          t.every(([e, t]) => t.staged) &&
+            (t.sort((e, t) => e[1].priority - t[1].priority),
+            t.forEach(([t]) => {
+              (e.runtime.drainRegistry.delete(t), l(e, t));
+            }));
+        }
+        function l(e, t, r = !0) {
+          if (!e) return;
+          const s = e.ee,
+            a = i.i.handlers;
+          if (s && !s.aborted && s.backlog && a) {
+            if (
+              ((0, n.W)({ type: "lifecycle", name: "drain", feature: t }), r)
+            ) {
+              const e = s.backlog[t],
+                r = a[t];
+              if (r) {
+                for (let t = 0; e && t < e.length; ++t) f(e[t], r);
+                Object.entries(r).forEach(([e, t]) => {
+                  Object.values(t || {}).forEach((t) => {
+                    t[0]?.on &&
+                      t[0].context() instanceof o.y &&
+                      !t[0].listeners(e).includes(t[1]) &&
+                      t[0].on(e, t[1]);
+                  });
+                });
+              }
+            }
+            (s.isolatedBacklog || delete a[t],
+              (s.backlog[t] = null),
+              s.emit("drain-" + t, []));
+          }
+        }
+        function f(e, t) {
+          var r = e[1];
+          Object.values(t[r] || {}).forEach((t) => {
+            var r = e[0];
+            if (t[0] === r) {
+              var n = t[1],
+                i = e[3],
+                s = e[2];
+              n.apply(i, s);
+            }
+          });
+        }
+      },
+      1738: (e, t, r) => {
+        "use strict";
+        r.d(t, { U: () => f, Y: () => l });
+        var n = r(3241),
+          i = r(9908),
+          s = r(1863),
+          o = r(944),
+          a = r(3969),
+          c = r(8362),
+          d = r(860),
+          u = r(4261);
+        function l(e, t, r, s) {
+          const l = s || r;
+          !l ||
+            (l[e] && l[e] !== c.d.prototype[e]) ||
+            (l[e] = function () {
+              ((0, i.p)(
+                a.xV,
+                ["API/" + e + "/called"],
+                void 0,
+                d.K7.metrics,
+                r.ee
+              ),
+                (0, n.W)({
+                  drained: !!r.runtime?.activatedFeatures,
+                  type: "data",
+                  name: "api",
+                  feature: u.Pl + e,
+                  data: {},
+                }));
+              try {
+                return t.apply(this, arguments);
+              } catch (e) {
+                (0, o.R)(23, e);
+              }
+            });
+        }
+        function f(e, t, r, n, o) {
+          const a = e.info;
+          (null === r ? delete a.jsAttributes[t] : (a.jsAttributes[t] = r),
+            (o || null === r) &&
+              (0, i.p)(u.Pl + n, [(0, s.t)(), t, r], void 0, "session", e.ee));
+        }
+      },
+      1741: (e, t, r) => {
+        "use strict";
+        r.d(t, { W: () => s });
+        var n = r(944),
+          i = r(4261);
+        class s {
+          #e(e, ...t) {
+            if (this[e] !== s.prototype[e]) return this[e](...t);
+            (0, n.R)(35, e);
+          }
+          addPageAction(e, t) {
+            return this.#e(i.hG, e, t);
+          }
+          register(e) {
+            return this.#e(i.eY, e);
+          }
+          recordCustomEvent(e, t) {
+            return this.#e(i.fF, e, t);
+          }
+          setPageViewName(e, t) {
+            return this.#e(i.Fw, e, t);
+          }
+          setCustomAttribute(e, t, r) {
+            return this.#e(i.cD, e, t, r);
+          }
+          noticeError(e, t) {
+            return this.#e(i.o5, e, t);
+          }
+          setUserId(e, t = !1) {
+            return this.#e(i.Dl, e, t);
+          }
+          setApplicationVersion(e) {
+            return this.#e(i.nb, e);
+          }
+          setErrorHandler(e) {
+            return this.#e(i.bt, e);
+          }
+          addRelease(e, t) {
+            return this.#e(i.k6, e, t);
+          }
+          log(e, t) {
+            return this.#e(i.$9, e, t);
+          }
+          start() {
+            return this.#e(i.d3);
+          }
+          finished(e) {
+            return this.#e(i.BL, e);
+          }
+          recordReplay() {
+            return this.#e(i.CH);
+          }
+          pauseReplay() {
+            return this.#e(i.Tb);
+          }
+          addToTrace(e) {
+            return this.#e(i.U2, e);
+          }
+          setCurrentRouteName(e) {
+            return this.#e(i.PA, e);
+          }
+          interaction(e) {
+            return this.#e(i.dT, e);
+          }
+          wrapLogger(e, t, r) {
+            return this.#e(i.Wb, e, t, r);
+          }
+          measure(e, t) {
+            return this.#e(i.V1, e, t);
+          }
+          consent(e) {
+            return this.#e(i.Pv, e);
+          }
+        }
+      },
+      1863: (e, t, r) => {
+        "use strict";
+        function n() {
+          return Math.floor(performance.now());
+        }
+        r.d(t, { t: () => n });
+      },
+      1910: (e, t, r) => {
+        "use strict";
+        r.d(t, { i: () => s });
+        var n = r(944);
+        const i = new Map();
+        function s(...e) {
+          return e.every((e) => {
+            if (i.has(e)) return i.get(e);
+            const t = "function" == typeof e ? e.toString() : "",
+              r = t.includes("[native code]"),
+              s = t.includes("nrWrapper");
+            return (r || s || (0, n.R)(64, e?.name || t), i.set(e, r), r);
+          });
+        }
+      },
+      2555: (e, t, r) => {
+        "use strict";
+        r.d(t, { D: () => a, f: () => o });
+        var n = r(384),
+          i = r(8122);
+        const s = {
+          beacon: n.NT.beacon,
+          errorBeacon: n.NT.errorBeacon,
+          licenseKey: void 0,
+          applicationID: void 0,
+          sa: void 0,
+          queueTime: void 0,
+          applicationTime: void 0,
+          ttGuid: void 0,
+          user: void 0,
+          account: void 0,
+          product: void 0,
+          extra: void 0,
+          jsAttributes: {},
+          userAttributes: void 0,
+          atts: void 0,
+          transactionName: void 0,
+          tNamePlain: void 0,
+        };
+        function o(e) {
+          try {
+            return !!e.licenseKey && !!e.errorBeacon && !!e.applicationID;
+          } catch (e) {
+            return !1;
+          }
+        }
+        const a = (e) => (0, i.a)(e, s);
+      },
+      2614: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          BB: () => o,
+          H3: () => n,
+          g: () => d,
+          iL: () => c,
+          tS: () => a,
+          uh: () => i,
+          wk: () => s,
+        });
+        const n = "NRBA",
+          i = "SESSION",
+          s = 144e5,
+          o = 18e5,
+          a = {
+            STARTED: "session-started",
+            PAUSE: "session-pause",
+            RESET: "session-reset",
+            RESUME: "session-resume",
+            UPDATE: "session-update",
+          },
+          c = { SAME_TAB: "same-tab", CROSS_TAB: "cross-tab" },
+          d = { OFF: 0, FULL: 1, ERROR: 2 };
+      },
+      2646: (e, t, r) => {
+        "use strict";
+        r.d(t, { y: () => n });
+        class n {
+          constructor(e) {
+            this.contextId = e;
+          }
+        }
+      },
+      2843: (e, t, r) => {
+        "use strict";
+        r.d(t, { G: () => s, u: () => i });
+        var n = r(3878);
+        function i(e, t = !1, r, i) {
+          (0, n.DD)(
+            "visibilitychange",
+            function () {
+              if (t) return void ("hidden" === document.visibilityState && e());
+              e(document.visibilityState);
+            },
+            r,
+            i
+          );
+        }
+        function s(e, t, r) {
+          (0, n.sp)("pagehide", e, t, r);
+        }
+      },
+      3241: (e, t, r) => {
+        "use strict";
+        r.d(t, { W: () => s });
+        var n = r(6154);
+        const i = "newrelic";
+        function s(e = {}) {
+          try {
+            n.gm.dispatchEvent(new CustomEvent(i, { detail: e }));
+          } catch (e) {}
+        }
+      },
+      3304: (e, t, r) => {
+        "use strict";
+        r.d(t, { A: () => s });
+        var n = r(7836);
+        const i = () => {
+          const e = new WeakSet();
+          return (t, r) => {
+            if ("object" == typeof r && null !== r) {
+              if (e.has(r)) return;
+              e.add(r);
+            }
+            return r;
+          };
+        };
+        function s(e) {
+          try {
+            return JSON.stringify(e, i()) ?? "";
+          } catch (e) {
+            try {
+              n.ee.emit("internal-error", [e]);
+            } catch (e) {}
+            return "";
+          }
+        }
+      },
+      3333: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          $v: () => u,
+          TZ: () => n,
+          Xh: () => c,
+          Zp: () => i,
+          kd: () => d,
+          mq: () => a,
+          nf: () => o,
+          qN: () => s,
+        });
+        const n = r(860).K7.genericEvents,
+          i = ["auxclick", "click", "copy", "keydown", "paste", "scrollend"],
+          s = ["focus", "blur"],
+          o = 4,
+          a = 1e3,
+          c = 2e3,
+          d = ["PageAction", "UserAction", "BrowserPerformance"],
+          u = { RESOURCES: "experimental.resources", REGISTER: "register" };
+      },
+      3434: (e, t, r) => {
+        "use strict";
+        r.d(t, { Jt: () => o, YM: () => u });
+        var n = r(7836),
+          i = r(5607),
+          s = r(1541);
+        const o = "nr@original:".concat(i.W),
+          a = 50;
+        var c = Object.prototype.hasOwnProperty,
+          d = !1;
+        function u(e, t, r) {
+          return (
+            e || (e = n.ee),
+            (i.inPlace = function (e, t, r, n, s, o) {
+              r || (r = "");
+              const a = "-" === r.charAt(0);
+              for (let c = 0; c < t.length; c++) {
+                const d = t[c],
+                  u = e[d];
+                f(u) || (e[d] = i(u, a ? d + r : r, n, d, s, o));
+              }
+            }),
+            (i.flag = o),
+            i
+          );
+          function i(t, n, i, d, h, p) {
+            return f(t)
+              ? t
+              : (n || (n = ""),
+                (nrWrapper[o] = t),
+                (function (e, t, r) {
+                  if (Object.defineProperty && Object.keys)
+                    try {
+                      return (
+                        Object.keys(e).forEach(function (r) {
+                          Object.defineProperty(t, r, {
+                            get: function () {
+                              return e[r];
+                            },
+                            set: function (t) {
+                              return ((e[r] = t), t);
+                            },
+                          });
+                        }),
+                        t
+                      );
+                    } catch (e) {
+                      l([e], r);
+                    }
+                  for (var n in e) c.call(e, n) && (t[n] = e[n]);
+                })(t, nrWrapper, e),
+                nrWrapper);
+            function nrWrapper() {
+              var o, c, f, g;
+              let m, v;
+              try {
+                ((c = this),
+                  (o = [...arguments]),
+                  (v = p ? (0, s.$5)(r) : [void 0]),
+                  (f = "function" == typeof i ? i(o, c) : i || {}));
+              } catch (t) {
+                l([t, "", [o, c, d], f], e);
+              }
+              u(n + "start", [o, c, d, v], f, h);
+              const y = performance.now();
+              let b;
+              try {
+                return ((g = t.apply(c, o)), (b = performance.now()), g);
+              } catch (e) {
+                throw (
+                  (b = performance.now()),
+                  u(n + "err", [o, c, e, v], f, h),
+                  (m = e),
+                  m
+                );
+              } finally {
+                const e = b - y,
+                  t = {
+                    start: y,
+                    end: b,
+                    duration: e,
+                    isLongTask: e >= a,
+                    methodName: d,
+                    thrownError: m,
+                  };
+                (t.isLongTask && u("long-task", [t, c, v], f, h),
+                  u(n + "end", [o, c, g, v], f, h));
+              }
+            }
+          }
+          function u(r, n, i, s) {
+            if (!d || t) {
+              var o = d;
+              d = !0;
+              try {
+                e.emit(r, n, i, t, s);
+              } catch (t) {
+                l([t, r, n, i], e);
+              }
+              d = o;
+            }
+          }
+        }
+        function l(e, t) {
+          t || (t = n.ee);
+          try {
+            t.emit("internal-error", e);
+          } catch (e) {}
+        }
+        function f(e) {
+          return !(e && "function" == typeof e && e.apply && !e[o]);
+        }
+      },
+      3606: (e, t, r) => {
+        "use strict";
+        r.d(t, { i: () => s });
+        var n = r(9908);
+        s.on = o;
+        var i = (s.handlers = {});
+        function s(e, t, r, s) {
+          o(s || n.d, i, e, t, r);
+        }
+        function o(e, t, r, i, s) {
+          (s || (s = "feature"), e || (e = n.d));
+          var o = (t[s] = t[s] || {});
+          (o[r] = o[r] || []).push([e, i]);
+        }
+      },
+      3738: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          He: () => i,
+          Kp: () => a,
+          Lc: () => d,
+          Rz: () => u,
+          TZ: () => n,
+          bD: () => s,
+          d3: () => o,
+          jx: () => l,
+          sl: () => f,
+          uP: () => c,
+        });
+        const n = r(860).K7.sessionTrace,
+          i = "bstResource",
+          s = "resource",
+          o = "-start",
+          a = "-end",
+          c = "fn" + o,
+          d = "fn" + a,
+          u = "pushState",
+          l = 1e3,
+          f = 3e4;
+      },
+      3785: (e, t, r) => {
+        "use strict";
+        r.d(t, { R: () => c, b: () => d });
+        var n = r(9908),
+          i = r(1863),
+          s = r(860),
+          o = r(3969),
+          a = r(993);
+        function c(e, t, r = {}, c = a.p_.INFO, d = !0, u, l = (0, i.t)()) {
+          ((0, n.p)(
+            o.xV,
+            ["API/logging/".concat(c.toLowerCase(), "/called")],
+            void 0,
+            s.K7.metrics,
+            e
+          ),
+            (0, n.p)(a.ET, [l, t, r, c, d, u], void 0, s.K7.logging, e));
+        }
+        function d(e) {
+          return (
+            "string" == typeof e &&
+            Object.values(a.p_).some((t) => t === e.toUpperCase().trim())
+          );
+        }
+      },
+      3878: (e, t, r) => {
+        "use strict";
+        function n(e, t) {
+          return { capture: e, passive: !1, signal: t };
+        }
+        function i(e, t, r = !1, i) {
+          window.addEventListener(e, t, n(r, i));
+        }
+        function s(e, t, r = !1, i) {
+          document.addEventListener(e, t, n(r, i));
+        }
+        r.d(t, { DD: () => s, jT: () => n, sp: () => i });
+      },
+      3962: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          AM: () => o,
+          O2: () => l,
+          OV: () => s,
+          Qu: () => f,
+          TZ: () => c,
+          ih: () => h,
+          pP: () => a,
+          t1: () => u,
+          tC: () => i,
+          wD: () => d,
+        });
+        var n = r(860);
+        const i = ["click", "keydown", "submit"],
+          s = "popstate",
+          o = "api",
+          a = "initialPageLoad",
+          c = n.K7.softNav,
+          d = 5e3,
+          u = 500,
+          l = { INITIAL_PAGE_LOAD: "", ROUTE_CHANGE: 1, UNSPECIFIED: 2 },
+          f = { INTERACTION: 1, AJAX: 2, CUSTOM_END: 3, CUSTOM_TRACER: 4 },
+          h = {
+            IP: "in progress",
+            PF: "pending finish",
+            FIN: "finished",
+            CAN: "cancelled",
+          };
+      },
+      3969: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          TZ: () => n,
+          XG: () => a,
+          rs: () => i,
+          xV: () => o,
+          z_: () => s,
+        });
+        const n = r(860).K7.metrics,
+          i = "sm",
+          s = "cm",
+          o = "storeSupportabilityMetrics",
+          a = "storeEventMetrics";
+      },
+      4234: (e, t, r) => {
+        "use strict";
+        r.d(t, { W: () => i });
+        var n = r(1687);
+        class i {
+          constructor(e, t) {
+            ((this.agentRef = e),
+              (this.ee = e?.ee),
+              (this.featureName = t),
+              (this.blocked = !1));
+          }
+          deregisterDrain() {
+            (0, n.x3)(this.agentRef, this.featureName);
+          }
+        }
+      },
+      4261: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          $9: () => u,
+          BL: () => c,
+          CH: () => p,
+          Dl: () => R,
+          Fw: () => w,
+          PA: () => v,
+          Pl: () => n,
+          Pv: () => x,
+          Tb: () => f,
+          U2: () => o,
+          V1: () => A,
+          Wb: () => T,
+          bt: () => b,
+          cD: () => y,
+          d3: () => E,
+          dT: () => d,
+          eY: () => g,
+          fF: () => h,
+          hG: () => s,
+          hw: () => i,
+          k6: () => a,
+          nb: () => m,
+          o5: () => l,
+        });
+        const n = "api-",
+          i = n + "ixn-",
+          s = "addPageAction",
+          o = "addToTrace",
+          a = "addRelease",
+          c = "finished",
+          d = "interaction",
+          u = "log",
+          l = "noticeError",
+          f = "pauseReplay",
+          h = "recordCustomEvent",
+          p = "recordReplay",
+          g = "register",
+          m = "setApplicationVersion",
+          v = "setCurrentRouteName",
+          y = "setCustomAttribute",
+          b = "setErrorHandler",
+          w = "setPageViewName",
+          R = "setUserId",
+          E = "start",
+          T = "wrapLogger",
+          A = "measure",
+          x = "consent";
+      },
+      5205: (e, t, r) => {
+        "use strict";
+        r.d(t, { j: () => x });
+        var n = r(384),
+          i = r(1741);
+        var s = r(2555),
+          o = r(3333);
+        const a = (e) => {
+          if (!e || "string" != typeof e) return !1;
+          try {
+            document.createDocumentFragment().querySelector(e);
+          } catch {
+            return !1;
+          }
+          return !0;
+        };
+        var c = r(2614),
+          d = r(944),
+          u = r(8122);
+        const l = "[data-nr-mask]",
+          f = (e) =>
+            (0, u.a)(
+              e,
+              (() => {
+                const e = {
+                  feature_flags: [],
+                  experimental: {
+                    allow_registered_children: !1,
+                    resources: !1,
+                  },
+                  mask_selector: "*",
+                  block_selector: "[data-nr-block]",
+                  mask_input_options: {
+                    color: !1,
+                    date: !1,
+                    "datetime-local": !1,
+                    email: !1,
+                    month: !1,
+                    number: !1,
+                    range: !1,
+                    search: !1,
+                    tel: !1,
+                    text: !1,
+                    time: !1,
+                    url: !1,
+                    week: !1,
+                    textarea: !1,
+                    select: !1,
+                    password: !0,
+                  },
+                };
+                return {
+                  ajax: {
+                    deny_list: void 0,
+                    block_internal: !0,
+                    enabled: !0,
+                    autoStart: !0,
+                  },
+                  api: {
+                    get allow_registered_children() {
+                      return (
+                        e.feature_flags.includes(o.$v.REGISTER) ||
+                        e.experimental.allow_registered_children
+                      );
+                    },
+                    set allow_registered_children(t) {
+                      e.experimental.allow_registered_children = t;
+                    },
+                    duplicate_registered_data: !1,
+                  },
+                  browser_consent_mode: { enabled: !1 },
+                  distributed_tracing: {
+                    enabled: void 0,
+                    exclude_newrelic_header: void 0,
+                    cors_use_newrelic_header: void 0,
+                    cors_use_tracecontext_headers: void 0,
+                    allowed_origins: void 0,
+                  },
+                  get feature_flags() {
+                    return e.feature_flags;
+                  },
+                  set feature_flags(t) {
+                    e.feature_flags = t;
+                  },
+                  generic_events: { enabled: !0, autoStart: !0 },
+                  harvest: { interval: 30 },
+                  jserrors: { enabled: !0, autoStart: !0 },
+                  logging: { enabled: !0, autoStart: !0 },
+                  metrics: { enabled: !0, autoStart: !0 },
+                  obfuscate: void 0,
+                  page_action: { enabled: !0 },
+                  page_view_event: { enabled: !0, autoStart: !0 },
+                  page_view_timing: { enabled: !0, autoStart: !0 },
+                  performance: {
+                    capture_marks: !1,
+                    capture_measures: !1,
+                    capture_detail: !0,
+                    resources: {
+                      get enabled() {
+                        return (
+                          e.feature_flags.includes(o.$v.RESOURCES) ||
+                          e.experimental.resources
+                        );
+                      },
+                      set enabled(t) {
+                        e.experimental.resources = t;
+                      },
+                      asset_types: [],
+                      first_party_domains: [],
+                      ignore_newrelic: !0,
+                    },
+                  },
+                  privacy: { cookies_enabled: !0 },
+                  proxy: { assets: void 0, beacon: void 0 },
+                  session: { expiresMs: c.wk, inactiveMs: c.BB },
+                  session_replay: {
+                    autoStart: !0,
+                    enabled: !1,
+                    preload: !1,
+                    sampling_rate: 10,
+                    error_sampling_rate: 100,
+                    collect_fonts: !1,
+                    inline_images: !1,
+                    fix_stylesheets: !0,
+                    mask_all_inputs: !0,
+                    get mask_text_selector() {
+                      return e.mask_selector;
+                    },
+                    set mask_text_selector(t) {
+                      a(t)
+                        ? (e.mask_selector = "".concat(t, ",").concat(l))
+                        : "" === t || null === t
+                          ? (e.mask_selector = l)
+                          : (0, d.R)(5, t);
+                    },
+                    get block_class() {
+                      return "nr-block";
+                    },
+                    get ignore_class() {
+                      return "nr-ignore";
+                    },
+                    get mask_text_class() {
+                      return "nr-mask";
+                    },
+                    get block_selector() {
+                      return e.block_selector;
+                    },
+                    set block_selector(t) {
+                      a(t)
+                        ? (e.block_selector += ",".concat(t))
+                        : "" !== t && (0, d.R)(6, t);
+                    },
+                    get mask_input_options() {
+                      return e.mask_input_options;
+                    },
+                    set mask_input_options(t) {
+                      t && "object" == typeof t
+                        ? (e.mask_input_options = { ...t, password: !0 })
+                        : (0, d.R)(7, t);
+                    },
+                  },
+                  session_trace: { enabled: !0, autoStart: !0 },
+                  soft_navigations: { enabled: !0, autoStart: !0 },
+                  ssl: void 0,
+                  user_actions: {
+                    enabled: !0,
+                    elementAttributes: ["id", "className", "tagName", "type"],
+                  },
+                };
+              })()
+            );
+        var h = r(6154),
+          p = r(9324);
+        let g = 0;
+        const m = {
+            buildEnv: p.F3,
+            distMethod: p.Xs,
+            version: p.xv,
+            originTime: h.WN,
+          },
+          v = { consented: !1 },
+          y = {
+            activatedFeatures: void 0,
+            appMetadata: {},
+            configured: !1,
+            get consented() {
+              return this.session?.state?.consent || v.consented;
+            },
+            set consented(e) {
+              v.consented = e;
+            },
+            customTransaction: void 0,
+            denyList: [],
+            disabled: !1,
+            drainRegistry: new Map(),
+            harvester: void 0,
+            isolatedBacklog: !1,
+            isRecording: !1,
+            loaderType: void 0,
+            maxBytes: 3e4,
+            obfuscator: void 0,
+            onerror: void 0,
+            ptid: void 0,
+            releaseIds: {},
+            session: void 0,
+            timeKeeper: void 0,
+            registeredEntities: [],
+            jsAttributesMetadata: { bytes: 0 },
+            get harvestCount() {
+              return ++g;
+            },
+          },
+          b = (e) => {
+            const t = (0, u.a)(e, y),
+              r = Object.keys(m).reduce(
+                (e, t) => (
+                  (e[t] = {
+                    value: m[t],
+                    writable: !1,
+                    configurable: !0,
+                    enumerable: !0,
+                  }),
+                  e
+                ),
+                {}
+              );
+            return Object.defineProperties(t, r);
+          },
+          w = (e) => {
+            const t = e.startsWith("http");
+            ((e += "/"), (r.p = t ? e : "https://" + e));
+          };
+        var R = r(7836),
+          E = r(3241);
+        const T = {
+            accountID: void 0,
+            trustKey: void 0,
+            agentID: void 0,
+            licenseKey: void 0,
+            applicationID: void 0,
+            xpid: void 0,
+          },
+          A = (e) => (0, u.a)(e, T);
+        function x(e, t = {}, r, o) {
+          let {
+            init: a,
+            info: c,
+            loader_config: d,
+            runtime: u = {},
+            exposed: l = !0,
+          } = t;
+          if (!c) {
+            const e = (0, n.pV)();
+            ((a = e.init), (c = e.info), (d = e.loader_config));
+          }
+          ((e.init = f(a || {})),
+            (e.loader_config = A(d || {})),
+            (c.jsAttributes ??= {}),
+            h.bv && (c.jsAttributes.isWorker = !0),
+            (e.info = (0, s.D)(c)));
+          const p = e.init;
+          ((e.runtime ??= b(u)),
+            p.proxy.assets && w(p.proxy.assets),
+            e.runtime.configured ||
+              (Object.defineProperty(e, "beacons", {
+                get: () =>
+                  [
+                    e.info.beacon,
+                    e.info.errorBeacon,
+                    e.init.proxy.assets,
+                    e.init.proxy.beacon,
+                  ].filter(Boolean),
+              }),
+              Object.defineProperty(e.runtime, "denyList", {
+                get: () => [
+                  ...(e.init.ajax.deny_list || []),
+                  ...(e.init.ajax.block_internal ? e.beacons : []),
+                ],
+              }),
+              (e.runtime.ptid = e.agentIdentifier),
+              (function (e) {
+                const t = (0, n.pV)();
+                Object.getOwnPropertyNames(i.W.prototype).forEach((r) => {
+                  const n = i.W.prototype[r];
+                  if ("function" != typeof n || "constructor" === n) return;
+                  let s = t[r];
+                  e[r] &&
+                    !1 !== e.exposed &&
+                    "micro-agent" !== e.runtime?.loaderType &&
+                    (t[r] = (...t) => {
+                      const n = e[r](...t);
+                      return s ? s(...t) : n;
+                    });
+                });
+              })(e),
+              (e.runtime.loaderType = r),
+              (e.ee = R.ee.get(e.agentIdentifier)),
+              (e.exposed = l),
+              (0, E.W)({
+                drained: !!e.runtime.activatedFeatures,
+                type: "lifecycle",
+                name: "initialize",
+                feature: void 0,
+                data: e.config,
+              }),
+              (e.runtime.configured = !0)));
+        }
+      },
+      5270: (e, t, r) => {
+        "use strict";
+        r.d(t, { Aw: () => o, SR: () => s, rF: () => a });
+        var n = r(384),
+          i = r(7767);
+        function s(e) {
+          return (
+            !!(0, n.dV)().o.MO && (0, i.V)(e) && !0 === e?.session_trace.enabled
+          );
+        }
+        function o(e) {
+          return !0 === e?.session_replay.preload && s(e);
+        }
+        function a(e, t) {
+          try {
+            if ("string" == typeof t?.type) {
+              if ("password" === t.type.toLowerCase())
+                return "*".repeat(e?.length || 0);
+              if (
+                void 0 !== t?.dataset?.nrUnmask ||
+                t?.classList?.contains("nr-unmask")
+              )
+                return e;
+            }
+          } catch (e) {}
+          return "string" == typeof e
+            ? e.replace(/[\S]/g, "*")
+            : "*".repeat(e?.length || 0);
+        }
+      },
+      5289: (e, t, r) => {
+        "use strict";
+        r.d(t, { GG: () => o, Qr: () => c, sB: () => a });
+        var n = r(3878),
+          i = r(6389);
+        function s() {
+          return (
+            "undefined" == typeof document || "complete" === document.readyState
+          );
+        }
+        function o(e, t) {
+          if (s()) return e();
+          const r = (0, i.J)(e),
+            o = setInterval(() => {
+              s() && (clearInterval(o), r());
+            }, 500);
+          (0, n.sp)("load", r, t);
+        }
+        function a(e) {
+          if (s()) return e();
+          (0, n.DD)("DOMContentLoaded", e);
+        }
+        function c(e) {
+          if (s()) return e();
+          (0, n.sp)("popstate", e);
+        }
+      },
+      5607: (e, t, r) => {
+        "use strict";
+        r.d(t, { W: () => n });
+        const n = (0, r(9566).bz)();
+      },
+      5871: (e, t, r) => {
+        "use strict";
+        r.d(t, { AZ: () => u, QL: () => l, Qr: () => f });
+        var n = r(6154),
+          i = r(1863),
+          s = r(9119),
+          o = r(7866);
+        let a;
+        try {
+          a = u(l())[0];
+        } catch (e) {
+          a = u(e)[0];
+        }
+        const c = new Set();
+        let d = [];
+        if (
+          n.gm.PerformanceObserver?.supportedEntryTypes.includes("resource")
+        ) {
+          new PerformanceObserver((e) => {
+            e.getEntries().forEach((e) => {
+              if (
+                ((e) =>
+                  "script" === e.initiatorType ||
+                  (["link", "fetch"].includes(e.initiatorType) &&
+                    e.name.endsWith(".js")))(e)
+              ) {
+                (c.size > 250 && c.delete(c.values().next().value), c.add(e));
+                const t = [];
+                (d.forEach(({ test: r, addedAt: n }, s) => {
+                  (r(e) || (0, i.t)() - n > 1e4) && t.push(s);
+                }),
+                  (d = d.filter((e, r) => !t.includes(r))));
+              }
+            });
+          }).observe({ type: "resource", buffered: !0 });
+        }
+        function u(e) {
+          if (!e || "string" != typeof e) return [];
+          const t = new Set(),
+            r = e.split("\n");
+          for (const e of r) {
+            const r = e.match(o.cn) || e.match(o.hB) || e.match(o.fL);
+            if (r && r[2]) t.add((0, s.L)(r[2]));
+            else {
+              const r =
+                e.match(/\(([^)]+\.js):\d+:\d+\)/) ||
+                e.match(/^\s+at\s+([^\s(]+\.js):\d+:\d+/);
+              r && r[1] && t.add((0, s.L)(r[1]));
+            }
+          }
+          return [...t];
+        }
+        function l() {
+          let e;
+          try {
+            const t = Error.stackTraceLimit;
+            ((Error.stackTraceLimit = 50),
+              (e = new Error().stack),
+              (Error.stackTraceLimit = t));
+          } catch (t) {
+            e = new Error().stack;
+          }
+          return e;
+        }
+        function f() {
+          const e = {
+              registeredAt: (0, i.t)(),
+              reportedAt: void 0,
+              fetchStart: 0,
+              fetchEnd: 0,
+              asset: void 0,
+              type: "unknown",
+            },
+            t = l();
+          if (!t) return e;
+          const r =
+            n.gm.performance?.getEntriesByType("navigation")?.[0]?.name || "";
+          try {
+            const o = u(t),
+              f = (
+                o.length > 1
+                  ? o.filter((e) => !a.endsWith(e) && !e.endsWith(a))
+                  : o
+              )[0];
+            if (!f) return e;
+            if (r.includes(f))
+              return ((e.asset = (0, s.L)(r)), (e.type = "inline"), e);
+            const h =
+              performance.getEntriesByType("resource").find(p) ||
+              [...c].find(p);
+            function p(e) {
+              const t = (0, s.L)(e.name);
+              return t.endsWith(f) || f.endsWith(t);
+            }
+            function g(t) {
+              ((e.fetchStart = Math.floor(t.startTime)),
+                (e.fetchEnd = Math.floor(t.responseEnd)),
+                (e.asset = t.name),
+                (e.type = t.initiatorType));
+            }
+            h
+              ? g(h)
+              : (function (e) {
+                  if (!e || !n.gm.document) return !1;
+                  try {
+                    const t = n.gm.document.querySelectorAll(
+                      'link[rel="preload"][as="script"]'
+                    );
+                    for (const r of t) if ((0, s.L)(r.href) === e) return !0;
+                  } catch (e) {}
+                  return !1;
+                })(f) &&
+                ((e.asset = f),
+                (e.type = "preload"),
+                d.push({
+                  addedAt: (0, i.t)(),
+                  test: (e) => !!p(e) && (g(e), !0),
+                }));
+          } catch (m) {}
+          return e;
+        }
+      },
+      6154: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          OF: () => d,
+          RI: () => i,
+          WN: () => f,
+          bv: () => s,
+          gm: () => o,
+          lR: () => l,
+          m: () => c,
+          mw: () => a,
+          sb: () => u,
+          zk: () => h,
+        });
+        var n = r(1863);
+        const i = "undefined" != typeof window && !!window.document,
+          s =
+            "undefined" != typeof WorkerGlobalScope &&
+            (("undefined" != typeof self &&
+              self instanceof WorkerGlobalScope &&
+              self.navigator instanceof WorkerNavigator) ||
+              ("undefined" != typeof globalThis &&
+                globalThis instanceof WorkerGlobalScope &&
+                globalThis.navigator instanceof WorkerNavigator)),
+          o = i
+            ? window
+            : "undefined" != typeof WorkerGlobalScope &&
+              (("undefined" != typeof self &&
+                self instanceof WorkerGlobalScope &&
+                self) ||
+                ("undefined" != typeof globalThis &&
+                  globalThis instanceof WorkerGlobalScope &&
+                  globalThis)),
+          a = Boolean("hidden" === o?.document?.visibilityState),
+          c = "" + o?.location,
+          d = /iPad|iPhone|iPod/.test(o.navigator?.userAgent),
+          u = d && "undefined" == typeof SharedWorker,
+          l = (() => {
+            const e = o.navigator?.userAgent?.match(/Firefox[/\s](\d+\.\d+)/);
+            return Array.isArray(e) && e.length >= 2 ? +e[1] : 0;
+          })(),
+          f = Date.now() - (0, n.t)(),
+          h = () => {
+            const e = o?.performance?.getEntriesByType?.("navigation")?.[0];
+            if (
+              e &&
+              e.responseStart > 0 &&
+              e.responseStart < o.performance.now()
+            )
+              return e;
+          };
+      },
+      6344: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          BB: () => u,
+          Qb: () => l,
+          TZ: () => i,
+          Ug: () => o,
+          Vh: () => s,
+          _s: () => a,
+          bc: () => d,
+          yP: () => c,
+        });
+        var n = r(2614);
+        const i = r(860).K7.sessionReplay,
+          s = "errorDuringReplay",
+          o = 0.12,
+          a = {
+            DomContentLoaded: 0,
+            Load: 1,
+            FullSnapshot: 2,
+            IncrementalSnapshot: 3,
+            Meta: 4,
+            Custom: 5,
+          },
+          c = { [n.g.ERROR]: 15e3, [n.g.FULL]: 3e5, [n.g.OFF]: 0 },
+          d = {
+            RESET: { message: "Session was reset", sm: "Reset" },
+            IMPORT: { message: "Recorder failed to import", sm: "Import" },
+            TOO_MANY: { message: "429: Too Many Requests", sm: "Too-Many" },
+            TOO_BIG: { message: "Payload was too large", sm: "Too-Big" },
+            CROSS_TAB: {
+              message: "Session Entity was set to OFF on another tab",
+              sm: "Cross-Tab",
+            },
+            ENTITLEMENTS: {
+              message: "Session Replay is not allowed and will not be started",
+              sm: "Entitlement",
+            },
+          },
+          u = 5e3,
+          l = {
+            API: "api",
+            RESUME: "resume",
+            SWITCH_TO_FULL: "switchToFull",
+            INITIALIZE: "initialize",
+            PRELOAD: "preload",
+          };
+      },
+      6389: (e, t, r) => {
+        "use strict";
+        function n(e, t = 500, r = {}) {
+          const n = r?.leading || !1;
+          let i;
+          return (...r) => {
+            (n &&
+              void 0 === i &&
+              (e.apply(this, r),
+              (i = setTimeout(() => {
+                i = clearTimeout(i);
+              }, t))),
+              n ||
+                (clearTimeout(i),
+                (i = setTimeout(() => {
+                  e.apply(this, r);
+                }, t))));
+          };
+        }
+        function i(e) {
+          let t = !1;
+          return (...r) => {
+            t || ((t = !0), e.apply(this, r));
+          };
+        }
+        r.d(t, { J: () => i, s: () => n });
+      },
+      6630: (e, t, r) => {
+        "use strict";
+        r.d(t, { T: () => n });
+        const n = r(860).K7.pageViewEvent;
+      },
+      6774: (e, t, r) => {
+        "use strict";
+        r.d(t, { T: () => n });
+        const n = r(860).K7.jserrors;
+      },
+      7295: (e, t, r) => {
+        "use strict";
+        r.d(t, { Xv: () => o, gX: () => i, iW: () => s });
+        var n = [];
+        function i(e) {
+          if (!e || s(e)) return !1;
+          if (0 === n.length) return !0;
+          if ("*" === n[0].hostname) return !1;
+          for (var t = 0; t < n.length; t++) {
+            var r = n[t];
+            if (r.hostname.test(e.hostname) && r.pathname.test(e.pathname))
+              return !1;
+          }
+          return !0;
+        }
+        function s(e) {
+          return void 0 === e.hostname;
+        }
+        function o(e) {
+          if (((n = []), e && e.length))
+            for (var t = 0; t < e.length; t++) {
+              let r = e[t];
+              if (!r) continue;
+              if ("*" === r) return void (n = [{ hostname: "*" }]);
+              0 === r.indexOf("http://")
+                ? (r = r.substring(7))
+                : 0 === r.indexOf("https://") && (r = r.substring(8));
+              const i = r.indexOf("/");
+              let s, o;
+              i > 0
+                ? ((s = r.substring(0, i)), (o = r.substring(i)))
+                : ((s = r), (o = "*"));
+              let [c] = s.split(":");
+              n.push({ hostname: a(c), pathname: a(o, !0) });
+            }
+        }
+        function a(e, t = !1) {
+          const r = e
+            .replace(/[.+?^${}()|[\]\\]/g, (e) => "\\" + e)
+            .replace(/\*/g, ".*?");
+          return new RegExp((t ? "^" : "") + r + "$");
+        }
+      },
+      7485: (e, t, r) => {
+        "use strict";
+        r.d(t, { D: () => i });
+        var n = r(6154);
+        function i(e) {
+          if (0 === (e || "").indexOf("data:")) return { protocol: "data" };
+          try {
+            const t = new URL(e, location.href),
+              r = {
+                port: t.port,
+                hostname: t.hostname,
+                pathname: t.pathname,
+                search: t.search,
+                protocol: t.protocol.slice(0, t.protocol.indexOf(":")),
+                sameOrigin:
+                  t.protocol === n.gm?.location?.protocol &&
+                  t.host === n.gm?.location?.host,
+              };
+            return (
+              (r.port && "" !== r.port) ||
+                ("http:" === t.protocol && (r.port = "80"),
+                "https:" === t.protocol && (r.port = "443")),
+              r.pathname && "" !== r.pathname
+                ? r.pathname.startsWith("/") ||
+                  (r.pathname = "/".concat(r.pathname))
+                : (r.pathname = "/"),
+              r
+            );
+          } catch (e) {
+            return {};
+          }
+        }
+      },
+      7699: (e, t, r) => {
+        "use strict";
+        r.d(t, { It: () => s, KC: () => a, No: () => i, qh: () => o });
+        var n = r(860);
+        const i = 16e3,
+          s = 1e6,
+          o = "SESSION_ERROR",
+          a = {
+            [n.K7.logging]: !0,
+            [n.K7.genericEvents]: !0,
+            [n.K7.jserrors]: !0,
+            [n.K7.ajax]: !0,
+          };
+      },
+      7767: (e, t, r) => {
+        "use strict";
+        r.d(t, { V: () => i });
+        var n = r(6154);
+        const i = (e) => n.RI && !0 === e?.privacy.cookies_enabled;
+      },
+      7836: (e, t, r) => {
+        "use strict";
+        r.d(t, { P: () => a, ee: () => c });
+        var n = r(384),
+          i = r(8990),
+          s = r(2646),
+          o = r(5607);
+        const a = "nr@context:".concat(o.W),
+          c = (function e(t, r) {
+            var n = {},
+              o = {},
+              u = {},
+              l = !1;
+            try {
+              l =
+                16 === r.length &&
+                d.initializedAgents?.[r]?.runtime.isolatedBacklog;
+            } catch (e) {}
+            var f = {
+              on: p,
+              addEventListener: p,
+              removeEventListener: function (e, t) {
+                var r = n[e];
+                if (!r) return;
+                for (var i = 0; i < r.length; i++) r[i] === t && r.splice(i, 1);
+              },
+              emit: function (e, r, n, i, s) {
+                !1 !== s && (s = !0);
+                if (c.aborted && !i) return;
+                t && s && t.emit(e, r, n);
+                var a = h(n);
+                g(e).forEach((e) => {
+                  e.apply(a, r);
+                });
+                var d = v()[o[e]];
+                d && d.push([f, e, r, a]);
+                return a;
+              },
+              get: m,
+              listeners: g,
+              context: h,
+              buffer: function (e, t) {
+                const r = v();
+                if (((t = t || "feature"), f.aborted)) return;
+                Object.entries(e || {}).forEach(([e, n]) => {
+                  ((o[n] = t), t in r || (r[t] = []));
+                });
+              },
+              abort: function () {
+                ((f._aborted = !0),
+                  Object.keys(f.backlog).forEach((e) => {
+                    delete f.backlog[e];
+                  }));
+              },
+              isBuffering: function (e) {
+                return !!v()[o[e]];
+              },
+              debugId: r,
+              backlog: l
+                ? {}
+                : t && "object" == typeof t.backlog
+                  ? t.backlog
+                  : {},
+              isolatedBacklog: l,
+            };
+            return (
+              Object.defineProperty(f, "aborted", {
+                get: () => {
+                  let e = f._aborted || !1;
+                  return e || (t && (e = t.aborted), e);
+                },
+              }),
+              f
+            );
+            function h(e) {
+              return e && e instanceof s.y
+                ? e
+                : e
+                  ? (0, i.I)(e, a, () => new s.y(a))
+                  : new s.y(a);
+            }
+            function p(e, t) {
+              n[e] = g(e).concat(t);
+            }
+            function g(e) {
+              return n[e] || [];
+            }
+            function m(t) {
+              return (u[t] = u[t] || e(f, t));
+            }
+            function v() {
+              return f.backlog;
+            }
+          })(void 0, "globalEE"),
+          d = (0, n.Zm)();
+        d.ee || (d.ee = c);
+      },
+      7866: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          Nc: () => s,
+          cn: () => a,
+          fL: () => i,
+          h3: () => n,
+          hB: () => o,
+        });
+        const n = /function (.+?)\s*\(/,
+          i =
+            /^\s*at .+ \(eval at \S+ \((?:(?:file|http|https):[^)]+)?\)(?:, [^:]*:\d+:\d+)?\)$/i,
+          s = /^\s*at Function code \(Function code:\d+:\d+\)\s*/i,
+          o =
+            /^\s*at (?:((?:\[object object\])?(?:[^(]*\([^)]*\))*[^()]*(?: \[as \S+\])?) )?\(?((?:file|http|https|chrome-extension):.*?)?:(\d+)(?::(\d+))?\)?\s*$/i,
+          a =
+            /^\s*(?:([^@]*)(?:\(.*?\))?@)?((?:file|http|https|chrome|safari-extension).*?):(\d+)(?::(\d+))?\s*$/i;
+      },
+      8122: (e, t, r) => {
+        "use strict";
+        r.d(t, { a: () => i });
+        var n = r(944);
+        function i(e, t) {
+          try {
+            if (!e || "object" != typeof e) return (0, n.R)(3);
+            if (!t || "object" != typeof t) return (0, n.R)(4);
+            const r = Object.create(
+                Object.getPrototypeOf(t),
+                Object.getOwnPropertyDescriptors(t)
+              ),
+              s = 0 === Object.keys(r).length ? e : r;
+            for (let o in s)
+              if (void 0 !== e[o])
+                try {
+                  if (null === e[o]) {
+                    r[o] = null;
+                    continue;
+                  }
+                  Array.isArray(e[o]) && Array.isArray(t[o])
+                    ? (r[o] = Array.from(new Set([...e[o], ...t[o]])))
+                    : e[o] instanceof Map ||
+                        e[o] instanceof Set ||
+                        e[o] instanceof Date ||
+                        e[o] instanceof RegExp
+                      ? (r[o] = e[o])
+                      : "object" == typeof e[o] && "object" == typeof t[o]
+                        ? (r[o] = i(e[o], t[o]))
+                        : (r[o] = e[o]);
+                } catch (e) {
+                  r[o] || (0, n.R)(1, e);
+                }
+            return r;
+          } catch (e) {
+            (0, n.R)(2, e);
+          }
+        }
+      },
+      8139: (e, t, r) => {
+        "use strict";
+        r.d(t, { u: () => f });
+        var n = r(7836),
+          i = r(3434),
+          s = r(8990),
+          o = r(6154);
+        const a = {},
+          c = o.gm.XMLHttpRequest,
+          d = "addEventListener",
+          u = "removeEventListener",
+          l = "nr@wrapped:".concat(n.P);
+        function f(e) {
+          var t = (function (e) {
+            return (e || n.ee).get("events");
+          })(e);
+          if (a[t.debugId]++) return t;
+          a[t.debugId] = 1;
+          var r = (0, i.YM)(t, !0);
+          function f(e) {
+            r.inPlace(e, [d, u], "-", p);
+          }
+          function p(e, t) {
+            return e[1];
+          }
+          return (
+            "getPrototypeOf" in Object &&
+              (o.RI && h(document, f), c && h(c.prototype, f), h(o.gm, f)),
+            t.on(d + "-start", function (e, t) {
+              var n = e[1];
+              if (
+                null !== n &&
+                ("function" == typeof n || "object" == typeof n) &&
+                "newrelic" !== e[0]
+              ) {
+                var i = (0, s.I)(n, l, function () {
+                  var e = {
+                    object: function () {
+                      if ("function" != typeof n.handleEvent) return;
+                      return n.handleEvent.apply(n, arguments);
+                    },
+                    function: n,
+                  }[typeof n];
+                  return e ? r(e, "fn-", null, e.name || "anonymous") : n;
+                });
+                this.wrapped = e[1] = i;
+              }
+            }),
+            t.on(u + "-start", function (e) {
+              e[1] = this.wrapped || e[1];
+            }),
+            t
+          );
+        }
+        function h(e, t, ...r) {
+          let n = e;
+          for (
+            ;
+            "object" == typeof n && !Object.prototype.hasOwnProperty.call(n, d);
+
+          )
+            n = Object.getPrototypeOf(n);
+          n && t(n, ...r);
+        }
+      },
+      8362: (e, t, r) => {
+        "use strict";
+        r.d(t, { d: () => s });
+        var n = r(9566),
+          i = r(1741);
+        class s extends i.W {
+          agentIdentifier = (0, n.LA)(16);
+        }
+      },
+      8374: (e, t, r) => {
+        r.nc = (() => {
+          try {
+            return document?.currentScript?.nonce;
+          } catch (e) {}
+          return "";
+        })();
+      },
+      8990: (e, t, r) => {
+        "use strict";
+        r.d(t, { I: () => i });
+        var n = Object.prototype.hasOwnProperty;
+        function i(e, t, r) {
+          if (n.call(e, t)) return e[t];
+          var i = r();
+          if (Object.defineProperty && Object.keys)
+            try {
+              return (
+                Object.defineProperty(e, t, {
+                  value: i,
+                  writable: !0,
+                  enumerable: !1,
+                }),
+                i
+              );
+            } catch (e) {}
+          return ((e[t] = i), i);
+        }
+      },
+      9119: (e, t, r) => {
+        "use strict";
+        r.d(t, { L: () => s });
+        var n = /([^?#]*)[^#]*(#[^?]*|$).*/,
+          i = /([^?#]*)().*/;
+        function s(e, t) {
+          return e ? e.replace(t ? n : i, "$1$2") : e;
+        }
+      },
+      9300: (e, t, r) => {
+        "use strict";
+        r.d(t, { T: () => n });
+        const n = r(860).K7.ajax;
+      },
+      9324: (e, t, r) => {
+        "use strict";
+        r.d(t, {
+          AJ: () => o,
+          F3: () => i,
+          Xs: () => s,
+          Yq: () => a,
+          xv: () => n,
+        });
+        const n = "1.312.1",
+          i = "PROD",
+          s = "CDN",
+          o = "@newrelic/rrweb",
+          a = "1.1.0";
+      },
+      9566: (e, t, r) => {
+        "use strict";
+        r.d(t, { LA: () => a, ZF: () => c, bz: () => o, el: () => d });
+        var n = r(6154);
+        const i = "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx";
+        function s(e, t) {
+          return e ? 15 & e[t] : (16 * Math.random()) | 0;
+        }
+        function o() {
+          const e = n.gm?.crypto || n.gm?.msCrypto;
+          let t,
+            r = 0;
+          return (
+            e &&
+              e.getRandomValues &&
+              (t = e.getRandomValues(new Uint8Array(30))),
+            i
+              .split("")
+              .map((e) =>
+                "x" === e
+                  ? s(t, r++).toString(16)
+                  : "y" === e
+                    ? ((3 & s()) | 8).toString(16)
+                    : e
+              )
+              .join("")
+          );
+        }
+        function a(e) {
+          const t = n.gm?.crypto || n.gm?.msCrypto;
+          let r,
+            i = 0;
+          t && t.getRandomValues && (r = t.getRandomValues(new Uint8Array(e)));
+          const o = [];
+          for (var a = 0; a < e; a++) o.push(s(r, i++).toString(16));
+          return o.join("");
+        }
+        function c() {
+          return a(16);
+        }
+        function d() {
+          return a(32);
+        }
+      },
+      9908: (e, t, r) => {
+        "use strict";
+        r.d(t, { d: () => n, p: () => i });
+        var n = r(7836).ee.get("handle");
+        function i(e, t, r, i, s) {
+          s
+            ? (s.buffer([e], i), s.emit(e, t, r))
+            : (n.buffer([e], i), n.emit(e, t, r));
+        }
+      },
+    },
+    n = {};
+  function i(e) {
+    var t = n[e];
+    if (void 0 !== t) return t.exports;
+    var s = (n[e] = { exports: {} });
+    return (r[e](s, s.exports, i), s.exports);
+  }
+  ((i.m = r),
+    (i.d = (e, t) => {
+      for (var r in t)
+        i.o(t, r) &&
+          !i.o(e, r) &&
+          Object.defineProperty(e, r, { enumerable: !0, get: t[r] });
+    }),
+    (i.f = {}),
+    (i.e = (e) =>
+      Promise.all(Object.keys(i.f).reduce((t, r) => (i.f[r](e, t), t), []))),
+    (i.u = (e) =>
+      ({ 212: "nr-spa-compressor", 249: "nr-spa-recorder", 478: "nr-spa" })[e] +
+      "-1.312.1.min.js"),
+    (i.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t)),
+    (e = {}),
+    (t = "NRBA-1.312.1.PROD:"),
+    (i.l = (r, n, s, o) => {
+      if (e[r]) e[r].push(n);
+      else {
+        var a, c;
+        if (void 0 !== s)
+          for (
+            var d = document.getElementsByTagName("script"), u = 0;
+            u < d.length;
+            u++
+          ) {
+            var l = d[u];
+            if (
+              l.getAttribute("src") == r ||
+              l.getAttribute("data-webpack") == t + s
+            ) {
+              a = l;
+              break;
+            }
+          }
+        if (!a) {
+          c = !0;
+          var f = {
+            478: "sha512-dZhtzLTOyIsYHGHWAipD4+6jjzEIycTqL1F9NwinUiYL8cf0kIXf7WUbskVMB7p/nhDF+zJ9Bfd6LU9PMn0Yhw==",
+            249: "sha512-SJV3E/3SdEyaahYm8FHEFwhJvDQy/nRJJV/o+18MgXENJWR/8tfvIKfc4LE1xV9RniczXT7eQLcZi2G99UlugA==",
+            212: "sha512-dRFaJY5mEo/nxzPqxS/sHnvU66fpkTff91nWUFOafyPR61R+r2GZiy81lT47BWA4MouemCj4tvhHmn8Ofh/UOg==",
+          };
+          (((a = document.createElement("script")).charset = "utf-8"),
+            i.nc && a.setAttribute("nonce", i.nc),
+            a.setAttribute("data-webpack", t + s),
+            (a.src = r),
+            0 !== a.src.indexOf(window.location.origin + "/") &&
+              (a.crossOrigin = "anonymous"),
+            f[o] && (a.integrity = f[o]));
+        }
+        e[r] = [n];
+        var h = (t, n) => {
+            ((a.onerror = a.onload = null), clearTimeout(p));
+            var i = e[r];
+            if (
+              (delete e[r],
+              a.parentNode && a.parentNode.removeChild(a),
+              i && i.forEach((e) => e(n)),
+              t)
+            )
+              return t(n);
+          },
+          p = setTimeout(
+            h.bind(null, void 0, { type: "timeout", target: a }),
+            12e4
+          );
+        ((a.onerror = h.bind(null, a.onerror)),
+          (a.onload = h.bind(null, a.onload)),
+          c && document.head.appendChild(a));
+      }
+    }),
+    (i.r = (e) => {
+      ("undefined" != typeof Symbol &&
+        Symbol.toStringTag &&
+        Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }),
+        Object.defineProperty(e, "__esModule", { value: !0 }));
+    }),
+    (i.p = "https://js-agent.newrelic.com/"),
+    (() => {
+      var e = { 38: 0, 788: 0 };
+      i.f.j = (t, r) => {
+        var n = i.o(e, t) ? e[t] : void 0;
+        if (0 !== n)
+          if (n) r.push(n[2]);
+          else {
+            var s = new Promise((r, i) => (n = e[t] = [r, i]));
+            r.push((n[2] = s));
+            var o = i.p + i.u(t),
+              a = new Error();
+            i.l(
+              o,
+              (r) => {
+                if (i.o(e, t) && (0 !== (n = e[t]) && (e[t] = void 0), n)) {
+                  var s = r && ("load" === r.type ? "missing" : r.type),
+                    o = r && r.target && r.target.src;
+                  ((a.message =
+                    "Loading chunk " + t + " failed: (" + s + ": " + o + ")"),
+                    (a.name = "ChunkLoadError"),
+                    (a.type = s),
+                    (a.request = o),
+                    n[1](a));
+                }
+              },
+              "chunk-" + t,
+              t
+            );
+          }
+      };
+      var t = (t, r) => {
+          var n,
+            s,
+            [o, a, c] = r,
+            d = 0;
+          if (o.some((t) => 0 !== e[t])) {
+            for (n in a) i.o(a, n) && (i.m[n] = a[n]);
+            if (c) c(i);
+          }
+          for (t && t(r); d < o.length; d++)
+            ((s = o[d]), i.o(e, s) && e[s] && e[s][0](), (e[s] = 0));
+        },
+        r = (self["webpackChunk:NRBA-1.312.1.PROD"] =
+          self["webpackChunk:NRBA-1.312.1.PROD"] || []);
+      (r.forEach(t.bind(null, 0)), (r.push = t.bind(null, r.push.bind(r))));
+    })(),
+    (() => {
+      "use strict";
+      i(8374);
+      var e = i(8362),
+        t = i(860);
+      const r = Object.values(t.K7);
+      var n = i(5205);
+      var s = i(9908),
+        o = i(1863),
+        a = i(4261),
+        c = i(1738);
+      var d = i(1687),
+        u = i(4234),
+        l = i(5289),
+        f = i(6154),
+        h = i(944),
+        p = i(5270),
+        g = i(7767),
+        m = i(6389),
+        v = i(7699);
+      class y extends u.W {
+        constructor(e, t) {
+          (super(e, t),
+            (this.abortHandler = void 0),
+            (this.featAggregate = void 0),
+            (this.loadedSuccessfully = void 0),
+            (this.onAggregateImported = new Promise((e) => {
+              this.loadedSuccessfully = e;
+            })),
+            (this.deferred = Promise.resolve()),
+            !1 === e.init[this.featureName].autoStart
+              ? (this.deferred = new Promise((t, r) => {
+                  this.ee.on(
+                    "manual-start-all",
+                    (0, m.J)(() => {
+                      ((0, d.Ak)(e, this.featureName), t());
+                    })
+                  );
+                }))
+              : (0, d.Ak)(e, t));
+        }
+        importAggregator(e, t, r = {}) {
+          if (this.featAggregate) return;
+          const n = async () => {
+            let n;
+            await this.deferred;
+            try {
+              if ((0, g.V)(e.init)) {
+                const { setupAgentSession: t } = await i
+                  .e(478)
+                  .then(i.bind(i, 8766));
+                n = t(e);
+              }
+            } catch (e) {
+              ((0, h.R)(20, e),
+                this.ee.emit("internal-error", [e]),
+                (0, s.p)(v.qh, [e], void 0, this.featureName, this.ee));
+            }
+            try {
+              if (!this.#t(this.featureName, n, e.init))
+                return (
+                  (0, d.Ze)(this.agentRef, this.featureName),
+                  void this.loadedSuccessfully(!1)
+                );
+              const { Aggregate: i } = await t();
+              ((this.featAggregate = new i(e, r)),
+                e.runtime.harvester.initializedAggregates.push(
+                  this.featAggregate
+                ),
+                this.loadedSuccessfully(!0));
+            } catch (e) {
+              ((0, h.R)(34, e),
+                this.abortHandler?.(),
+                (0, d.Ze)(this.agentRef, this.featureName, !0),
+                this.loadedSuccessfully(!1),
+                this.ee && this.ee.abort());
+            }
+          };
+          f.RI ? (0, l.GG)(() => n(), !0) : n();
+        }
+        #t(e, r, n) {
+          if (this.blocked) return !1;
+          switch (e) {
+            case t.K7.sessionReplay:
+              return (0, p.SR)(n) && !!r;
+            case t.K7.sessionTrace:
+              return !!r;
+            default:
+              return !0;
+          }
+        }
+      }
+      var b = i(6630),
+        w = i(2614),
+        R = i(3241);
+      class E extends y {
+        static featureName = b.T;
+        constructor(e) {
+          var t;
+          (super(e, b.T),
+            this.setupInspectionEvents(),
+            (t = e),
+            (0, c.Y)(
+              a.Fw,
+              function (e, r) {
+                "string" == typeof e &&
+                  ("/" !== e.charAt(0) && (e = "/" + e),
+                  (t.runtime.customTransaction =
+                    (r || "http://custom.transaction") + e),
+                  (0, s.p)(a.Pl + a.Fw, [(0, o.t)()], void 0, void 0, t.ee));
+              },
+              t
+            ),
+            this.importAggregator(e, () => i.e(478).then(i.bind(i, 5839))));
+        }
+        setupInspectionEvents() {
+          const e = (e, t) => {
+            e &&
+              (0, R.W)({
+                timeStamp: e.timeStamp,
+                loaded: "complete" === e.target.readyState,
+                type: "window",
+                name: t,
+                data: e.target.location + "",
+              });
+          };
+          ((0, l.sB)((t) => {
+            e(t, "DOMContentLoaded");
+          }),
+            (0, l.GG)((t) => {
+              e(t, "load");
+            }),
+            (0, l.Qr)((t) => {
+              e(t, "navigate");
+            }),
+            this.ee.on(w.tS.UPDATE, (e, t) => {
+              (0, R.W)({ type: "lifecycle", name: "session", data: t });
+            }));
+        }
+      }
+      var T = i(384);
+      class A extends e.d {
+        constructor(e) {
+          var t;
+          (super(), f.gm)
+            ? ((this.features = {}),
+              (0, T.bQ)(this.agentIdentifier, this),
+              (this.desiredFeatures = new Set(e.features || [])),
+              this.desiredFeatures.add(E),
+              (0, n.j)(this, e, e.loaderType || "agent"),
+              (t = this),
+              (0, c.Y)(
+                a.cD,
+                function (e, r, n = !1) {
+                  if ("string" == typeof e) {
+                    if (
+                      ["string", "number", "boolean"].includes(typeof r) ||
+                      null === r
+                    )
+                      return (0, c.U)(t, e, r, a.cD, n);
+                    (0, h.R)(40, typeof r);
+                  } else (0, h.R)(39, typeof e);
+                },
+                t
+              ),
+              (function (e) {
+                (0, c.Y)(
+                  a.Dl,
+                  function (t, r = !1) {
+                    if ("string" != typeof t && null !== t)
+                      return void (0, h.R)(41, typeof t);
+                    const n = e.info.jsAttributes["enduser.id"];
+                    r && null != n && n !== t
+                      ? (0, s.p)(
+                          a.Pl + "setUserIdAndResetSession",
+                          [t],
+                          void 0,
+                          "session",
+                          e.ee
+                        )
+                      : (0, c.U)(e, "enduser.id", t, a.Dl, !0);
+                  },
+                  e
+                );
+              })(this),
+              (function (e) {
+                (0, c.Y)(
+                  a.nb,
+                  function (t) {
+                    if ("string" == typeof t || null === t)
+                      return (0, c.U)(e, "application.version", t, a.nb, !1);
+                    (0, h.R)(42, typeof t);
+                  },
+                  e
+                );
+              })(this),
+              (function (e) {
+                (0, c.Y)(
+                  a.d3,
+                  function () {
+                    e.ee.emit("manual-start-all");
+                  },
+                  e
+                );
+              })(this),
+              (function (e) {
+                (0, c.Y)(
+                  a.Pv,
+                  function (t = !0) {
+                    if ("boolean" == typeof t) {
+                      if (
+                        ((0, s.p)(a.Pl + a.Pv, [t], void 0, "session", e.ee),
+                        (e.runtime.consented = t),
+                        t)
+                      ) {
+                        const t = e.features.page_view_event;
+                        t.onAggregateImported.then((e) => {
+                          const r = t.featAggregate;
+                          e && !r.sentRum && r.sendRum();
+                        });
+                      }
+                    } else (0, h.R)(65, typeof t);
+                  },
+                  e
+                );
+              })(this),
+              this.run())
+            : (0, h.R)(21);
+        }
+        get config() {
+          return {
+            info: this.info,
+            init: this.init,
+            loader_config: this.loader_config,
+            runtime: this.runtime,
+          };
+        }
+        get api() {
+          return this;
+        }
+        run() {
+          try {
+            const e = (function (e) {
+                const t = {};
+                return (
+                  r.forEach((r) => {
+                    t[r] = !!e[r]?.enabled;
+                  }),
+                  t
+                );
+              })(this.init),
+              n = [...this.desiredFeatures];
+            (n.sort((e, r) => t.P3[e.featureName] - t.P3[r.featureName]),
+              n.forEach((r) => {
+                if (!e[r.featureName] && r.featureName !== t.K7.pageViewEvent)
+                  return;
+                const n = (function (e) {
+                  switch (e) {
+                    case t.K7.ajax:
+                      return [t.K7.jserrors];
+                    case t.K7.sessionTrace:
+                      return [t.K7.ajax, t.K7.pageViewEvent];
+                    case t.K7.sessionReplay:
+                      return [t.K7.sessionTrace];
+                    case t.K7.pageViewTiming:
+                      return [t.K7.pageViewEvent];
+                    default:
+                      return [];
+                  }
+                })(r.featureName).filter((e) => !(e in this.features));
+                (n.length > 0 &&
+                  (0, h.R)(36, {
+                    targetFeature: r.featureName,
+                    missingDependencies: n,
+                  }),
+                  (this.features[r.featureName] = new r(this)));
+              }));
+          } catch (e) {
+            (0, h.R)(22, e);
+            for (const e in this.features) this.features[e].abortHandler?.();
+            const t = (0, T.Zm)();
+            (delete t.initializedAgents[this.agentIdentifier]?.features,
+              delete this.sharedAggregator);
+            return (t.ee.get(this.agentIdentifier).abort(), !1);
+          }
+        }
+      }
+      var x = i(2843),
+        S = i(782);
+      class _ extends y {
+        static featureName = S.T;
+        constructor(e) {
+          (super(e, S.T),
+            f.RI &&
+              ((0, x.u)(
+                () => (0, s.p)("docHidden", [(0, o.t)()], void 0, S.T, this.ee),
+                !0
+              ),
+              (0, x.G)(() =>
+                (0, s.p)("winPagehide", [(0, o.t)()], void 0, S.T, this.ee)
+              ),
+              this.importAggregator(e, () => i.e(478).then(i.bind(i, 9917)))));
+        }
+      }
+      var O = i(3969);
+      class P extends y {
+        static featureName = O.TZ;
+        constructor(e) {
+          (super(e, O.TZ),
+            f.RI &&
+              document.addEventListener("securitypolicyviolation", (e) => {
+                (0, s.p)(
+                  O.xV,
+                  ["Generic/CSPViolation/Detected"],
+                  void 0,
+                  this.featureName,
+                  this.ee
+                );
+              }),
+            this.importAggregator(e, () => i.e(478).then(i.bind(i, 6555))));
+        }
+      }
+      var k = i(6774),
+        N = i(3878),
+        D = i(3304);
+      class j {
+        constructor(e, t, r, n, i) {
+          ((this.name = "UncaughtError"),
+            (this.message = "string" == typeof e ? e : (0, D.A)(e)),
+            (this.sourceURL = t),
+            (this.line = r),
+            (this.column = n),
+            (this.__newrelic = i));
+        }
+      }
+      function C(e) {
+        return M(e)
+          ? e
+          : new j(
+              void 0 !== e?.message ? e.message : e,
+              e?.filename || e?.sourceURL,
+              e?.lineno || e?.line,
+              e?.colno || e?.col,
+              e?.__newrelic,
+              e?.cause
+            );
+      }
+      function L(e) {
+        const t = "Unhandled Promise Rejection: ";
+        if (!e?.reason) return;
+        if (M(e.reason)) {
+          try {
+            e.reason.message.startsWith(t) ||
+              (e.reason.message = t + e.reason.message);
+          } catch (e) {}
+          return C(e.reason);
+        }
+        const r = C(e.reason);
+        return (
+          (r.message || "").startsWith(t) || (r.message = t + r.message),
+          r
+        );
+      }
+      function I(e) {
+        if (
+          e.error instanceof SyntaxError &&
+          !/:\d+$/.test(e.error.stack?.trim())
+        ) {
+          const t = new j(
+            e.message,
+            e.filename,
+            e.lineno,
+            e.colno,
+            e.error.__newrelic,
+            e.cause
+          );
+          return ((t.name = SyntaxError.name), t);
+        }
+        return M(e.error) ? e.error : C(e);
+      }
+      function M(e) {
+        return e instanceof Error && !!e.stack;
+      }
+      function B(e, r, n, i, a = (0, o.t)()) {
+        ("string" == typeof e && (e = new Error(e)),
+          (0, s.p)(
+            "err",
+            [e, a, !1, r, n.runtime.isRecording, void 0, i],
+            void 0,
+            t.K7.jserrors,
+            n.ee
+          ),
+          (0, s.p)("uaErr", [], void 0, t.K7.genericEvents, n.ee));
+      }
+      var H = i(1541),
+        W = i(993),
+        K = i(3785);
+      function F(
+        e,
+        { customAttributes: t = {}, level: r = W.p_.INFO } = {},
+        n,
+        i,
+        s = (0, o.t)()
+      ) {
+        (0, K.R)(n.ee, e, t, r, !1, i, s);
+      }
+      function U(e, r, n, i, c = (0, o.t)()) {
+        (0, s.p)(a.Pl + a.hG, [c, e, r, i], void 0, t.K7.genericEvents, n.ee);
+      }
+      function V(e, r, n, i, c = (0, o.t)()) {
+        const { start: d, end: u, customAttributes: l } = r || {},
+          f = { customAttributes: l || {} };
+        if (
+          "object" != typeof f.customAttributes ||
+          "string" != typeof e ||
+          0 === e.length
+        )
+          return void (0, h.R)(57);
+        const p = (e, t) =>
+          null == e
+            ? t
+            : "number" == typeof e
+              ? e
+              : e instanceof PerformanceMark
+                ? e.startTime
+                : Number.NaN;
+        if (
+          ((f.start = p(d, 0)),
+          (f.end = p(u, c)),
+          Number.isNaN(f.start) || Number.isNaN(f.end))
+        )
+          (0, h.R)(57);
+        else {
+          if (((f.duration = f.end - f.start), !(f.duration < 0)))
+            return (
+              (0, s.p)(
+                a.Pl + a.V1,
+                [f, e, i],
+                void 0,
+                t.K7.genericEvents,
+                n.ee
+              ),
+              f
+            );
+          (0, h.R)(58);
+        }
+      }
+      function G(e, r = {}, n, i, c = (0, o.t)()) {
+        (0, s.p)(a.Pl + a.fF, [c, e, r, i], void 0, t.K7.genericEvents, n.ee);
+      }
+      var z = i(5871),
+        Y = i(9566);
+      const Z = ["name", "id", "type"];
+      function q(e) {
+        (0, c.Y)(
+          a.eY,
+          function (t) {
+            return X(e, t);
+          },
+          e
+        );
+      }
+      function X(e, r, n) {
+        ((0, h.R)(54, "newrelic.register"),
+          (r ||= {}),
+          (r.instance = (0, Y.LA)(8)),
+          (r.type = H.fQ.MFE),
+          (r.licenseKey ||= e.info.licenseKey),
+          (r.blocked = !1),
+          ("object" != typeof r.tags ||
+            null === r.tags ||
+            Array.isArray(r.tags)) &&
+            (r.tags = {}),
+          (r.parent = n || {
+            get id() {
+              return e.runtime.appMetadata.agents[0].entityGuid;
+            },
+            type: H.fQ.BA,
+          }));
+        const i = (0, z.Qr)(),
+          a = {};
+        (Object.defineProperty(r, "attributes", {
+          get: () => ({
+            ...a,
+            "source.id": r.id,
+            "source.name": r.name,
+            "source.type": r.type,
+            "parent.type": r.parent?.type || H.fQ.BA,
+            "parent.id": r.parent?.id,
+          }),
+        }),
+          Object.entries(r.tags).forEach(([e, t]) => {
+            Z.includes(e) || (a["source.".concat(e)] = t);
+          }),
+          (r.isolated ??= !0));
+        let c = () => {};
+        const d = e.runtime.registeredEntities;
+        if (!r.isolated) {
+          const e = d.find(
+            ({
+              metadata: {
+                target: { id: e },
+              },
+            }) => e === r.id && !r.isolated
+          );
+          if (e) return e;
+        }
+        const u = (e) => {
+          ((r.blocked = !0), (c = e));
+        };
+        function l(e) {
+          return "string" == typeof e && !!e.trim() && e.trim().length < 501;
+        }
+        (e.init.api.allow_registered_children ||
+          u((0, m.J)(() => (0, h.R)(55))),
+          (l(r.id) && l(r.name)) || u((0, m.J)(() => (0, h.R)(48, r))));
+        const f = {
+            addPageAction: (t, n = {}) => y(U, [t, { ...a, ...n }, e], r),
+            deregister: () => {
+              (g(), u((0, m.J)(() => (0, h.R)(68))));
+            },
+            log: (t, n = {}) =>
+              y(
+                F,
+                [
+                  t,
+                  {
+                    ...n,
+                    customAttributes: { ...a, ...(n.customAttributes || {}) },
+                  },
+                  e,
+                ],
+                r
+              ),
+            measure: (t, n = {}) =>
+              y(
+                V,
+                [
+                  t,
+                  {
+                    ...n,
+                    customAttributes: { ...a, ...(n.customAttributes || {}) },
+                  },
+                  e,
+                ],
+                r
+              ),
+            noticeError: (t, n = {}) => y(B, [t, { ...a, ...n }, e], r),
+            register: (t = {}) => y(X, [e, t], f.metadata.target),
+            recordCustomEvent: (t, n = {}) => y(G, [t, { ...a, ...n }, e], r),
+            setApplicationVersion: (e) => v("application.version", e),
+            setCustomAttribute: (e, t) => v(e, t),
+            setUserId: (e) => v("enduser.id", e),
+            metadata: {
+              get customAttributes() {
+                return a;
+              },
+              target: r,
+              timings: i,
+            },
+          },
+          p = () => (r.blocked && c(), r.blocked);
+        function g() {
+          i.reportedAt ||
+            ((i.reportedAt = (0, o.t)()),
+            f.recordCustomEvent("MicroFrontEndTiming", {
+              assetUrl: i.asset,
+              assetType: i.type,
+              timeToLoad: i.registeredAt - i.fetchStart,
+              timeToBeRequested: i.fetchStart,
+              timeToFetch: i.fetchEnd - i.fetchStart,
+              timeToRegister: i.registeredAt - i.fetchEnd,
+              timeAlive: i.reportedAt - i.registeredAt,
+            }));
+        }
+        p() || (d.push(f), (0, x.G)(g));
+        const v = (e, t) => {
+            p() || (a[e] = t);
+          },
+          y = (r, n, i) => {
+            if (p() && r !== X) return;
+            const a = (0, o.t)();
+            (0, s.p)(
+              O.xV,
+              ["API/register/".concat(r.name, "/called")],
+              void 0,
+              t.K7.metrics,
+              e.ee
+            );
+            try {
+              return r(...n, i, a);
+            } catch (e) {
+              (0, h.R)(50, e);
+            }
+          };
+        return f;
+      }
+      class Q extends y {
+        static featureName = k.T;
+        constructor(e) {
+          var t;
+          (super(e, k.T),
+            (t = e),
+            (0, c.Y)(a.o5, (e, r) => B(e, r, t), t),
+            (function (e) {
+              (0, c.Y)(
+                a.bt,
+                function (t) {
+                  e.runtime.onerror = t;
+                },
+                e
+              );
+            })(e),
+            (function (e) {
+              let t = 0;
+              (0, c.Y)(
+                a.k6,
+                function (e, r) {
+                  ++t > 10 ||
+                    (this.runtime.releaseIds[e.slice(-200)] = ("" + r).slice(
+                      -200
+                    ));
+                },
+                e
+              );
+            })(e),
+            q(e));
+          try {
+            this.removeOnAbort = new AbortController();
+          } catch (e) {}
+          (this.ee.on("internal-error", (t, r) => {
+            this.abortHandler &&
+              (0, s.p)(
+                "ierr",
+                [C(t), (0, o.t)(), !0, {}, e.runtime.isRecording, r],
+                void 0,
+                this.featureName,
+                this.ee
+              );
+          }),
+            f.gm.addEventListener(
+              "unhandledrejection",
+              (t) => {
+                this.abortHandler &&
+                  (0, s.p)(
+                    "err",
+                    [
+                      L(t),
+                      (0, o.t)(),
+                      !1,
+                      { unhandledPromiseRejection: 1 },
+                      e.runtime.isRecording,
+                    ],
+                    void 0,
+                    this.featureName,
+                    this.ee
+                  );
+              },
+              (0, N.jT)(!1, this.removeOnAbort?.signal)
+            ),
+            f.gm.addEventListener(
+              "error",
+              (t) => {
+                this.abortHandler &&
+                  (0, s.p)(
+                    "err",
+                    [I(t), (0, o.t)(), !1, {}, e.runtime.isRecording],
+                    void 0,
+                    this.featureName,
+                    this.ee
+                  );
+              },
+              (0, N.jT)(!1, this.removeOnAbort?.signal)
+            ),
+            (this.abortHandler = this.#r),
+            this.importAggregator(e, () => i.e(478).then(i.bind(i, 2176))));
+        }
+        #r() {
+          (this.removeOnAbort?.abort(), (this.abortHandler = void 0));
+        }
+      }
+      var J = i(8990);
+      let ee = 1;
+      function te(e) {
+        const t = typeof e;
+        return !e || ("object" !== t && "function" !== t)
+          ? -1
+          : e === f.gm
+            ? 0
+            : (0, J.I)(e, "nr@id", function () {
+                return ee++;
+              });
+      }
+      function re(e) {
+        if ("string" == typeof e && e.length) return e.length;
+        if ("object" == typeof e) {
+          if (
+            "undefined" != typeof ArrayBuffer &&
+            e instanceof ArrayBuffer &&
+            e.byteLength
+          )
+            return e.byteLength;
+          if ("undefined" != typeof Blob && e instanceof Blob && e.size)
+            return e.size;
+          if (!("undefined" != typeof FormData && e instanceof FormData))
+            try {
+              return (0, D.A)(e).length;
+            } catch (e) {
+              return;
+            }
+        }
+      }
+      var ne = i(8139),
+        ie = i(7836),
+        se = i(3434);
+      const oe = {},
+        ae = ["open", "send"];
+      function ce(e, t) {
+        var r = e || ie.ee;
+        const n = (function (e) {
+          return (e || ie.ee).get("xhr");
+        })(r);
+        if (void 0 === f.gm.XMLHttpRequest) return n;
+        if (oe[n.debugId]++) return n;
+        ((oe[n.debugId] = 1), (0, ne.u)(r));
+        var i = (0, se.YM)(n),
+          s = f.gm.XMLHttpRequest,
+          o = f.gm.MutationObserver,
+          a = f.gm.Promise,
+          c = f.gm.setInterval,
+          d = "readystatechange",
+          u = [
+            "onload",
+            "onerror",
+            "onabort",
+            "onloadstart",
+            "onloadend",
+            "onprogress",
+            "ontimeout",
+          ],
+          l = [],
+          p = (f.gm.XMLHttpRequest = function (e) {
+            const r = new s(e),
+              o = n.context(r);
+            o.targets = (0, H.$5)(t);
+            try {
+              (n.emit("new-xhr", [r], o),
+                r.addEventListener(
+                  d,
+                  ((a = o),
+                  function () {
+                    var e = this;
+                    (e.readyState > 3 &&
+                      !a.resolved &&
+                      ((a.resolved = !0), n.emit("xhr-resolved", [], e)),
+                      i.inPlace(e, u, "fn-", w));
+                  }),
+                  (0, N.jT)(!1)
+                ));
+            } catch (e) {
+              (0, h.R)(15, e);
+              try {
+                n.emit("internal-error", [e]);
+              } catch (e) {}
+            }
+            var a;
+            return r;
+          });
+        function g(e, t) {
+          i.inPlace(t, ["onreadystatechange"], "fn-", w);
+        }
+        if (
+          ((function (e, t) {
+            for (var r in e) t[r] = e[r];
+          })(s, p),
+          (p.prototype = s.prototype),
+          i.inPlace(p.prototype, ae, "-xhr-", w),
+          n.on("send-xhr-start", function (e, t) {
+            (g(e, t),
+              (function (e) {
+                (l.push(e),
+                  o && (m ? m.then(b) : c ? c(b) : ((v = -v), (y.data = v))));
+              })(t));
+          }),
+          n.on("open-xhr-start", g),
+          o)
+        ) {
+          var m = a && a.resolve();
+          if (!c && !a) {
+            var v = 1,
+              y = document.createTextNode(v);
+            new o(b).observe(y, { characterData: !0 });
+          }
+        } else
+          r.on("fn-end", function (e) {
+            (e[0] && e[0].type === d) || b();
+          });
+        function b() {
+          for (var e = 0; e < l.length; e++) g(0, l[e]);
+          l.length && (l = []);
+        }
+        function w(e, t) {
+          return t;
+        }
+        return n;
+      }
+      var de = "fetch-",
+        ue = de + "body-",
+        le = ["arrayBuffer", "blob", "json", "text", "formData"],
+        fe = f.gm.Request,
+        he = f.gm.Response,
+        pe = "prototype";
+      const ge = {};
+      function me(e, t) {
+        const r = (function (e) {
+          return (e || ie.ee).get("fetch");
+        })(e);
+        if (!(fe && he && f.gm.fetch)) return r;
+        if (ge[r.debugId]++) return r;
+        function n(e, n, i) {
+          var s = e[n];
+          "function" == typeof s &&
+            (e[n] = function () {
+              var e = [...arguments];
+              const n = {},
+                o = (0, H.$5)(t);
+              var a;
+              (r.emit(i + "before-start", [e], n),
+                n[ie.P] && n[ie.P].dt && (a = n[ie.P].dt));
+              var c = s.apply(this, e);
+              return (
+                r.emit(i + "start", [e, a], c),
+                c.then(
+                  function (e) {
+                    return (r.emit(i + "end", [null, e, o], c), e);
+                  },
+                  function (e) {
+                    throw (r.emit(i + "end", [e, void 0, o], c), e);
+                  }
+                )
+              );
+            });
+        }
+        return (
+          (ge[r.debugId] = 1),
+          le.forEach((e) => {
+            (n(fe[pe], e, ue), n(he[pe], e, ue));
+          }),
+          n(f.gm, "fetch", de),
+          r.on(de + "end", function (e, t, n) {
+            var i = this;
+            if (((i.targets = n || [void 0]), t)) {
+              var s = t.headers.get("content-length");
+              (null !== s && (i.rxSize = s), r.emit(de + "done", [null, t], i));
+            } else r.emit(de + "done", [e], i);
+          }),
+          r
+        );
+      }
+      var ve = i(7485);
+      class ye {
+        constructor(e) {
+          this.agentRef = e;
+        }
+        generateTracePayload(e) {
+          const t = this.agentRef.loader_config;
+          if (!this.shouldGenerateTrace(e) || !t) return null;
+          var r = (t.accountID || "").toString() || null,
+            n = (t.agentID || "").toString() || null,
+            i = (t.trustKey || "").toString() || null;
+          if (!r || !n) return null;
+          var s = (0, Y.ZF)(),
+            o = (0, Y.el)(),
+            a = Date.now(),
+            c = { spanId: s, traceId: o, timestamp: a };
+          return (
+            (e.sameOrigin ||
+              (this.isAllowedOrigin(e) &&
+                this.useTraceContextHeadersForCors())) &&
+              ((c.traceContextParentHeader =
+                this.generateTraceContextParentHeader(s, o)),
+              (c.traceContextStateHeader = this.generateTraceContextStateHeader(
+                s,
+                a,
+                r,
+                n,
+                i
+              ))),
+            ((e.sameOrigin && !this.excludeNewrelicHeader()) ||
+              (!e.sameOrigin &&
+                this.isAllowedOrigin(e) &&
+                this.useNewrelicHeaderForCors())) &&
+              (c.newrelicHeader = this.generateTraceHeader(s, o, a, r, n, i)),
+            c
+          );
+        }
+        generateTraceContextParentHeader(e, t) {
+          return "00-" + t + "-" + e + "-01";
+        }
+        generateTraceContextStateHeader(e, t, r, n, i) {
+          return i + "@nr=0-1-" + r + "-" + n + "-" + e + "----" + t;
+        }
+        generateTraceHeader(e, t, r, n, i, s) {
+          if (!("function" == typeof f.gm?.btoa)) return null;
+          var o = {
+            v: [0, 1],
+            d: { ty: "Browser", ac: n, ap: i, id: e, tr: t, ti: r },
+          };
+          return (s && n !== s && (o.d.tk = s), btoa((0, D.A)(o)));
+        }
+        shouldGenerateTrace(e) {
+          return (
+            this.agentRef.init?.distributed_tracing?.enabled &&
+            this.isAllowedOrigin(e)
+          );
+        }
+        isAllowedOrigin(e) {
+          var t = !1;
+          const r = this.agentRef.init?.distributed_tracing;
+          if (e.sameOrigin) t = !0;
+          else if (r?.allowed_origins instanceof Array)
+            for (var n = 0; n < r.allowed_origins.length; n++) {
+              var i = (0, ve.D)(r.allowed_origins[n]);
+              if (
+                e.hostname === i.hostname &&
+                e.protocol === i.protocol &&
+                e.port === i.port
+              ) {
+                t = !0;
+                break;
+              }
+            }
+          return t;
+        }
+        excludeNewrelicHeader() {
+          var e = this.agentRef.init?.distributed_tracing;
+          return !!e && !!e.exclude_newrelic_header;
+        }
+        useNewrelicHeaderForCors() {
+          var e = this.agentRef.init?.distributed_tracing;
+          return !!e && !1 !== e.cors_use_newrelic_header;
+        }
+        useTraceContextHeadersForCors() {
+          var e = this.agentRef.init?.distributed_tracing;
+          return !!e && !!e.cors_use_tracecontext_headers;
+        }
+      }
+      var be = i(9300),
+        we = i(7295);
+      function Re(e) {
+        return "string" == typeof e
+          ? e
+          : e instanceof (0, T.dV)().o.REQ
+            ? e.url
+            : f.gm?.URL && e instanceof URL
+              ? e.href
+              : void 0;
+      }
+      var Ee = ["load", "error", "abort", "timeout"],
+        Te = Ee.length,
+        Ae = (0, T.dV)().o.REQ,
+        xe = (0, T.dV)().o.XHR;
+      const Se = "X-NewRelic-App-Data";
+      class _e extends y {
+        static featureName = be.T;
+        constructor(e) {
+          (super(e, be.T),
+            (this.dt = new ye(e)),
+            (this.handler = (e, t, r, n) => (0, s.p)(e, t, r, n, this.ee)));
+          try {
+            const e = {
+              xmlhttprequest: "xhr",
+              fetch: "fetch",
+              beacon: "beacon",
+            };
+            f.gm?.performance?.getEntriesByType("resource").forEach((r) => {
+              if (r.initiatorType in e && 0 !== r.responseStatus) {
+                const n = { status: r.responseStatus },
+                  i = {
+                    rxSize: r.transferSize,
+                    duration: Math.floor(r.duration),
+                    cbTime: 0,
+                  };
+                (Oe(n, r.name),
+                  this.handler(
+                    "xhr",
+                    [n, i, r.startTime, r.responseEnd, e[r.initiatorType]],
+                    void 0,
+                    t.K7.ajax
+                  ));
+              }
+            });
+          } catch (e) {}
+          (me(this.ee, e),
+            ce(this.ee, e),
+            (function (e, r, n, i) {
+              function a(e) {
+                var t = this;
+                ((t.totalCbs = 0),
+                  (t.called = 0),
+                  (t.cbTime = 0),
+                  (t.end = T),
+                  (t.ended = !1),
+                  (t.xhrGuids = {}),
+                  (t.lastSize = null),
+                  (t.loadCaptureCalled = !1),
+                  (t.params = this.params || {}),
+                  (t.metrics = this.metrics || {}),
+                  (t.latestLongtaskEnd = 0),
+                  e.addEventListener(
+                    "load",
+                    function (r) {
+                      x(t, e);
+                    },
+                    (0, N.jT)(!1)
+                  ),
+                  f.lR ||
+                    e.addEventListener(
+                      "progress",
+                      function (e) {
+                        t.lastSize = e.loaded;
+                      },
+                      (0, N.jT)(!1)
+                    ));
+              }
+              function c(e) {
+                ((this.params = { method: e[0] }),
+                  Oe(this, e[1]),
+                  (this.metrics = {}));
+              }
+              function d(t, r) {
+                e.loader_config.xpid &&
+                  this.sameOrigin &&
+                  r.setRequestHeader("X-NewRelic-ID", e.loader_config.xpid);
+                var n = i.generateTracePayload(this.parsedOrigin);
+                if (n) {
+                  var s = !1;
+                  (n.newrelicHeader &&
+                    (r.setRequestHeader("newrelic", n.newrelicHeader),
+                    (s = !0)),
+                    n.traceContextParentHeader &&
+                      (r.setRequestHeader(
+                        "traceparent",
+                        n.traceContextParentHeader
+                      ),
+                      n.traceContextStateHeader &&
+                        r.setRequestHeader(
+                          "tracestate",
+                          n.traceContextStateHeader
+                        ),
+                      (s = !0)),
+                    s && (this.dt = n));
+                }
+              }
+              function u(e, t) {
+                var n = this.metrics,
+                  i = e[0],
+                  s = this;
+                if (n && i) {
+                  var a = re(i);
+                  a && (n.txSize = a);
+                }
+                ((this.startTime = (0, o.t)()),
+                  (this.body = i),
+                  (this.listener = function (e) {
+                    try {
+                      ("abort" !== e.type ||
+                        s.loadCaptureCalled ||
+                        (s.params.aborted = !0),
+                        ("load" !== e.type ||
+                          (s.called === s.totalCbs &&
+                            (s.onloadCalled || "function" != typeof t.onload) &&
+                            "function" == typeof s.end)) &&
+                          s.end(t));
+                    } catch (e) {
+                      try {
+                        r.emit("internal-error", [e]);
+                      } catch (e) {}
+                    }
+                  }));
+                for (var c = 0; c < Te; c++)
+                  t.addEventListener(Ee[c], this.listener, (0, N.jT)(!1));
+              }
+              function l(e, t, r) {
+                ((this.cbTime += e),
+                  t ? (this.onloadCalled = !0) : (this.called += 1),
+                  this.called !== this.totalCbs ||
+                    (!this.onloadCalled && "function" == typeof r.onload) ||
+                    "function" != typeof this.end ||
+                    this.end(r));
+              }
+              function h(e, t) {
+                var r = "" + te(e) + !!t;
+                this.xhrGuids &&
+                  !this.xhrGuids[r] &&
+                  ((this.xhrGuids[r] = !0), (this.totalCbs += 1));
+              }
+              function p(e, t) {
+                var r = "" + te(e) + !!t;
+                this.xhrGuids &&
+                  this.xhrGuids[r] &&
+                  (delete this.xhrGuids[r], (this.totalCbs -= 1));
+              }
+              function g() {
+                this.endTime = (0, o.t)();
+              }
+              function m(e, t) {
+                t instanceof xe &&
+                  "load" === e[0] &&
+                  r.emit("xhr-load-added", [e[1], e[2]], t);
+              }
+              function v(e, t) {
+                t instanceof xe &&
+                  "load" === e[0] &&
+                  r.emit("xhr-load-removed", [e[1], e[2]], t);
+              }
+              function y(e, t, r) {
+                t instanceof xe &&
+                  ("onload" === r && (this.onload = !0),
+                  ("load" === (e[0] && e[0].type) || this.onload) &&
+                    (this.xhrCbStart = (0, o.t)()));
+              }
+              function b(e, t) {
+                this.xhrCbStart &&
+                  r.emit(
+                    "xhr-cb-time",
+                    [(0, o.t)() - this.xhrCbStart, this.onload, t],
+                    t
+                  );
+              }
+              function w(e) {
+                var t,
+                  r = e[1] || {};
+                if (
+                  ("string" == typeof e[0]
+                    ? 0 === (t = e[0]).length &&
+                      f.RI &&
+                      (t = "" + f.gm.location.href)
+                    : e[0] && e[0].url
+                      ? (t = e[0].url)
+                      : f.gm?.URL && e[0] && e[0] instanceof URL
+                        ? (t = e[0].href)
+                        : "function" == typeof e[0].toString &&
+                          (t = e[0].toString()),
+                  "string" == typeof t && 0 !== t.length)
+                ) {
+                  t &&
+                    ((this.parsedOrigin = (0, ve.D)(t)),
+                    (this.sameOrigin = this.parsedOrigin.sameOrigin));
+                  var n = i.generateTracePayload(this.parsedOrigin);
+                  if (n && (n.newrelicHeader || n.traceContextParentHeader))
+                    if (e[0] && e[0].headers)
+                      a(e[0].headers, n) && (this.dt = n);
+                    else {
+                      var s = {};
+                      for (var o in r) s[o] = r[o];
+                      ((s.headers = new Headers(r.headers || {})),
+                        a(s.headers, n) && (this.dt = n),
+                        e.length > 1 ? (e[1] = s) : e.push(s));
+                    }
+                }
+                function a(e, t) {
+                  var r = !1;
+                  return (
+                    t.newrelicHeader &&
+                      (e.set("newrelic", t.newrelicHeader), (r = !0)),
+                    t.traceContextParentHeader &&
+                      (e.set("traceparent", t.traceContextParentHeader),
+                      t.traceContextStateHeader &&
+                        e.set("tracestate", t.traceContextStateHeader),
+                      (r = !0)),
+                    r
+                  );
+                }
+              }
+              function R(e, t) {
+                ((this.params = {}),
+                  (this.metrics = {}),
+                  (this.startTime = (0, o.t)()),
+                  (this.dt = t));
+                let [r, n = {}] = e;
+                Oe(this, Re(r));
+                const i = (
+                  "" + ((r && r instanceof Ae && r.method) || n.method || "GET")
+                ).toUpperCase();
+                ((this.params.method = i),
+                  (this.body = n.body),
+                  (this.txSize = re(n.body) || 0));
+              }
+              function E(e, t) {
+                if (
+                  ((this.endTime = (0, o.t)()),
+                  this.params || (this.params = {}),
+                  (0, we.iW)(this.params))
+                )
+                  return;
+                let r;
+                ((this.params.status = t ? t.status : 0),
+                  "string" == typeof this.rxSize &&
+                    this.rxSize.length > 0 &&
+                    (r = +this.rxSize));
+                const n = {
+                    txSize: this.txSize,
+                    rxSize: r,
+                    duration: (0, o.t)() - this.startTime,
+                  },
+                  i = [this.params, n, this.startTime, this.endTime, "fetch"];
+                this.targets.forEach((e) => A(i, this, e));
+              }
+              function T(e) {
+                const t = this.params,
+                  r = this.metrics;
+                if (this.ended) return;
+                this.ended = !0;
+                for (let t = 0; t < Te; t++)
+                  e.removeEventListener(Ee[t], this.listener, !1);
+                if (t.aborted) return;
+                if ((0, we.iW)(t)) return;
+                ((r.duration = (0, o.t)() - this.startTime),
+                  this.loadCaptureCalled || 4 !== e.readyState
+                    ? null == t.status && (t.status = 0)
+                    : x(this, e),
+                  (r.cbTime = this.cbTime));
+                const n = [t, r, this.startTime, this.endTime, "xhr"];
+                this.targets.forEach((e) => A(n, this, e));
+              }
+              function A(e, r, i) {
+                n("xhr", [...e, i], r, t.K7.ajax);
+              }
+              function x(e, n) {
+                e.params.status = n.status;
+                var i = (function (e, t) {
+                  var r = e.responseType;
+                  return "json" === r && null !== t
+                    ? t
+                    : "arraybuffer" === r || "blob" === r || "json" === r
+                      ? re(e.response)
+                      : "text" === r || "" === r || void 0 === r
+                        ? re(e.responseText)
+                        : void 0;
+                })(n, e.lastSize);
+                if (
+                  (i && (e.metrics.rxSize = i),
+                  e.sameOrigin && n.getAllResponseHeaders().indexOf(Se) >= 0)
+                ) {
+                  var o = n.getResponseHeader(Se);
+                  o &&
+                    ((0, s.p)(
+                      O.rs,
+                      ["Ajax/CrossApplicationTracing/Header/Seen"],
+                      void 0,
+                      t.K7.metrics,
+                      r
+                    ),
+                    (e.params.cat = o.split(", ").pop()));
+                }
+                e.loadCaptureCalled = !0;
+              }
+              (r.on("new-xhr", a),
+                r.on("open-xhr-start", c),
+                r.on("open-xhr-end", d),
+                r.on("send-xhr-start", u),
+                r.on("xhr-cb-time", l),
+                r.on("xhr-load-added", h),
+                r.on("xhr-load-removed", p),
+                r.on("xhr-resolved", g),
+                r.on("addEventListener-end", m),
+                r.on("removeEventListener-end", v),
+                r.on("fn-end", b),
+                r.on("fetch-before-start", w),
+                r.on("fetch-start", R),
+                r.on("fn-start", y),
+                r.on("fetch-done", E));
+            })(e, this.ee, this.handler, this.dt),
+            this.importAggregator(e, () => i.e(478).then(i.bind(i, 3845))));
+        }
+      }
+      function Oe(e, t) {
+        var r = (0, ve.D)(t),
+          n = e.params || e;
+        ((n.hostname = r.hostname),
+          (n.port = r.port),
+          (n.protocol = r.protocol),
+          (n.host = r.hostname + ":" + r.port),
+          (n.pathname = r.pathname),
+          (e.parsedOrigin = r),
+          (e.sameOrigin = r.sameOrigin));
+      }
+      const Pe = {},
+        ke = ["pushState", "replaceState"];
+      function Ne(e) {
+        const t = (function (e) {
+          return (e || ie.ee).get("history");
+        })(e);
+        return (
+          !f.RI ||
+            Pe[t.debugId]++ ||
+            ((Pe[t.debugId] = 1),
+            (0, se.YM)(t).inPlace(window.history, ke, "-")),
+          t
+        );
+      }
+      var De = i(3738);
+      function je(e) {
+        (0, c.Y)(
+          a.BL,
+          function (r = Date.now()) {
+            const n = r - f.WN;
+            (n < 0 && (0, h.R)(62, r),
+              (0, s.p)(O.XG, [a.BL, { time: n }], void 0, t.K7.metrics, e.ee),
+              e.addToTrace({ name: a.BL, start: r, origin: "nr" }),
+              (0, s.p)(
+                a.Pl + a.hG,
+                [n, a.BL],
+                void 0,
+                t.K7.genericEvents,
+                e.ee
+              ));
+          },
+          e
+        );
+      }
+      const {
+        He: Ce,
+        bD: Le,
+        d3: Ie,
+        Kp: Me,
+        TZ: Be,
+        Lc: He,
+        uP: We,
+        Rz: Ke,
+      } = De;
+      class Fe extends y {
+        static featureName = Be;
+        constructor(e) {
+          var r;
+          (super(e, Be),
+            (r = e),
+            (0, c.Y)(
+              a.U2,
+              function (e) {
+                if (!(e && "object" == typeof e && e.name && e.start)) return;
+                const n = {
+                  n: e.name,
+                  s: e.start - f.WN,
+                  e: (e.end || e.start) - f.WN,
+                  o: e.origin || "",
+                  t: "api",
+                };
+                n.s < 0 || n.e < 0 || n.e < n.s
+                  ? (0, h.R)(61, { start: n.s, end: n.e })
+                  : (0, s.p)("bstApi", [n], void 0, t.K7.sessionTrace, r.ee);
+              },
+              r
+            ),
+            je(e));
+          if (!(0, g.V)(e.init)) return void this.deregisterDrain();
+          const n = this.ee;
+          let d;
+          (Ne(n),
+            (this.eventsEE = (0, ne.u)(n)),
+            this.eventsEE.on(We, function (e, t) {
+              this.bstStart = (0, o.t)();
+            }),
+            this.eventsEE.on(He, function (e, r) {
+              (0, s.p)(
+                "bst",
+                [e[0], r, this.bstStart, (0, o.t)()],
+                void 0,
+                t.K7.sessionTrace,
+                n
+              );
+            }),
+            n.on(Ke + Ie, function (e) {
+              ((this.time = (0, o.t)()),
+                (this.startPath = location.pathname + location.hash));
+            }),
+            n.on(Ke + Me, function (e) {
+              (0, s.p)(
+                "bstHist",
+                [location.pathname + location.hash, this.startPath, this.time],
+                void 0,
+                t.K7.sessionTrace,
+                n
+              );
+            }));
+          try {
+            ((d = new PerformanceObserver((e) => {
+              const r = e.getEntries();
+              (0, s.p)(Ce, [r], void 0, t.K7.sessionTrace, n);
+            })),
+              d.observe({ type: Le, buffered: !0 }));
+          } catch (e) {}
+          this.importAggregator(e, () => i.e(478).then(i.bind(i, 6974)), {
+            resourceObserver: d,
+          });
+        }
+      }
+      var Ue = i(6344);
+      class Ve extends y {
+        static featureName = Ue.TZ;
+        #n;
+        recorder;
+        constructor(e) {
+          var r;
+          let n;
+          (super(e, Ue.TZ),
+            (r = e),
+            (0, c.Y)(
+              a.CH,
+              function () {
+                (0, s.p)(a.CH, [], void 0, t.K7.sessionReplay, r.ee);
+              },
+              r
+            ),
+            (function (e) {
+              (0, c.Y)(
+                a.Tb,
+                function () {
+                  (0, s.p)(a.Tb, [], void 0, t.K7.sessionReplay, e.ee);
+                },
+                e
+              );
+            })(e));
+          try {
+            n = JSON.parse(
+              localStorage.getItem("".concat(w.H3, "_").concat(w.uh))
+            );
+          } catch (e) {}
+          ((0, p.SR)(e.init) && this.ee.on(a.CH, () => this.#i()),
+            this.#s(n) &&
+              this.importRecorder().then((e) => {
+                e.startRecording(Ue.Qb.PRELOAD, n?.sessionReplayMode);
+              }),
+            this.importAggregator(
+              this.agentRef,
+              () => i.e(478).then(i.bind(i, 6167)),
+              this
+            ),
+            this.ee.on("err", (e) => {
+              this.blocked ||
+                (this.agentRef.runtime.isRecording &&
+                  ((this.errorNoticed = !0),
+                  (0, s.p)(Ue.Vh, [e], void 0, this.featureName, this.ee)));
+            }));
+        }
+        #s(e) {
+          return (
+            (e &&
+              (e.sessionReplayMode === w.g.FULL ||
+                e.sessionReplayMode === w.g.ERROR)) ||
+            (0, p.Aw)(this.agentRef.init)
+          );
+        }
+        importRecorder() {
+          return this.recorder
+            ? Promise.resolve(this.recorder)
+            : ((this.#n ??= Promise.all([i.e(478), i.e(249)])
+                .then(i.bind(i, 4866))
+                .then(
+                  ({ Recorder: e }) => (
+                    (this.recorder = new e(this)),
+                    this.recorder
+                  )
+                )
+                .catch((e) => {
+                  throw (
+                    this.ee.emit("internal-error", [e]),
+                    (this.blocked = !0),
+                    e
+                  );
+                })),
+              this.#n);
+        }
+        #i() {
+          this.blocked ||
+            (this.featAggregate
+              ? this.featAggregate.mode !== w.g.FULL &&
+                this.featAggregate.initializeRecording(w.g.FULL, !0, Ue.Qb.API)
+              : this.importRecorder().then(() => {
+                  this.recorder.startRecording(Ue.Qb.API, w.g.FULL);
+                }));
+        }
+      }
+      var Ge = i(3962);
+      class ze extends y {
+        static featureName = Ge.TZ;
+        constructor(e) {
+          if (
+            (super(e, Ge.TZ),
+            (function (e) {
+              const r = e.ee.get("tracer");
+              function n() {}
+              (0, c.Y)(
+                a.dT,
+                function (e) {
+                  return new n().get("object" == typeof e ? e : {});
+                },
+                e
+              );
+              const i = (n.prototype = {
+                createTracer: function (n, i) {
+                  var a = {},
+                    c = this,
+                    d = "function" == typeof i;
+                  return (
+                    (0, s.p)(
+                      O.xV,
+                      ["API/createTracer/called"],
+                      void 0,
+                      t.K7.metrics,
+                      e.ee
+                    ),
+                    function () {
+                      if (
+                        (r.emit(
+                          (d ? "" : "no-") + "fn-start",
+                          [(0, o.t)(), c, d],
+                          a
+                        ),
+                        d)
+                      )
+                        try {
+                          return i.apply(this, arguments);
+                        } catch (e) {
+                          const t = "string" == typeof e ? new Error(e) : e;
+                          throw (r.emit("fn-err", [arguments, this, t], a), t);
+                        } finally {
+                          r.emit("fn-end", [(0, o.t)()], a);
+                        }
+                    }
+                  );
+                },
+              });
+              ([
+                "actionText",
+                "setName",
+                "setAttribute",
+                "save",
+                "ignore",
+                "onEnd",
+                "getContext",
+                "end",
+                "get",
+              ].forEach((r) => {
+                c.Y.apply(this, [
+                  r,
+                  function () {
+                    return (
+                      (0, s.p)(
+                        a.hw + r,
+                        [performance.now(), ...arguments],
+                        this,
+                        t.K7.softNav,
+                        e.ee
+                      ),
+                      this
+                    );
+                  },
+                  e,
+                  i,
+                ]);
+              }),
+                (0, c.Y)(
+                  a.PA,
+                  function () {
+                    (0, s.p)(
+                      a.hw + "routeName",
+                      [performance.now(), ...arguments],
+                      void 0,
+                      t.K7.softNav,
+                      e.ee
+                    );
+                  },
+                  e
+                ));
+            })(e),
+            !f.RI || !(0, T.dV)().o.MO)
+          )
+            return;
+          const r = Ne(this.ee);
+          try {
+            this.removeOnAbort = new AbortController();
+          } catch (e) {}
+          Ge.tC.forEach((e) => {
+            (0, N.sp)(
+              e,
+              (e) => {
+                l(e);
+              },
+              !0,
+              this.removeOnAbort?.signal
+            );
+          });
+          const n = () =>
+            (0, s.p)(
+              "newURL",
+              [(0, o.t)(), "" + window.location],
+              void 0,
+              this.featureName,
+              this.ee
+            );
+          (r.on("pushState-end", n),
+            r.on("replaceState-end", n),
+            (0, N.sp)(
+              Ge.OV,
+              (e) => {
+                (l(e),
+                  (0, s.p)(
+                    "newURL",
+                    [e.timeStamp, "" + window.location],
+                    void 0,
+                    this.featureName,
+                    this.ee
+                  ));
+              },
+              !0,
+              this.removeOnAbort?.signal
+            ));
+          let d = !1;
+          const u = new ((0, T.dV)().o.MO)((e, t) => {
+              d ||
+                ((d = !0),
+                requestAnimationFrame(() => {
+                  ((0, s.p)(
+                    "newDom",
+                    [(0, o.t)()],
+                    void 0,
+                    this.featureName,
+                    this.ee
+                  ),
+                    (d = !1));
+                }));
+            }),
+            l = (0, m.s)(
+              (e) => {
+                "loading" !== document.readyState &&
+                  ((0, s.p)(
+                    "newUIEvent",
+                    [e],
+                    void 0,
+                    this.featureName,
+                    this.ee
+                  ),
+                  u.observe(document.body, {
+                    attributes: !0,
+                    childList: !0,
+                    subtree: !0,
+                    characterData: !0,
+                  }));
+              },
+              100,
+              { leading: !0 }
+            );
+          ((this.abortHandler = function () {
+            (this.removeOnAbort?.abort(),
+              u.disconnect(),
+              (this.abortHandler = void 0));
+          }),
+            this.importAggregator(e, () => i.e(478).then(i.bind(i, 4393)), {
+              domObserver: u,
+            }));
+        }
+      }
+      var Ye = i(3333),
+        Ze = i(9119);
+      const qe = {},
+        Xe = new Set();
+      function $e(e) {
+        return "string" == typeof e
+          ? { type: "string", size: new TextEncoder().encode(e).length }
+          : e instanceof ArrayBuffer
+            ? { type: "ArrayBuffer", size: e.byteLength }
+            : e instanceof Blob
+              ? { type: "Blob", size: e.size }
+              : e instanceof DataView
+                ? { type: "DataView", size: e.byteLength }
+                : ArrayBuffer.isView(e)
+                  ? { type: "TypedArray", size: e.byteLength }
+                  : { type: "unknown", size: 0 };
+      }
+      class Qe {
+        constructor(e, t) {
+          ((this.timestamp = (0, o.t)()),
+            (this.currentUrl = (0, Ze.L)(window.location.href)),
+            (this.socketId = (0, Y.LA)(8)),
+            (this.requestedUrl = (0, Ze.L)(e)),
+            (this.requestedProtocols = Array.isArray(t)
+              ? t.join(",")
+              : t || ""),
+            (this.openedAt = void 0),
+            (this.protocol = void 0),
+            (this.extensions = void 0),
+            (this.binaryType = void 0),
+            (this.messageOrigin = void 0),
+            (this.messageCount = 0),
+            (this.messageBytes = 0),
+            (this.messageBytesMin = 0),
+            (this.messageBytesMax = 0),
+            (this.messageTypes = void 0),
+            (this.sendCount = 0),
+            (this.sendBytes = 0),
+            (this.sendBytesMin = 0),
+            (this.sendBytesMax = 0),
+            (this.sendTypes = void 0),
+            (this.closedAt = void 0),
+            (this.closeCode = void 0),
+            (this.closeReason = "unknown"),
+            (this.closeWasClean = void 0),
+            (this.connectedDuration = 0),
+            (this.hasErrors = void 0));
+        }
+      }
+      class Je extends y {
+        static featureName = Ye.TZ;
+        constructor(e) {
+          super(e, Ye.TZ);
+          const r = e.init.feature_flags.includes("websockets"),
+            n = [
+              e.init.page_action.enabled,
+              e.init.performance.capture_marks,
+              e.init.performance.capture_measures,
+              e.init.performance.resources.enabled,
+              e.init.user_actions.enabled,
+              r,
+            ];
+          var d;
+          let u, l;
+          if (
+            ((d = e),
+            (0, c.Y)(a.hG, (e, t) => U(e, t, d), d),
+            (function (e) {
+              (0, c.Y)(a.fF, (t, r) => G(t, r, e), e);
+            })(e),
+            je(e),
+            q(e),
+            (function (e) {
+              (0, c.Y)(a.V1, (t, r) => V(t, r, e), e);
+            })(e),
+            r &&
+              (l = (function (e) {
+                if (!(0, T.dV)().o.WS) return e;
+                const t = e.get("websockets");
+                if (qe[t.debugId]++) return t;
+                ((qe[t.debugId] = 1),
+                  (0, x.G)(() => {
+                    const e = (0, o.t)();
+                    Xe.forEach((r) => {
+                      ((r.nrData.closedAt = e),
+                        (r.nrData.closeCode = 1001),
+                        (r.nrData.closeReason = "Page navigating away"),
+                        (r.nrData.closeWasClean = !1),
+                        r.nrData.openedAt &&
+                          (r.nrData.connectedDuration = e - r.nrData.openedAt),
+                        t.emit("ws", [r.nrData], r));
+                    });
+                  }));
+                class r extends WebSocket {
+                  static name = "WebSocket";
+                  static toString() {
+                    return "function WebSocket() { [native code] }";
+                  }
+                  toString() {
+                    return "[object WebSocket]";
+                  }
+                  get [Symbol.toStringTag]() {
+                    return r.name;
+                  }
+                  #o(e) {
+                    (((e.__newrelic ??= {}).socketId = this.nrData.socketId),
+                      (this.nrData.hasErrors ??= !0));
+                  }
+                  constructor(...e) {
+                    (super(...e),
+                      (this.nrData = new Qe(e[0], e[1])),
+                      this.addEventListener("open", () => {
+                        ((this.nrData.openedAt = (0, o.t)()),
+                          ["protocol", "extensions", "binaryType"].forEach(
+                            (e) => {
+                              this.nrData[e] = this[e];
+                            }
+                          ),
+                          Xe.add(this));
+                      }),
+                      this.addEventListener("message", (e) => {
+                        const { type: t, size: r } = $e(e.data);
+                        ((this.nrData.messageOrigin ??= (0, Ze.L)(e.origin)),
+                          this.nrData.messageCount++,
+                          (this.nrData.messageBytes += r),
+                          (this.nrData.messageBytesMin = Math.min(
+                            this.nrData.messageBytesMin || 1 / 0,
+                            r
+                          )),
+                          (this.nrData.messageBytesMax = Math.max(
+                            this.nrData.messageBytesMax,
+                            r
+                          )),
+                          (this.nrData.messageTypes ?? "").includes(t) ||
+                            (this.nrData.messageTypes = this.nrData.messageTypes
+                              ? ""
+                                  .concat(this.nrData.messageTypes, ",")
+                                  .concat(t)
+                              : t));
+                      }),
+                      this.addEventListener("close", (e) => {
+                        ((this.nrData.closedAt = (0, o.t)()),
+                          (this.nrData.closeCode = e.code),
+                          e.reason && (this.nrData.closeReason = e.reason),
+                          (this.nrData.closeWasClean = e.wasClean),
+                          (this.nrData.connectedDuration =
+                            this.nrData.closedAt - this.nrData.openedAt),
+                          Xe.delete(this),
+                          t.emit("ws", [this.nrData], this));
+                      }));
+                  }
+                  addEventListener(e, t, ...r) {
+                    const n = this,
+                      i =
+                        "function" == typeof t
+                          ? function (...e) {
+                              try {
+                                return t.apply(this, e);
+                              } catch (e) {
+                                throw (n.#o(e), e);
+                              }
+                            }
+                          : t?.handleEvent
+                            ? {
+                                handleEvent: function (...e) {
+                                  try {
+                                    return t.handleEvent.apply(t, e);
+                                  } catch (e) {
+                                    throw (n.#o(e), e);
+                                  }
+                                },
+                              }
+                            : t;
+                    return super.addEventListener(e, i, ...r);
+                  }
+                  send(e) {
+                    if (this.readyState === WebSocket.OPEN) {
+                      const { type: t, size: r } = $e(e);
+                      (this.nrData.sendCount++,
+                        (this.nrData.sendBytes += r),
+                        (this.nrData.sendBytesMin = Math.min(
+                          this.nrData.sendBytesMin || 1 / 0,
+                          r
+                        )),
+                        (this.nrData.sendBytesMax = Math.max(
+                          this.nrData.sendBytesMax,
+                          r
+                        )),
+                        (this.nrData.sendTypes ?? "").includes(t) ||
+                          (this.nrData.sendTypes = this.nrData.sendTypes
+                            ? "".concat(this.nrData.sendTypes, ",").concat(t)
+                            : t));
+                    }
+                    try {
+                      return super.send(e);
+                    } catch (e) {
+                      throw (this.#o(e), e);
+                    }
+                  }
+                  close(...e) {
+                    try {
+                      super.close(...e);
+                    } catch (e) {
+                      throw (this.#o(e), e);
+                    }
+                  }
+                }
+                return ((f.gm.WebSocket = r), t);
+              })(this.ee)),
+            f.RI)
+          ) {
+            if (
+              (me(this.ee, e),
+              ce(this.ee, e),
+              (u = Ne(this.ee)),
+              e.init.user_actions.enabled)
+            ) {
+              function h(t) {
+                const r = (0, ve.D)(t);
+                return e.beacons.includes(r.hostname + ":" + r.port);
+              }
+              function p() {
+                u.emit("navChange");
+              }
+              (Ye.Zp.forEach((e) =>
+                (0, N.sp)(
+                  e,
+                  (e) => (0, s.p)("ua", [e], void 0, this.featureName, this.ee),
+                  !0
+                )
+              ),
+                Ye.qN.forEach((e) => {
+                  const t = (0, m.s)(
+                    (e) => {
+                      (0, s.p)("ua", [e], void 0, this.featureName, this.ee);
+                    },
+                    500,
+                    { leading: !0 }
+                  );
+                  (0, N.sp)(e, t);
+                }),
+                f.gm.addEventListener(
+                  "error",
+                  () => {
+                    (0, s.p)("uaErr", [], void 0, t.K7.genericEvents, this.ee);
+                  },
+                  (0, N.jT)(!1, this.removeOnAbort?.signal)
+                ),
+                this.ee.on("open-xhr-start", (e, r) => {
+                  h(e[1]) ||
+                    r.addEventListener("readystatechange", () => {
+                      2 === r.readyState &&
+                        (0, s.p)(
+                          "uaXhr",
+                          [],
+                          void 0,
+                          t.K7.genericEvents,
+                          this.ee
+                        );
+                    });
+                }),
+                this.ee.on("fetch-start", (e) => {
+                  e.length >= 1 &&
+                    !h(Re(e[0])) &&
+                    (0, s.p)("uaXhr", [], void 0, t.K7.genericEvents, this.ee);
+                }),
+                u.on("pushState-end", p),
+                u.on("replaceState-end", p),
+                window.addEventListener(
+                  "hashchange",
+                  p,
+                  (0, N.jT)(!0, this.removeOnAbort?.signal)
+                ),
+                window.addEventListener(
+                  "popstate",
+                  p,
+                  (0, N.jT)(!0, this.removeOnAbort?.signal)
+                ));
+            }
+            if (
+              e.init.performance.resources.enabled &&
+              f.gm.PerformanceObserver?.supportedEntryTypes.includes("resource")
+            ) {
+              new PerformanceObserver((e) => {
+                e.getEntries().forEach((e) => {
+                  (0, s.p)(
+                    "browserPerformance.resource",
+                    [e],
+                    void 0,
+                    this.featureName,
+                    this.ee
+                  );
+                });
+              }).observe({ type: "resource", buffered: !0 });
+            }
+          }
+          r &&
+            l.on("ws", (e) => {
+              (0, s.p)("ws-complete", [e], void 0, this.featureName, this.ee);
+            });
+          try {
+            this.removeOnAbort = new AbortController();
+          } catch (g) {}
+          ((this.abortHandler = () => {
+            (this.removeOnAbort?.abort(), (this.abortHandler = void 0));
+          }),
+            n.some((e) => e)
+              ? this.importAggregator(e, () => i.e(478).then(i.bind(i, 8019)))
+              : this.deregisterDrain());
+        }
+      }
+      var et = i(2646);
+      const tt = new Map();
+      function rt(e, t, r, n, i = !0, s) {
+        if (
+          "object" != typeof t ||
+          !t ||
+          "string" != typeof r ||
+          !r ||
+          "function" != typeof t[r]
+        )
+          return (0, h.R)(29);
+        const o = (function (e) {
+            return (e || ie.ee).get("logger");
+          })(e),
+          a = (0, se.YM)(o, void 0, s),
+          c = new et.y(ie.P);
+        ((c.level = n.level),
+          (c.customAttributes = n.customAttributes),
+          (c.autoCaptured = i));
+        const d = t[r]?.[se.Jt] || t[r];
+        return (
+          tt.set(d, c),
+          a.inPlace(t, [r], "wrap-logger-", () => tt.get(d), void 0, !0),
+          o
+        );
+      }
+      var nt = i(1910);
+      class it extends y {
+        static featureName = W.TZ;
+        constructor(e) {
+          var t;
+          (super(e, W.TZ),
+            (t = e),
+            (0, c.Y)(a.$9, (e, r) => F(e, r, t), t),
+            (function (e) {
+              (0, c.Y)(
+                a.Wb,
+                (
+                  t,
+                  r,
+                  { customAttributes: n = {}, level: i = W.p_.INFO } = {}
+                ) => {
+                  rt(e.ee, t, r, { customAttributes: n, level: i }, !1, e);
+                },
+                e
+              );
+            })(e),
+            q(e));
+          const r = this.ee;
+          (["log", "error", "warn", "info", "debug", "trace"].forEach((t) => {
+            ((0, nt.i)(f.gm.console[t]),
+              rt(
+                r,
+                f.gm.console,
+                t,
+                { level: "log" === t ? "info" : t },
+                void 0,
+                e
+              ));
+          }),
+            this.ee.on("wrap-logger-end", function ([e], t, n, i = []) {
+              const { level: s, customAttributes: o, autoCaptured: a } = this;
+              i.forEach((t) => {
+                (0, K.R)(r, e, o, s, a, t);
+              });
+            }),
+            this.importAggregator(e, () => i.e(478).then(i.bind(i, 5288))));
+        }
+      }
+      new A({
+        features: [_e, E, _, Fe, Ve, P, Q, Je, it, ze],
+        loaderType: "spa",
+      });
+    })());
+})();


### PR DESCRIPTION
## Description
The Vercel preview links currently don’t include New Relic because Vercel hosts the Next.js app on AWS Lambda, and New Relic doesn’t support injecting the browser agent in that environment.

This PR adds a manual injection of the QA New Relic browser instance into the headers for Vercel builds.

Tickets:

- [JIRA-1234](https://newyorkpubliclibrary.atlassian.net/browse/JIRA-1234)

## Motivation and Context

Nicole was testing a preview link and encountered a weird bug that I was unable to reproduce, and we do not have any logs on vercel.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
