### PR TITLE
SWIS-381 Password validation logic

### DIFF
--- a/playwright/utils/form-helper.ts
+++ b/playwright/utils/form-helper.ts
@@ -8,17 +8,6 @@ import { ReviewPage } from "../pageobjects/review.page";
 import { AddressFormPage, AddressData, AccountData, PatronData } from "./types";
 import { SPINNER_TIMEOUT } from "./constants";
 
-let usernameCounter = 0;
-
-const createUniqueUsername = (username: string): string => {
-  usernameCounter = (usernameCounter + 1) % 100;
-  const sanitizedBase = username.replace(/[^a-zA-Z0-9]/g, "").slice(0, 15);
-  const uniqueSuffix = `${Date.now().toString().slice(-7)}${usernameCounter
-    .toString()
-    .padStart(2, "0")}`;
-  return `${sanitizedBase}${uniqueSuffix}`.slice(0, 25);
-};
-
 export async function fillPersonalInfo(
   page: PersonalPage | ReviewPage,
   patronData: PatronData
@@ -47,7 +36,6 @@ export async function fillAccountInfo(
   page: AccountPage | ReviewPage,
   accountData: AccountData
 ) {
-  accountData.username = createUniqueUsername(accountData.username);
   await page.usernameInput.fill(accountData.username);
   await page.passwordInput.fill(accountData.password);
   await page.verifyPasswordInput.fill(accountData.password);
@@ -110,7 +98,7 @@ export async function clickNextButton(
   );
 
   if (!nextPageLoaded) {
-    const visibleErrors = [];
+    let visibleErrors;
 
     for (const errorMessage of errorMessages) {
       if (await errorMessage.isVisible()) {

--- a/playwright/utils/form-helper.ts
+++ b/playwright/utils/form-helper.ts
@@ -8,6 +8,17 @@ import { ReviewPage } from "../pageobjects/review.page";
 import { AddressFormPage, AddressData, AccountData, PatronData } from "./types";
 import { SPINNER_TIMEOUT } from "./constants";
 
+let usernameCounter = 0;
+
+const createUniqueUsername = (username: string): string => {
+  usernameCounter = (usernameCounter + 1) % 100;
+  const sanitizedBase = username.replace(/[^a-zA-Z0-9]/g, "").slice(0, 15);
+  const uniqueSuffix = `${Date.now().toString().slice(-7)}${usernameCounter
+    .toString()
+    .padStart(2, "0")}`;
+  return `${sanitizedBase}${uniqueSuffix}`.slice(0, 25);
+};
+
 export async function fillPersonalInfo(
   page: PersonalPage | ReviewPage,
   patronData: PatronData
@@ -36,6 +47,7 @@ export async function fillAccountInfo(
   page: AccountPage | ReviewPage,
   accountData: AccountData
 ) {
+  accountData.username = createUniqueUsername(accountData.username);
   await page.usernameInput.fill(accountData.username);
   await page.passwordInput.fill(accountData.password);
   await page.verifyPasswordInput.fill(accountData.password);
@@ -98,7 +110,7 @@ export async function clickNextButton(
   );
 
   if (!nextPageLoaded) {
-    let visibleErrors;
+    const visibleErrors = [];
 
     for (const errorMessage of errorMessages) {
       if (await errorMessage.isVisible()) {

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -68,11 +68,16 @@ function AccountFormFields({
 
   const validatePasswordLength = (val) => {
     return (
-      (val.length >= minPasswordLength && val.length <= maxPasswordLength) ||
+      (val.length >= minPasswordLength &&
+        val.length <= maxPasswordLength &&
+        !val.includes(".")) ||
       t("account.errorMessage.password")
     );
   };
   const verifyPasswordMatch = () => {
+    if (validatePasswordLength(getValues("password")) !== true) {
+      return true;
+    }
     return (
       getValues("password") === getValues("verifyPassword") ||
       t("account.errorMessage.verifyPassword")

--- a/src/components/AccountFormFields/index.tsx
+++ b/src/components/AccountFormFields/index.tsx
@@ -75,9 +75,6 @@ function AccountFormFields({
     );
   };
   const verifyPasswordMatch = () => {
-    if (validatePasswordLength(getValues("password")) !== true) {
-      return true;
-    }
     return (
       getValues("password") === getValues("verifyPassword") ||
       t("account.errorMessage.verifyPassword")


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
- Updated the password validation logic to exclude periods(.)
- If the password itself is invalid (length or period), let that error own the message instead of also flagging a mismatch.

Tickets:

- [SWIS-381](https://newyorkpubliclibrary.atlassian.net/browse/SWIS-381)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[SWIS-381]: https://newyorkpubliclibrary.atlassian.net/browse/SWIS-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ