### PR TITLE
SWIS_484 Optinmonster

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -44,14 +44,7 @@ class MyDocument extends Document<DocumentProps> {
     const { browserTimingHeader, isVercel } = this.props;
     return (
       <Html lang="en">
-        <Head>
-          {/* OptinMonster */}
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `(function(d,u,ac){var s=d.createElement('script');s.type='text/javascript';s.src='https://a.omappapi.com/app/js/api.min.js';s.async=true;s.dataset.user=u;s.dataset.account=ac;d.getElementsByTagName('head')[0].appendChild(s);})(document,12468,1044);`,
-            }}
-          />
-        </Head>
+        <Head />
         <body>
           <noscript>
             <iframe
@@ -72,6 +65,12 @@ class MyDocument extends Document<DocumentProps> {
           <NextScript />
           {/* <!-- Optimizely --> */}
           <script src="https://cdn.optimizely.com/js/284748925.js"></script>
+          {/* OptinMonster */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(d,u,ac){var s=d.createElement('script');s.type='text/javascript';s.src='https://a.omappapi.com/app/js/api.min.js';s.async=true;s.dataset.user=u;s.dataset.account=ac;d.getElementsByTagName('head')[0].appendChild(s);})(document,12468,1044);`,
+            }}
+          />
           {/* 
               Vercel serverless environment prevents us from generating the 
               browser header from the agent, so we are injecting the QA instance manually 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -72,8 +72,6 @@ class MyDocument extends Document<DocumentProps> {
           <NextScript />
           {/* <!-- Optimizely --> */}
           <script src="https://cdn.optimizely.com/js/284748925.js"></script>
-          {/* <!-- OptinMonster --> */}
-          <script src="https://assets.nypl.org/js/advocacy.js"></script>
           {/* 
               Vercel serverless environment prevents us from generating the 
               browser header from the agent, so we are injecting the QA instance manually 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -44,7 +44,14 @@ class MyDocument extends Document<DocumentProps> {
     const { browserTimingHeader, isVercel } = this.props;
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          {/* OptinMonster */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `<!-- This site is converting visitors into subscribers and customers with OptinMonster - https://optinmonster.com --> <script>(function(d,u,ac){var s=d.createElement('script');s.type='text/javascript';s.src='https://a.omappapi.com/app/js/api.min.js';s.async=true;s.dataset.user=u;s.dataset.account=ac;d.getElementsByTagName('head')[0].appendChild(s);})(document,12468,1044);</script> <!-- / https://optinmonster.com -->`,
+            }}
+          />
+        </Head>
         <body>
           <noscript>
             <iframe

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -48,7 +48,7 @@ class MyDocument extends Document<DocumentProps> {
           {/* OptinMonster */}
           <script
             dangerouslySetInnerHTML={{
-              __html: `<!-- This site is converting visitors into subscribers and customers with OptinMonster - https://optinmonster.com --> <script>(function(d,u,ac){var s=d.createElement('script');s.type='text/javascript';s.src='https://a.omappapi.com/app/js/api.min.js';s.async=true;s.dataset.user=u;s.dataset.account=ac;d.getElementsByTagName('head')[0].appendChild(s);})(document,12468,1044);</script> <!-- / https://optinmonster.com -->`,
+              __html: `(function(d,u,ac){var s=d.createElement('script');s.type='text/javascript';s.src='https://a.omappapi.com/app/js/api.min.js';s.async=true;s.dataset.user=u;s.dataset.account=ac;d.getElementsByTagName('head')[0].appendChild(s);})(document,12468,1044);`,
             }}
           />
         </Head>


### PR DESCRIPTION
## Description

We are going to publish a survey to get some user insights on the identity verification to inform the new build of LCA. Comms will manage the survey in their tool, optinmonster, but we need a snippet to LCA in order for the tool to run.

Tickets:

- [SWIS-484](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-484)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified optinmonster is active in the networking tab of Chrome Dev Tools.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[SWIS-484]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ