### PR TITLE
SWIS-50: Add prod rollback workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "production-*"
 
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
@@ -56,7 +60,7 @@ jobs:
           docker build \
            --build-arg NEXT_BUILD_ID="${NEXT_BUILD_ID}" \
            --build-arg NEW_RELIC_APP_NAME="Library Card App" \
-           --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY \
+           --build-arg NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}" \
            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  \
            .
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
@@ -70,9 +74,33 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
 
+      - name: Tag current production-latest as production-previous
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: nypl-library-card-app
+        run: |
+          MANIFEST=$(aws ecr batch-get-image \
+            --repository-name $ECR_REPOSITORY \
+            --image-ids imageTag=production-latest \
+            --query 'images[0].imageManifest' \
+            --output text) || true
+
+          if [ -n "$MANIFEST" ] && [ "$MANIFEST" != "None" ]; then
+            aws ecr put-image \
+              --repository-name $ECR_REPOSITORY \
+              --image-tag production-previous \
+              --image-manifest "$MANIFEST"
+          fi
+
       - name: Deploy to ECS
         run: |
           aws ecs update-service \
             --cluster nypl-library-card-app-production \
             --service nypl-library-card-app-production \
             --force-new-deployment
+
+      - name: Wait for ECS to stabilize
+        run: |
+          aws ecs wait services-stable \
+            --cluster nypl-library-card-app-production \
+            --services nypl-library-card-app-production

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "qa-*"
 
+concurrency:
+  group: qa-deploy
+  cancel-in-progress: false
+
 jobs:
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
@@ -64,12 +68,36 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
 
+      - name: Tag current qa-latest as qa-previous
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: nypl-library-card-app
+        run: |
+          MANIFEST=$(aws ecr batch-get-image \
+            --repository-name $ECR_REPOSITORY \
+            --image-ids imageTag=qa-latest \
+            --query 'images[0].imageManifest' \
+            --output text) || true
+
+          if [ -n "$MANIFEST" ] && [ "$MANIFEST" != "None" ]; then
+            aws ecr put-image \
+              --repository-name $ECR_REPOSITORY \
+              --image-tag qa-previous \
+              --image-manifest "$MANIFEST"
+          fi
+
       - name: Deploy to ECS
         run: |
           aws ecs update-service \
             --cluster nypl-library-card-app-qa \
             --service nypl-library-card-app-qa \
             --force-new-deployment
+                  - name: Wait for ECS to stabilize
+      - name: Wait for ECS to stabilize
+        run: |
+          aws ecs wait services-stable \
+            --cluster nypl-library-card-app-qa \
+            --services nypl-library-card-app-qa
 
   playwright-tests:
     uses: ./.github/workflows/playwright-tests.yml

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -1,0 +1,68 @@
+name: Rollback Production
+
+on:
+    workflow_dispatch:
+        inputs:
+            image_tag:
+                description: "ECR image tag to roll back to (defaults to production-previous if omitted)"
+                required: false
+                type: string
+
+concurrency:
+    group: production-deploy
+    cancel-in-progress: false
+
+jobs:
+    rollback-production:
+        runs-on: ubuntu-latest
+        environment: production
+
+        permissions:
+            id-token: write
+            contents: read
+
+        steps:
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::946183545209:role/GithubActionsDeployerRole
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: login-ecr
+              uses: aws-actions/amazon-ecr-login@v2
+
+            - name: Retag rollback target as production-latest
+              env:
+                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  ECR_REPOSITORY: nypl-library-card-app
+                  ROLLBACK_TAG: ${{ inputs.image_tag || 'production-previous' }}
+              run: |
+                  MANIFEST=$(aws ecr batch-get-image \
+                  --repository-name $ECR_REPOSITORY \
+                  --image-ids imageTag=$ROLLBACK_TAG \
+                  --query 'images[0].imageManifest' \
+                  --output text)
+
+                  if [ -z "$MANIFEST" ] || [ "$MANIFEST" = "None" ]; then
+                    echo "ERROR: Image '$ROLLBACK_TAG' not found in ECR. Cannot rollback."
+                    exit 1
+                  fi
+
+                  aws ecr put-image \
+                  --repository-name $ECR_REPOSITORY \
+                  --image-tag production-latest \
+                  --image-manifest "$MANIFEST"
+
+            - name: Force new ECS deployment
+              run: |
+                  aws ecs update-service \
+                    --cluster nypl-library-card-app-production \
+                    --service nypl-library-card-app-production \
+                    --force-new-deployment
+
+            - name: Wait for ECS to stabilize
+              run: |
+                  aws ecs wait services-stable \
+                    --cluster nypl-library-card-app-production \
+                    --services nypl-library-card-app-production

--- a/.github/workflows/rollback-qa.yml
+++ b/.github/workflows/rollback-qa.yml
@@ -1,0 +1,68 @@
+name: Rollback QA
+
+on:
+    workflow_dispatch:
+        inputs:
+            image_tag:
+                description: "ECR image tag to roll back to (defaults to qa-previous if omitted)"
+                required: false
+                type: string
+
+concurrency:
+    group: qa-deploy
+    cancel-in-progress: false
+
+jobs:
+    rollback-qa:
+        runs-on: ubuntu-latest
+        environment: qa
+
+        permissions:
+            id-token: write
+            contents: read
+
+        steps:
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: arn:aws:iam::946183545209:role/GithubActionsDeployerRole
+                  aws-region: us-east-1
+
+            - name: Login to Amazon ECR
+              id: login-ecr
+              uses: aws-actions/amazon-ecr-login@v2
+
+            - name: Retag rollback target as qa-latest
+              env:
+                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  ECR_REPOSITORY: nypl-library-card-app
+                  ROLLBACK_TAG: ${{ inputs.image_tag || 'qa-previous' }}
+              run: |
+                  MANIFEST=$(aws ecr batch-get-image \
+                  --repository-name $ECR_REPOSITORY \
+                  --image-ids imageTag=$ROLLBACK_TAG \
+                  --query 'images[0].imageManifest' \
+                  --output text)
+
+                  if [ -z "$MANIFEST" ] || [ "$MANIFEST" = "None" ]; then
+                    echo "ERROR: Image '$ROLLBACK_TAG' not found in ECR. Cannot rollback."
+                    exit 1
+                  fi
+
+                  aws ecr put-image \
+                  --repository-name $ECR_REPOSITORY \
+                  --image-tag qa-latest \
+                  --image-manifest "$MANIFEST"
+
+            - name: Force new ECS deployment
+              run: |
+                  aws ecs update-service \
+                    --cluster nypl-library-card-app-qa \
+                    --service nypl-library-card-app-qa \
+                    --force-new-deployment
+
+            - name: Wait for ECS to stabilize
+              run: |
+                  aws ecs wait services-stable \
+                    --cluster nypl-library-card-app-qa \
+                    --services nypl-library-card-app-qa

--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ Our CI/CD pipeline uses GitHub Actions with multiple specialized workflows to en
 | **Playwright Tests**     | End-to-end browser testing       | PRs, pushes to `main`, called by deployments |
 | **Deploy to QA**         | Deploy to QA environment         | `qa-*` tags                                  |
 | **Deploy to Production** | Deploy to production environment | `production-*` tags                          |
+| **Rollback Production**  | Roll back to a previous image    | Manual (`workflow_dispatch`)                 |
+
+### Production Rollback
+
+Each production deploy automatically saves the previous image as `production-previous` in ECR before deploying the new one. If a bad deploy needs to be reverted:
+
+1. Go to the **Run workflow** dashboard
+2. [Optional] specify an `image_tag` (e.g. a git SHA) to roll back to a specific version. Leave blank to use `production-previous` (the image from the last deploy)
+3. The workflow will retag the target image as `production-latest` and trigger a new ECS deployment
 
 ## Internationalization
 


### PR DESCRIPTION
## Description

- Update prod-deploy.tml to include tagging the previous build with the label production-previous
- Add rollback deploy to use the previous tag and deploy it to ecs
- Update README to reflect changes around rollbacks
- Add github button to trigger the rollback workflow

Tickets:

- [SWIS-50](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-50)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[SWIS-50]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ