### PR TITLE
SWIS-421: Update address-verificaiton page

### DIFF
--- a/__tests__/library-card_address-verification.test.tsx
+++ b/__tests__/library-card_address-verification.test.tsx
@@ -17,7 +17,8 @@ jest.mock("react-i18next", () => {
   const en = {
     verifyAddress: {
       title: "Step 3 of 5: Address verification",
-      description: "Please select the correct address.",
+      description:
+        "Please verify your address details. If you need to make changes, click 'Previous'.",
       homeAddress: "Home address",
       workAddress: "Alternate address",
     },

--- a/pages/address-verification/index.tsx
+++ b/pages/address-verification/index.tsx
@@ -27,7 +27,7 @@ function AddressVerificationPage({
   return (
     <>
       <PageHeading autoScrollOnMount>{t("verifyAddress.title")}</PageHeading>
-      <Paragraph id="select-address-heading">
+      <Paragraph id="select-address-heading" mb="l">
         {t("verifyAddress.description")}
       </Paragraph>
       <AddressVerificationContainer />

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -91,9 +91,12 @@
   },
   "verifyAddress": {
     "title": "Step 3 of 5: Address verification",
-    "description": "Please select the correct address.",
+    "description": "Please verify your address details. If you need to make changes, click 'Previous'.",
     "homeAddress": "Home address",
-    "workAddress": "Alternate address"
+    "workAddress": "Alternate address",
+    "errorMessage": {
+      "select": "There was a problem. Please select the correct address."
+    }
   },
   "account": {
     "title": "Step 4 of 5: Customize your account",

--- a/src/components/AddressVerificationContainer/index.tsx
+++ b/src/components/AddressVerificationContainer/index.tsx
@@ -5,6 +5,7 @@ import {
   FormRow,
   Radio,
   RadioGroup,
+  Text,
 } from "@nypl/design-system-react-components";
 import React, { useState } from "react";
 import { useRouter } from "next/router";
@@ -31,17 +32,16 @@ const styles = {
  * Main page component for the "address review" page.
  */
 function AddressVerificationContainer() {
-  // Keep track of the user's selection of the preferred home
-  // and/or work address.
   const [homeAddressSelect, setHomeAddressSelect] = useState("");
   const [workAddressSelect, setWorkAddressSelect] = useState("");
-  // Use react-hook-form for the new radio button input form.
-  const { handleSubmit, register } = useForm();
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm();
   const { state, dispatch } = useFormDataContext();
   const [isLoading, setIsLoading] = useState(false);
-  // The `addressesResponse` is the value from Service Objects through the NYPL
-  // Platform API.
-  // The `formValues` object holds all the submitted user values.
+  // The `addressesResponse` is the value from Service Objects through the NYPL Platform API.
   const { formValues, addressesResponse } = state;
   const router = useRouter();
   // Get the URL query params for `newCard` and `lang`.
@@ -164,50 +164,63 @@ function AddressVerificationContainer() {
       addressType === "home"
         ? t("verifyAddress.homeAddress")
         : t("verifyAddress.workAddress");
+
+    const selectError = errors?.[`${addressType}-address-select`]?.message;
+    const selectErrorMessage = t("verifyAddress.errorMessage.select");
+
     return (
-      <RadioGroup
-        className="address-container"
-        name=""
-        id={addressType.replace(/[^0-9a-zA-Z]/g, "-")}
-        labelText={labelText}
-        showLabel={false}
-        sx={{
-          "& .ds-radioGroup-stack": {
-            display: { base: "flex" },
-            flexDirection: { base: "column", sm: "row" },
-          },
-        }}
-        // If there's only one option, it's checked by default.
-        defaultValue={addressesLength === 1 ? `${addressType}-0` : undefined}
-      >
-        {addresses.map((address, idx) => {
-          const selected = `${addressType}-${idx}`;
-          const checked = selected === selectedValue;
-          return (
-            <Radio
-              key={`${addressType}-${idx}`}
-              id={`${addressType}-${idx}`}
-              sx={styles.input}
-              className={`radio-input`}
-              {...register(`${addressType}-address-select`, {
-                required: true,
-                onChange: onChange,
-              })}
-              isChecked={checked}
-              value={selected}
-              labelText={
-                <Box>
-                  <Box>{address.line1}</Box>
-                  {address.line2 && <Box>{address.line2}</Box>}
+      <>
+        <RadioGroup
+          className="address-container"
+          name=""
+          id={addressType.replace(/[^0-9a-zA-Z]/g, "-")}
+          labelText={labelText}
+          showLabel={false}
+          sx={{
+            "& .ds-radioGroup-stack": {
+              display: { base: "flex" },
+              flexDirection: { base: "column", sm: "row" },
+            },
+          }}
+          // If there's only one option, it's checked by default.
+          defaultValue={addressesLength === 1 ? `${addressType}-0` : undefined}
+        >
+          {addresses.map((address, idx) => {
+            const selected = `${addressType}-${idx}`;
+            const checked = selected === selectedValue;
+            return (
+              <Radio
+                key={`${addressType}-${idx}`}
+                id={`${addressType}-${idx}`}
+                sx={styles.input}
+                className={`radio-input`}
+                {...register(`${addressType}-address-select`, {
+                  required: selectErrorMessage,
+                  onChange: onChange,
+                })}
+                isChecked={checked}
+                value={selected}
+                labelText={
                   <Box>
-                    {address.city}, {address.state} {address.zip}
+                    <Box>{address.line1}</Box>
+                    {address.line2 && <Box>{address.line2}</Box>}
+                    <Box>
+                      {address.city}, {address.state} {address.zip}
+                    </Box>
                   </Box>
-                </Box>
-              }
-            />
-          );
-        })}
-      </RadioGroup>
+                }
+              />
+            );
+          })}
+        </RadioGroup>
+        <Box m={0} aria-live="polite">
+          {selectError && (
+            <Text mt="s" color="ui.error.primary" fontSize="xs">
+              {selectErrorMessage}
+            </Text>
+          )}
+        </Box>
+      </>
     );
   };
 


### PR DESCRIPTION
## Description

Updates the subheading text and displays error when buttons are not selected on /address-verification page:

Tickets:

- [SWIS-421](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-421)

## Motivation and Context

Our current prompt on the /address-verification page is confusing to users

## How Has This Been Tested?

VQA

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[SWIS-421]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ