### PR TITLE
SWIS-465: Add global error pages

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,26 @@
+import { GetStaticProps } from "next";
+import { Text } from "@nypl/design-system-react-components";
+import {
+  BackToHomeLink,
+  ContactUsLink,
+  ErrorComponent,
+} from "../src/components/Error";
+
+export default function NotFoundPage() {
+  return (
+    <ErrorComponent
+      heading="We couldn't find that page"
+      description={
+        <Text maxWidth="730px" margin="auto">
+          The page you were looking for doesn't exist or may have moved
+          elsewhere. Try starting a <BackToHomeLink /> or <ContactUsLink /> if
+          the error persists.
+        </Text>
+      }
+    />
+  );
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+  return { props: {} };
+};

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,21 @@
+import { Text } from "@nypl/design-system-react-components";
+import {
+  BackToHomeLink,
+  ContactUsLink,
+  ErrorComponent,
+} from "../src/components/Error";
+
+export default function ServerErrorPage() {
+  return (
+    <ErrorComponent
+      heading="Something went wrong on our end"
+      description={
+        <Text maxWidth="700px" margin="auto">
+          We are working to resolve a server issue. Your application progress
+          may not have been saved. Try starting a <BackToHomeLink /> in a few
+          minutes or <ContactUsLink /> if the error persists.
+        </Text>
+      }
+    />
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -61,6 +61,7 @@ function MyApp({ Component, pageProps }: MyAppProps) {
   };
   const initState = { ...formInitialStateCopy };
   const pageTitles = getPageTitles();
+  const isErrorPage = ["/404", "/500"].includes(router.pathname);
 
   return (
     <>
@@ -138,13 +139,17 @@ function MyApp({ Component, pageProps }: MyAppProps) {
         <FormProvider {...formMethods}>
           <FormDataContextProvider initState={initState}>
             <ErrorBoundary reset={router.asPath}>
-              <ApplicationContainer>
-                <Component
-                  {...pageProps}
-                  pageTitles={pageTitles}
-                  policyType={router.query.policyType}
-                />
-              </ApplicationContainer>
+              {isErrorPage ? (
+                <Component {...pageProps} />
+              ) : (
+                <ApplicationContainer>
+                  <Component
+                    {...pageProps}
+                    pageTitles={pageTitles}
+                    policyType={router.query.policyType}
+                  />
+                </ApplicationContainer>
+              )}
             </ErrorBoundary>
           </FormDataContextProvider>
         </FormProvider>

--- a/src/components/Error/index.tsx
+++ b/src/components/Error/index.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import {
+  Box,
+  Heading,
+  Template,
+  TemplateBreakout,
+  TemplateContent,
+  TemplateHeader,
+  TemplateMain,
+  Link as DSLink,
+} from "@nypl/design-system-react-components";
+import Link from "next/link";
+import Breadcrumbs from "../Breadcrumb";
+import { useRouter } from "next/router";
+import { BrokenBook as BrokenBookIcon } from "../Icons/BrokenBook";
+
+export const ContactUsLink = () => {
+  return (
+    <DSLink href="https://www.nypl.org/get-help/contact-us">contact us</DSLink>
+  );
+};
+
+export const BackToHomeLink = ({
+  text = "new application",
+}: {
+  text?: string;
+}) => {
+  const router = useRouter();
+  const lang = router.isReady ? router.query.lang : undefined;
+  const href = lang && lang !== "en" ? `/new?lang=${lang}` : "/new";
+  return <Link href={href}>{text}</Link>;
+};
+
+export const ErrorComponent = ({
+  heading,
+  description,
+}: {
+  heading: string;
+  description: React.ReactNode;
+}) => {
+  return (
+    <Template variant="narrow" gap="0!">
+      <TemplateHeader id="mainHeader" m="0!" dir="ltr">
+        <TemplateBreakout>
+          <Breadcrumbs />
+        </TemplateBreakout>
+      </TemplateHeader>
+      <TemplateMain id="mainContent">
+        <TemplateContent my="xxl" textAlign="center">
+          <Box mb="xl">
+            <BrokenBookIcon />
+          </Box>
+          <Box textAlign="center">
+            <Heading level="h2" size="heading3" mb="m">
+              {heading}
+            </Heading>
+            {description}
+          </Box>
+        </TemplateContent>
+      </TemplateMain>
+    </Template>
+  );
+};

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -1,19 +1,7 @@
-import {
-  Heading,
-  Text,
-  Box,
-  Template,
-  TemplateMain,
-  TemplateContent,
-  TemplateHeader,
-  TemplateBreakout,
-  Link as DSLink,
-} from "@nypl/design-system-react-components";
-import Link from "next/link";
+import { Text } from "@nypl/design-system-react-components";
 import React from "react";
-import Breadcrumbs from "../Breadcrumb";
-import { BrokenBook as BrokenBookIcon } from "../Icons/BrokenBook";
 import { NRError } from "../../logger/newrelic";
+import { BackToHomeLink, ContactUsLink, ErrorComponent } from "../Error";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -58,46 +46,21 @@ class ErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return (
-        <ErrorComponent>
-          <Box mb="xl">
-            <BrokenBookIcon />
-          </Box>
-          <Box textAlign="center">
-            <Heading level="h2" size="heading3" mb="m">
-              There was an unexpected error
-            </Heading>
+        <ErrorComponent
+          heading="There was an unexpected error"
+          description={
             <Text maxWidth="730px" margin="auto">
               We couldn't process your request at this time. Your application
               progress may not have been saved. Try starting a{" "}
-              <Link href="/new">new application</Link> in a few minutes or{" "}
-              <DSLink href="https://www.nypl.org/get-help/contact-us">
-                contact us
-              </DSLink>{" "}
-              if the error persists.
+              <BackToHomeLink /> in a few minutes or <ContactUsLink /> if the
+              error persists.
             </Text>
-          </Box>
-        </ErrorComponent>
+          }
+        />
       );
     }
     return this.props.children;
   }
 }
-
-export const ErrorComponent = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <Template variant="narrow" gap="0!">
-      <TemplateHeader id="mainHeader" m="0!" dir="ltr">
-        <TemplateBreakout>
-          <Breadcrumbs />
-        </TemplateBreakout>
-      </TemplateHeader>
-      <TemplateMain id="mainContent">
-        <TemplateContent my="xxl" textAlign="center">
-          {children}
-        </TemplateContent>
-      </TemplateMain>
-    </Template>
-  );
-};
 
 export default ErrorBoundary;


### PR DESCRIPTION
## Description

This PRs replaces nextjs default 404 and 5xx error pages with our design

Tickets:

- [SWIS-465](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-465)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[SWIS-465]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ